### PR TITLE
Remove send button in favor of enter key

### DIFF
--- a/src/completion/Completion.ts
+++ b/src/completion/Completion.ts
@@ -78,6 +78,9 @@ export class Completion extends FormElement {
   @property({ type: Boolean })
   session: boolean;
 
+  @property({ type: Boolean })
+  submitOnEnter: boolean = false;
+
   @property({ type: Object })
   anchorPosition: Position = { left: 0, top: 0 };
 
@@ -212,6 +215,14 @@ export class Completion extends FormElement {
     }
   }
 
+  public click() {
+    super.click();
+    const input = this.shadowRoot.querySelector('temba-textinput') as TextInput;
+    if (input) {
+      input.click();
+    }
+  }
+
   public render(): TemplateResult {
     const anchorStyles = this.anchorPosition
       ? {
@@ -241,7 +252,7 @@ export class Completion extends FormElement {
             @blur=${this.handleOptionCanceled}
             .value=${this.value}
             ?textarea=${this.textarea}
-            ?ignoreSubmit=${true}
+            ?submitOnEnter=${this.submitOnEnter}
           >
           </temba-textinput>
           <temba-options

--- a/src/options/Options.ts
+++ b/src/options/Options.ts
@@ -24,7 +24,6 @@ export class Options extends RapidElement {
     return css`
       .options-container {
         visibility: hidden;
-        position: fixed;
         border-radius: var(--curvature-widget);
         background: var(--color-widget-bg-focused);
         box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
@@ -34,6 +33,19 @@ export class Options extends RapidElement {
         border-radius: var(--curvature-widget);
         overflow: hidden;
         margin-top: var(--options-margin-top);
+      }
+
+      .anchored {
+        position: fixed;
+      }
+
+      :host([block]) .options-container {
+        border: none;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1),
+          0 1px 2px 0 rgba(0, 0, 0, 0.03);
+        height: 100%;
+        z-index: 9000;
+        visibility: visible;
       }
 
       .options {
@@ -81,15 +93,6 @@ export class Options extends RapidElement {
 
       :host([block]) {
         position: relative;
-      }
-
-      :host([block]) .options-container {
-        position: relative;
-        border: none;
-        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1),
-          0 1px 2px 0 rgba(0, 0, 0, 0.03);
-        height: 100%;
-        z-index: 9000;
       }
 
       :host([block]) .options {
@@ -492,13 +495,16 @@ export class Options extends RapidElement {
       'margin-top': `${vertical}px`,
     };
 
-    const optionsStyle = {
-      width: `${this.width}px`,
-    };
+    const optionsStyle = {};
+    if (this.width) {
+      optionsStyle['width'] = `${this.width}px`;
+    }
 
     const classes = getClasses({
+      'options-container': true,
       show: this.visible,
       top: this.poppedTop,
+      anchored: !this.block,
     });
 
     const classesInner = getClasses({
@@ -508,10 +514,7 @@ export class Options extends RapidElement {
     const options = this.options || [];
 
     return html`
-      <div
-        class="options-container ${classes}"
-        style=${styleMap(containerStyle)}
-      >
+      <div class=${classes} style=${styleMap(containerStyle)}>
         <div
           @scroll=${throttle(this.handleInnerScroll, 100)}
           class="${classesInner}"

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -143,7 +143,7 @@ export class TextInput extends FormElement {
   loading: boolean = true;
 
   @property({ type: Boolean })
-  ignoreSubmit: boolean = false;
+  submitOnEnter: boolean = true;
 
   @property()
   onBlur: any;
@@ -362,12 +362,21 @@ export class TextInput extends FormElement {
         @input=${this.handleInput}
         @blur=${this.blur}
         @keydown=${(e: KeyboardEvent) => {
-          if (e.keyCode == 13) {
-            if (!this.ignoreSubmit) {
+          if (e.key === 'Enter') {
+            const input = this;
+
+            if (this.submitOnEnter) {
+              const parentModax = input.getParentModax();
+              const parentForm = !parentModax ? input.getParentForm() : null;
+
               this.value = this.values[0];
               this.fireEvent('change');
 
-              const input = this;
+              // if we don't have something to submit then bail
+              if (!parentModax && !parentForm) {
+                return false;
+              }
+
               input.blur();
 
               // look for a form to submit
@@ -375,6 +384,8 @@ export class TextInput extends FormElement {
                 // first, look for a modax that contains us
                 const modax = input.getParentModax();
                 if (modax) {
+                  input.blur();
+
                   modax.submit();
                 } else {
                   // otherwise, just look for a vanilla submit button
@@ -398,7 +409,7 @@ export class TextInput extends FormElement {
           }
         }}
         placeholder=${this.placeholder}
-        value="${this.value}"
+        .value="${this.value}"
         .disabled=${this.disabled}
       />
     `;


### PR DESCRIPTION
In the process identified a super weird Safari paint issue where options as blocks would disappear under certain circumstances. I don't fully understand the reason but eventually tracked it down to a cascading style for position where block was overriding `position:fixed` with `position:relative`. To fix this I ended up inverting it to have non-block options set their position and have everything else have an implicit position. 

That was a fine use of 6 hours of my life. 😞 