### PR TITLE
Remove push hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "yarn build && wtr --node-resolve"
+      "pre-push": "yarn build"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
-      "pre-push": "yarn build"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Build and test will be caught by CI, blocking things at this level complicates draft PRs with known issues.