### PR TITLE
Nicer accommodation on RunList for short browsers

### DIFF
--- a/src/list/RunList.ts
+++ b/src/list/RunList.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from 'lit';
+import { css, html, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 import { Checkbox } from '../checkbox/Checkbox';
 import { Select } from '../select/Select';
@@ -25,6 +25,26 @@ export class RunList extends TembaList {
   selectedRun: any;
 
   private resultKeys = {};
+
+  static get styles() {
+    return css`
+      :host {
+        overflow-y: auto !important;
+      }
+
+      @media only screen and (max-height: 768px) {
+        temba-options {
+          max-height: 20vh;
+        }
+      }
+
+      temba-options {
+        display: block;
+        width: 100%;
+        flex-grow: 1;
+      }
+    `;
+  }
 
   public firstUpdated(changedProperties: Map<string, any>) {
     super.firstUpdated(changedProperties);
@@ -294,9 +314,7 @@ export class RunList extends TembaList {
 
         ${resultKeys.length > 0
           ? html`
-              <div
-                style="padding:1em;overflow-y:auto;overflow-x:hidden;max-height:15vh;"
-              >
+              <div style="padding:1em;">
                 <div
                   style="display:flex;font-size:1.2em;position:relative;right:0px"
                 >

--- a/src/list/TembaList.ts
+++ b/src/list/TembaList.ts
@@ -79,9 +79,6 @@ export class TembaList extends RapidElement {
 
   static get styles() {
     return css`
-      :host {
-      }
-
       temba-options {
         display: block;
         width: 100%;


### PR DESCRIPTION
Uses a `@media` query to squeeze the top list if the screen is 768 or less.

<img width="797" alt="Screenshot 2023-03-22 at 5 42 13 PM" src="https://user-images.githubusercontent.com/211652/227070069-1b08974e-df98-4801-8367-a1587c04e57f.png">

Additionally, the run details now don't employ an inner scroll and instead rely on the tab pane scroll.

<img width="798" alt="Screenshot 2023-03-22 at 5 42 35 PM" src="https://user-images.githubusercontent.com/211652/227070077-70cce4ee-b683-4add-a4b0-ff2c9950de8c.png">
