### PR TITLE
Tighten up dropdown and dialog animations

### DIFF
--- a/src/dialog/Dialog.ts
+++ b/src/dialog/Dialog.ts
@@ -32,10 +32,15 @@ export class Dialog extends RapidElement {
         left: 0px;
         top: 0px;
         align-items: center;
+        height: 100vh;
       }
 
-      .flex-grow {
+      .grow-top {
         flex-grow: 1;
+      }
+
+      .grow-bottom {
+        flex-grow: 3;
       }
 
       .bottom-padding {
@@ -44,6 +49,7 @@ export class Dialog extends RapidElement {
 
       .dialog-mask {
         width: 100%;
+        height: 100%;
         background: rgba(0, 0, 0, 0.5);
         opacity: 0;
         position: fixed;
@@ -53,17 +59,16 @@ export class Dialog extends RapidElement {
         pointer-events: none;
       }
 
-      .dialog-container {
-        margin-top: -10000px;
+      .dialog-mask .dialog-container {
         position: relative;
-        transition: transform cubic-bezier(0.71, 0.18, 0.61, 1.33)
-            var(--transition-speed),
+        transition: transform var(--transition-speed) var(--bounce),
           opacity ease-in-out calc(var(--transition-speed) - 50ms);
         border-radius: var(--curvature);
         box-shadow: 0px 0px 2px 4px rgba(0, 0, 0, 0.06);
         overflow: hidden;
-        transform: scale(0.7);
+        transform: scale(0.9) translatey(2em);
         background: white;
+        margin: auto;
       }
 
       .dialog-body {
@@ -82,12 +87,10 @@ export class Dialog extends RapidElement {
       }
 
       .dialog-mask.dialog-animation-end .dialog-container {
-        margin-top: 10vh;
         transform: scale(1) !important;
       }
 
       .dialog-mask.dialog-ready .dialog-container {
-        margin-top: 10vh;
         transform: none;
       }
 
@@ -328,12 +331,6 @@ export class Dialog extends RapidElement {
   }
 
   public render(): TemplateResult {
-    const height = this.getDocumentHeight();
-
-    const maskStyle = {
-      height: `${height + 100}px`,
-    };
-
     const dialogStyle = {
       width: this.width,
       minWidth: '250px',
@@ -361,7 +358,6 @@ export class Dialog extends RapidElement {
           'dialog-animation-end': this.animationEnd,
           'dialog-ready': this.ready,
         })}"
-        style=${styleMap(maskStyle)}
       >
         <div style="position: absolute; width: 100%;">
           <temba-loading
@@ -373,7 +369,7 @@ export class Dialog extends RapidElement {
         </div>
 
         <div class="flex">
-          <div class="flex-grow"></div>
+          <div class="grow-top"></div>
           <div
             @keyup=${this.handleKeyUp}
             style=${styleMap(dialogStyle)}
@@ -408,8 +404,7 @@ export class Dialog extends RapidElement {
                 ></temba-button>
               </div>
             </div>
-            <div class="flex-grow bottom-padding"></div>
-            <div class="bottom-padding"></div>
+            <div class="grow-bottom"></div>
           </div>
         </div>
       </div>

--- a/src/dialog/Modax.ts
+++ b/src/dialog/Modax.ts
@@ -43,10 +43,6 @@ export class Modax extends RapidElement {
         z-index: 10000;
       }
 
-      temba-dialog {
-        --transition-speed: var(--transition-speed);
-      }
-
       temba-loading {
         margin: 0 auto;
         display: block;
@@ -148,7 +144,7 @@ export class Modax extends RapidElement {
 
   public updatePrimaryButton(): void {
     if (!this.noSubmit) {
-      this.updateComplete.then(()=>{
+      this.updateComplete.then(() => {
         const submitButton = this.shadowRoot.querySelector(
           "input[type='submit']"
         ) as any;
@@ -190,7 +186,7 @@ export class Modax extends RapidElement {
       const script = this.ownerDocument.createElement('script');
       const code = scripts[i].innerText;
 
-      if (scripts[i].src && scripts[i].src.indexOf("web-dev-server") === -1) {
+      if (scripts[i].src && scripts[i].src.indexOf('web-dev-server') === -1) {
         script.src = scripts[i].src;
         script.type = 'text/javascript';
         script.async = true;
@@ -213,7 +209,7 @@ export class Modax extends RapidElement {
       this.body = unsafeHTML(div.innerHTML);
     }
 
-    this.updateComplete.then(()=>{
+    this.updateComplete.then(() => {
       for (const script of toAdd) {
         scriptBlock.appendChild(script);
       }
@@ -234,9 +230,9 @@ export class Modax extends RapidElement {
     this.body = this.getLoading();
     getUrl(this.endpoint, null, this.getHeaders()).then(
       (response: WebResponse) => {
-        this.setBody(response.body);        
+        this.setBody(response.body);
         this.fetching = false;
-        this.updateComplete.then(()=>{
+        this.updateComplete.then(() => {
           this.updatePrimaryButton();
           this.fireCustomEvent(CustomEventType.Loaded, {
             body: this.getBody(),
@@ -270,7 +266,7 @@ export class Modax extends RapidElement {
 
           if (redirect) {
             if (redirect === 'hide') {
-              this.updateComplete.then(()=>{
+              this.updateComplete.then(() => {
                 this.open = false;
                 this.fireCustomEvent(CustomEventType.Submitted);
               });

--- a/src/dropdown/Dropdown.ts
+++ b/src/dropdown/Dropdown.ts
@@ -26,8 +26,8 @@ export class Dropdown extends RapidElement {
         padding: 0;
         border-radius: var(--curvature);
         background: #fff;
-        transform: translateY(-1em);
-        transition: all calc(0.6 * var(--transition-speed)) linear;
+        transform: translateY(1em) scale(0.9);
+        transition: all calc(0.8 * var(--transition-speed)) var(--bounce);
         user-select: none;
         margin-top: 0px;
         margin-left: 0px;
@@ -53,7 +53,7 @@ export class Dropdown extends RapidElement {
       .open .dropdown {
         opacity: 1;
         pointer-events: auto;
-        transform: translateY(0.5em);
+        transform: translateY(0.5em) scale(1);
       }
 
       .mask {

--- a/src/list/TembaMenu.ts
+++ b/src/list/TembaMenu.ts
@@ -988,7 +988,7 @@ export class TembaMenu extends RapidElement {
 
     if (menuItem.popup) {
       return html`
-        <temba-dropdown offsetx="10" arrowoffset="8" mask>
+        <temba-dropdown offsetx="10" arrowoffset="8" arrowSize="0" mask>
           <div slot="toggle">${item}</div>
           <div
             slot="dropdown"


### PR DESCRIPTION
A lot of this is pretty subtle polish

* Make temba-dropdown use cubic snap
* Tighten up dropdown shadow
* Remove arrow on org chooser
* Add scale in cubic snap for temba-dialog
* Base dialog size and placement on 3:1 flex grow
* Fix dialog mask to fill even if browser is resized

![screencast 2023-04-18 18-00-09](https://user-images.githubusercontent.com/211652/232939513-17058a28-43c4-41ae-947e-669140ebbb5a.gif)
