### PR TITLE
Nicer built in debugging

### DIFF
--- a/src/RapidElement.ts
+++ b/src/RapidElement.ts
@@ -1,5 +1,62 @@
-import { LitElement } from 'lit';
+import { LitElement, PropertyValueMap } from 'lit';
 import { CustomEventType } from './interfaces';
+
+enum Color {
+  YELLOW = 33,
+  PURPLE = 35,
+  WHITE = 37,
+  BLUE = 34,
+  RED = 31,
+  CYAN = 36,
+  GREEN = 32,
+  BLACK = 30,
+}
+
+const colorize = (text: string, color: Color) => {
+  return `\x1b[${color}m${text}\x1b[0m`;
+};
+
+const tag = (ele: HTMLElement) => {
+  return colorize(ele.tagName.padEnd(30), Color.PURPLE);
+};
+
+const showUpdates = (
+  ele: HTMLElement,
+  changes: Map<PropertyKey, unknown>,
+  firstUpdated = false
+) => {
+  if (ele['DEBUG_UPDATES'] || ele['DEBUG']) {
+    if (changes.size > 0) {
+      console.log(
+        tag(ele),
+        firstUpdated
+          ? colorize('<updated>', Color.YELLOW)
+          : colorize('<first-updated>', Color.BLACK)
+      );
+      for (const [key, value] of changes.entries()) {
+        console.log(
+          '  ' + String(key).padEnd(30),
+          value,
+          colorize('=>', Color.WHITE),
+          ele[key]
+        );
+      }
+    }
+  }
+};
+
+const showEvent = (ele: HTMLElement, type: string, details = undefined) => {
+  if (ele['DEBUG_EVENTS'] || ele['DEBUG']) {
+    console.log(
+      tag(ele),
+      details !== undefined
+        ? colorize('<custom-event>', Color.RED)
+        : colorize('<event>       ', Color.CYAN),
+      colorize(type, Color.BLUE),
+      details !== undefined ? details : ''
+    );
+  }
+};
 
 export interface EventHandler {
   event: string;
@@ -8,6 +65,10 @@ export interface EventHandler {
 }
 
 export class RapidElement extends LitElement {
+  DEBUG = false;
+  DEBUG_UPDATES = false;
+  DEBUG_EVENTS = false;
+
   private eles: { [selector: string]: HTMLDivElement } = {};
   public getEventHandlers(): EventHandler[] {
     return [];
@@ -36,7 +97,23 @@ export class RapidElement extends LitElement {
     super.disconnectedCallback();
   }
 
+  protected firstUpdated(
+    changes: PropertyValueMap<any> | Map<PropertyKey, unknown>
+  ): void {
+    super.updated(changes);
+    showUpdates(this, changes, true);
+  }
+
+  protected updated(
+    changes: PropertyValueMap<any> | Map<PropertyKey, unknown>
+  ): void {
+    super.updated(changes);
+    showUpdates(this, changes, false);
+  }
+
   public fireEvent(type: string): any {
+    showEvent(this, type);
+
     return this.dispatchEvent(
       new Event(type, {
         bubbles: true,
@@ -46,6 +123,10 @@ export class RapidElement extends LitElement {
   }
 
   public fireCustomEvent(type: CustomEventType, detail: any = {}): any {
+    if (this['DEBUG_EVENTS']) {
+      showEvent(this, type, detail);
+    }
+
     const event = new CustomEvent(type, {
       detail,
       bubbles: true,


### PR DESCRIPTION
Built-in debugging for `RapidElement`

You can set any of the following values on any RapidElement:

```javascript
// Show all debug for this element
DEBUG = true

// Show events and custom events (including detail payloads)
DEBUG_EVENTS = true

// Show calls to firstUpdated and updated with from => to
DEBUG_UPDATES = true
```

These can be toggled on any individual element, or globally on RapidElement itself, ie, `DEBUG = true` on `RapidElement` will give you the complete firehose.

Some example output running `temba-menu.test.ts` with `DEBUG=true`:

<img width="563" alt="Screenshot 2023-05-23 at 8 35 59 PM" src="https://github.com/nyaruka/temba-components/assets/211652/8b007097-14ae-4268-aa02-d9aff4d0500d">
