### PR TITLE
Give more space to the map on the alias editor page

### DIFF
--- a/src/aliaseditor/AliasEditor.ts
+++ b/src/aliaseditor/AliasEditor.ts
@@ -120,8 +120,8 @@ export class AliasEditor extends LitElement {
       }
 
       leaflet-map {
-        height: 250px;
-        width: 450px;
+        height: 600px;
+        width: 800px;
         border: 0px solid #999;
         border-radius: var(--curvature);
       }


### PR DESCRIPTION
Border is to show the space we allocate to the map

Before
<img width="1157" alt="Monosnap Ethiopia 2023-06-22 11-28-39" src="https://github.com/nyaruka/temba-components/assets/1040571/9e124ae7-921c-4167-afee-a9dc45c2beaa">


After
<img width="1316" alt="Monosnap Ethiopia 2023-06-22 11-29-12" src="https://github.com/nyaruka/temba-components/assets/1040571/d4b639e0-cead-4a45-a321-fdad8497c901">

The maps will fit the space available