### PR TITLE
Allow modax to serialize valueless temba-checkbox

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -387,9 +387,14 @@ export const serialize = function (form: any) {
       (field.type !== 'checkbox' && field.type !== 'radio') ||
       field.checked
     ) {
-      if (field.value) {
+      let value = field.value;
+      if (!value && field.checked) {
+        value = '1';
+      }
+
+      if (value) {
         serialized.push(
-          encodeURIComponent(field.name) + '=' + encodeURIComponent(field.value)
+          encodeURIComponent(field.name) + '=' + encodeURIComponent(value)
         );
       }
     }


### PR DESCRIPTION
The better fix for this would be to abandon the `serialize` method in favor of `new FormData(form)`. Since we are on a release, I'm doing the smallest possible fix here for now.