### PR TITLE
Adjustments for rendering optin and fix to only show that for empty t…

### DIFF
--- a/src/contacts/events.ts
+++ b/src/contacts/events.ts
@@ -811,11 +811,11 @@ export const renderMsgEvent = (
         class="${event.msg.text ? '' : 'no-message'} attachments-${(
           event.msg.attachments || []
         ).length} ${getClasses({
-          msg: true,
+          msg: Boolean(event.msg.text || event.msg.attachments),
           automated: !isInbound && !event.msg.created_by,
         })}"
       >
-        ${event.msg.text || event.optin
+        ${event.msg.text
           ? html` <div class="text">${event.msg.text}</div> `
           : null}
         ${event.msg.attachments

--- a/src/contacts/events.ts
+++ b/src/contacts/events.ts
@@ -186,6 +186,7 @@ export const getEventStyles = () => {
 
     .msg .text {
       padding: var(--event-padding);
+      min-height: 1.5em;
     }
 
     .event.msg_received .msg {
@@ -370,16 +371,14 @@ export const getEventStyles = () => {
     }
 
     .optin {
-      border: 1px solid #f2f2f2;
       color: #999;
-      padding: 0.5em 1em;
-      border-radius: var(--curvature);
+      padding: 0.3em 1px;
       display: inline-flex;
     }
 
     .optin .text {
       margin-left: 0.5em;
-      display: inline;
+      display: inline-flex;
     }
 
     .optin span.italic {
@@ -816,7 +815,7 @@ export const renderMsgEvent = (
           automated: !isInbound && !event.msg.created_by,
         })}"
       >
-        ${event.msg.text
+        ${event.msg.text || event.optin
           ? html` <div class="text">${event.msg.text}</div> `
           : null}
         ${event.msg.attachments
@@ -830,19 +829,7 @@ export const renderMsgEvent = (
             </div> `
           : null}
       </div>
-      ${event.optin
-        ? html`<div class="optin">
-            <temba-icon
-              size="1"
-              class="broadcast inline"
-              name="${Icon.restore}"
-            ></temba-icon>
-            <div class="text">
-              Requested Opt In for
-              <span class="italic">${event.optin.name}</span>
-            </div>
-          </div>`
-        : null}
+
       ${!event.msg.text && !event.msg.attachments && !event.optin
         ? html`<div class="unsupported">Unsupported Message</div>`
         : null}
@@ -851,6 +838,19 @@ export const renderMsgEvent = (
         class="msg-summary"
         style="flex-direction:row${isInbound ? '-reverse' : ''}"
       >
+        ${event.optin && !event.msg.text && !event.msg.attachments
+          ? html`<div class="optin">
+              <temba-icon
+                size="1"
+                class="broadcast inline"
+                name="${Icon.restore}"
+              ></temba-icon>
+              <div class="text">
+                Requested Opt In for
+                <span class="italic">${event.optin.name}</span>
+              </div>
+            </div>`
+          : null}
         <div style="flex-grow:1"></div>
         ${summary}
       </div>


### PR DESCRIPTION
…ext messages having optin data

Render optin request left of the timestamp
<img width="576" alt="Monosnap 1212121 2023-09-28 17-05-21" src="https://github.com/nyaruka/temba-components/assets/1040571/3eacff03-f7c0-42a3-b419-9a2f36a3be7c">


And correctly render broadcast messages send with the optin
<img width="1398" alt="Monosnap 1212121 2023-09-28 09-52-55" src="https://github.com/nyaruka/temba-components/assets/1040571/c6314097-7a90-4639-8db7-609b11c8b041">

