### PR TITLE
Render line breaks for messages on contact chat

### DIFF
--- a/src/chat/Chat.ts
+++ b/src/chat/Chat.ts
@@ -205,6 +205,10 @@ export class Chat extends RapidElement {
         word-break: break-word;
       }
 
+      .message-text {
+        white-space: pre-line;
+      }
+
       .chat {
         width: 28rem;
         border-radius: var(--curvature);
@@ -760,7 +764,7 @@ export class Chat extends RapidElement {
               ? html`
                   <div class="bubble">
                     ${name ? html`<div class="name">${name}</div>` : null}
-                    <div class="message">${message.text}</div>
+                    <div class="message message-text">${message.text}</div>
 
                     <!--div>${message.date.toLocaleDateString(
                       undefined,


### PR DESCRIPTION
Before
<img width="129" alt="Monosnap Norbert Kwizera 2024-12-10 12-30-02" src="https://github.com/user-attachments/assets/f0512d15-d56f-4baa-b9fc-8e64bc915297">


After 
<img width="153" alt="Monosnap Norbert Kwizera 2024-12-10 12-28-14" src="https://github.com/user-attachments/assets/1e9a772f-6d91-43f4-9972-952eb4203c97">
