### PR TITLE
Use zero height instead of pointer-events for dropdowns

### DIFF
--- a/src/dropdown/Dropdown.ts
+++ b/src/dropdown/Dropdown.ts
@@ -29,7 +29,8 @@ export class Dropdown extends RapidElement {
       }
 
       .dropdown.dormant {
-        pointer-events: none;
+        height: 0;
+        overflow: hidden;
       }
 
       .dropdown {
@@ -63,7 +64,6 @@ export class Dropdown extends RapidElement {
 
       .open .dropdown {
         opacity: 1;
-        pointer-events: auto;
         transform: translateY(0.5em) scale(1);
       }
 

--- a/src/list/TembaMenu.ts
+++ b/src/list/TembaMenu.ts
@@ -647,6 +647,13 @@ export class TembaMenu extends ResizeElement {
         padding: 0.4em 0.2em;
       }
 
+      .level-0 temba-dropdown div[slot='dropdown'] .icon-wrapper {
+        padding: 0em !important;
+        align-self: center;
+        margin-right: 0.4em;
+        margin-left: 0.4em;
+      }
+
       temba-workspace-select {
         margin: 0.2em;
         display: block;

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -804,9 +804,6 @@ export class Select<T extends SelectOption> extends FormElement {
   }
 
   public handleOptionSelection(event: CustomEvent) {
-    event.preventDefault();
-    event.stopPropagation();
-
     const selected = event.detail.selected;
     // check if we should post it
     if (selected.post && this.endpoint) {


### PR DESCRIPTION
 * Fixes sign out icon alignment
 * Fixes dropdown events filtering properly on safari
 * Fixes click occlusion for hidden dropdowns