### PR TITLE
Fix rendering of airtime transfer events

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -92,8 +92,7 @@ export interface AirtimeTransferredEvent extends ContactEvent {
   sender: string;
   recipient: string;
   currency: string;
-  desired_amount: string;
-  actual_amount: string;
+  amount: string;
 }
 
 export type CallStartedEvent = ContactEvent;

--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -189,10 +189,10 @@ export const renderTicketOpened = (event: TicketEvent): string => {
 export const renderAirtimeTransferredEvent = (
   event: AirtimeTransferredEvent
 ): string => {
-  if (parseFloat(event.actual_amount) === 0) {
+  if (parseFloat(event.amount) === 0) {
     return `Airtime transfer failed`;
   }
-  return `Transferred **${event.actual_amount}** ${event.currency} of airtime`;
+  return `Transferred **${event.amount}** ${event.currency} of airtime`;
 };
 
 export const renderCallStartedEvent = (): string => {

--- a/test-assets/contacts/history.json
+++ b/test-assets/contacts/history.json
@@ -77,8 +77,7 @@
       "sender": "tel:123456",
       "recipient": "tel:+250788123123?channel=8a81e9e0-10a0-4319-9b00-ce723cfa8303&id=9951&priority=1000",
       "currency": null,
-      "desired_amount": "0.00",
-      "actual_amount": "0.00"
+      "amount": "0.00"
     },
     {
       "uuid": "01988a70-6cd1-738d-b5d6-ef9f9a0c529f",


### PR DESCRIPTION
At some point in the past the engine event was changed.. but what RP was generating as an "event" from the db didn't