### PR TITLE
Fix Enter key not working for quick replies on Android tablets

### DIFF
--- a/src/form/select/Select.ts
+++ b/src/form/select/Select.ts
@@ -1721,6 +1721,22 @@ export class Select<T extends SelectOption> extends FieldElement {
     }
   }
 
+  private handleBeforeInput(evt: InputEvent) {
+    // Android virtual keyboards often don't fire keydown with key='Enter'.
+    // Instead they fire beforeinput with inputType 'insertLineBreak' or
+    // 'insertParagraph'. Handle these the same as Enter for tags/emails.
+    if (
+      (evt.inputType === 'insertLineBreak' ||
+        evt.inputType === 'insertParagraph') &&
+      this.completionOptions.length === 0 &&
+      (this.emails || this.tags || this.expressions) &&
+      this.isAcceptableInput(this.input)
+    ) {
+      evt.preventDefault();
+      this.addInputAsValue();
+    }
+  }
+
   private handleKeyDown(evt: KeyboardEvent) {
     // Prevent Enter from inserting newlines in contenteditable
     if (evt.key === 'Enter' && this.useExpressionInput) {
@@ -2143,6 +2159,7 @@ export class Select<T extends SelectOption> extends FieldElement {
                   spellcheck="false"
                   style=${styleMap(inputStyles)}
                   @input=${this.handleInput}
+                  @beforeinput=${this.handleBeforeInput}
                   @keydown=${this.handleKeyDown}
                   @click=${this.handleClick}
                 ></div>`
@@ -2150,6 +2167,7 @@ export class Select<T extends SelectOption> extends FieldElement {
                   class="searchbox"
                   style=${styleMap(inputStyles)}
                   @input=${this.handleInput}
+                  @beforeinput=${this.handleBeforeInput}
                   @keydown=${this.handleKeyDown}
                   @click=${this.handleClick}
                   type="text"

--- a/src/form/select/Select.ts
+++ b/src/form/select/Select.ts
@@ -1724,16 +1724,25 @@ export class Select<T extends SelectOption> extends FieldElement {
   private handleBeforeInput(evt: InputEvent) {
     // Android virtual keyboards often don't fire keydown with key='Enter'.
     // Instead they fire beforeinput with inputType 'insertLineBreak' or
-    // 'insertParagraph'. Handle these the same as Enter for tags/emails.
+    // 'insertParagraph'. Prevent those from inserting newlines in the
+    // contenteditable expression input, and then handle acceptable input
+    // the same as Enter for tags/emails/expressions.
     if (
-      (evt.inputType === 'insertLineBreak' ||
-        evt.inputType === 'insertParagraph') &&
-      this.completionOptions.length === 0 &&
-      (this.emails || this.tags || this.expressions) &&
-      this.isAcceptableInput(this.input)
+      evt.inputType === 'insertLineBreak' ||
+      evt.inputType === 'insertParagraph'
     ) {
-      evt.preventDefault();
-      this.addInputAsValue();
+      if (this.useExpressionInput) {
+        evt.preventDefault();
+      }
+
+      if (
+        this.completionOptions.length === 0 &&
+        (this.emails || this.tags || this.expressions) &&
+        this.isAcceptableInput(this.input)
+      ) {
+        evt.preventDefault();
+        this.addInputAsValue();
+      }
     }
   }
 

--- a/test/temba-select.test.ts
+++ b/test/temba-select.test.ts
@@ -597,6 +597,128 @@ describe('temba-select', () => {
     });
   });
 
+  describe('beforeinput handling (Android virtual keyboards)', () => {
+    it('adds tag via insertLineBreak beforeinput', async () => {
+      const select = await createSelect(
+        clock,
+        getSelectHTML([], {
+          placeholder: 'Enter tags',
+          multi: true,
+          searchable: true,
+          tags: true
+        })
+      );
+
+      await typeInto('temba-select', 'hello', false, false);
+      await clock.runAll();
+      await select.updateComplete;
+
+      const searchbox = select.shadowRoot.querySelector(
+        '.searchbox'
+      ) as HTMLInputElement;
+      const evt = new InputEvent('beforeinput', {
+        inputType: 'insertLineBreak',
+        bubbles: true,
+        cancelable: true
+      });
+      searchbox.dispatchEvent(evt);
+      await select.updateComplete;
+
+      expect(select.values.length).to.equal(1);
+      expect(select.values[0].value).to.equal('hello');
+      expect(evt.defaultPrevented).to.be.true;
+    });
+
+    it('adds tag via insertParagraph beforeinput', async () => {
+      const select = await createSelect(
+        clock,
+        getSelectHTML([], {
+          placeholder: 'Enter tags',
+          multi: true,
+          searchable: true,
+          tags: true
+        })
+      );
+
+      await typeInto('temba-select', 'world', false, false);
+      await clock.runAll();
+      await select.updateComplete;
+
+      const searchbox = select.shadowRoot.querySelector(
+        '.searchbox'
+      ) as HTMLInputElement;
+      const evt = new InputEvent('beforeinput', {
+        inputType: 'insertParagraph',
+        bubbles: true,
+        cancelable: true
+      });
+      searchbox.dispatchEvent(evt);
+      await select.updateComplete;
+
+      expect(select.values.length).to.equal(1);
+      expect(select.values[0].value).to.equal('world');
+      expect(evt.defaultPrevented).to.be.true;
+    });
+
+    it('adds email via beforeinput', async () => {
+      const select = await createSelect(
+        clock,
+        getSelectHTML([], {
+          placeholder: 'Enter email addresses',
+          searchable: true,
+          emails: true
+        })
+      );
+
+      await typeInto('temba-select', 'test@example.com', false, false);
+      await clock.runAll();
+      await select.updateComplete;
+
+      const searchbox = select.shadowRoot.querySelector(
+        '.searchbox'
+      ) as HTMLInputElement;
+      const evt = new InputEvent('beforeinput', {
+        inputType: 'insertLineBreak',
+        bubbles: true,
+        cancelable: true
+      });
+      searchbox.dispatchEvent(evt);
+      await select.updateComplete;
+
+      expect(select.values.length).to.equal(1);
+      expect(select.values[0].value).to.equal('test@example.com');
+    });
+
+    it('does not add invalid email via beforeinput', async () => {
+      const select = await createSelect(
+        clock,
+        getSelectHTML([], {
+          placeholder: 'Enter email addresses',
+          searchable: true,
+          emails: true
+        })
+      );
+
+      await typeInto('temba-select', 'invalid-email', false, false);
+      await clock.runAll();
+      await select.updateComplete;
+
+      const searchbox = select.shadowRoot.querySelector(
+        '.searchbox'
+      ) as HTMLInputElement;
+      searchbox.dispatchEvent(
+        new InputEvent('beforeinput', {
+          inputType: 'insertLineBreak',
+          bubbles: true,
+          cancelable: true
+        })
+      );
+      await select.updateComplete;
+
+      expect(select.values.length).to.equal(0);
+    });
+  });
+
   describe('emails functionality', () => {
     it('only allows valid email addresses as options', async () => {
       const select = await createSelect(


### PR DESCRIPTION
## Summary
- Android virtual keyboards don't fire standard `keydown` events with `key='Enter'` — they use `beforeinput` with `inputType: 'insertLineBreak'` or `'insertParagraph'` instead
- Adds a `handleBeforeInput` handler to `temba-select` that catches these input types and adds the current input as a value, matching the existing `keydown` Enter behavior
- Also prevents newline insertion in contenteditable expression inputs when `useExpressionInput` is true, matching the existing `keydown` guard
- The `@beforeinput` listener is attached unconditionally; on desktop/iOS the existing `keydown` handler already handles Enter, so this serves as a fallback for devices where the IME bypasses `keydown`

## Test plan
- [ ] Test adding quick replies on an Android tablet — Enter/Go should now add the tag
- [ ] Verify quick replies still work on desktop (Enter key)
- [ ] Verify quick replies still work on iOS
- [ ] Verify email input fields still work correctly