### PR TITLE
Extract floating windows (issues, revisions) from Editor

### DIFF
--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -9,19 +9,12 @@ import {
   NodeUI
 } from '../store/flow-definition';
 import { getStore, Store } from '../store/Store';
-import {
-  AppState,
-  FlowIssue,
-  fromStore,
-  zustand,
-  FLOW_SPEC_VERSION
-} from '../store/AppState';
+import { AppState, FlowIssue, fromStore, zustand } from '../store/AppState';
 import { RapidElement } from '../RapidElement';
 import { repeat } from 'lit-html/directives/repeat.js';
 import { CustomEventType, DirtyTrackable, Workspace } from '../interfaces';
 import {
   generateUUID,
-  fetchResults,
   getClasses,
   getCookie,
   setCookie,
@@ -29,7 +22,6 @@ import {
 } from '../utils';
 import { TEMBA_COMPONENTS_VERSION } from '../version';
 import {
-  formatIssueMessage,
   getNodeBounds,
   calculateReflowPositions,
   NodeBounds,
@@ -37,18 +29,8 @@ import {
 } from './utils';
 import { ACTION_CONFIG, NODE_CONFIG } from './config';
 import { calculateLayeredLayout, placeStickyNotes } from './reflow';
-interface Revision {
-  id: number;
-  user: {
-    id: number;
-    username: string;
-    first_name: string;
-    last_name: string;
-    name?: string;
-  };
-  created_on: string;
-  comment?: string;
-}
+import { IssuesWindow } from './IssuesWindow';
+import { RevisionsWindow } from './RevisionsWindow';
 
 import { ACTION_GROUP_METADATA } from './types';
 
@@ -65,7 +47,6 @@ import { Dialog } from '../layout/Dialog';
 
 import { CanvasMenu, CanvasMenuSelection } from './CanvasMenu';
 import { NodeTypeSelector, NodeTypeSelection } from './NodeTypeSelector';
-import { FloatingWindow } from '../layout/FloatingWindow';
 import { FlowSearch, SearchResult } from './FlowSearch';
 
 export function findNodeForExit(
@@ -191,6 +172,9 @@ export class Editor extends RapidElement {
   // zoom/pan/loupe manager
   public zoomManager: ZoomManager;
 
+  public issuesWindow: IssuesWindow;
+  public revisionsWindow: RevisionsWindow;
+
   // timer for debounced saving
   private saveTimer: number | null = null;
 
@@ -219,10 +203,10 @@ export class Editor extends RapidElement {
   private canvasSize!: { width: number; height: number };
 
   @fromStore(zustand, (state: AppState) => state.dirtyDate)
-  private dirtyDate!: Date;
+  public dirtyDate!: Date;
 
   @fromStore(zustand, (state: AppState) => state.languageCode)
-  private languageCode!: string;
+  public languageCode!: string;
 
   @fromStore(zustand, (state: AppState) => state.isTranslating)
   private isTranslating!: boolean;
@@ -233,8 +217,11 @@ export class Editor extends RapidElement {
   @fromStore(zustand, (state: AppState) => state.getCurrentActivity())
   private activityData!: any;
 
-  @fromStore(zustand, (state: AppState) => state.flowInfo?.issues ?? EMPTY_FLOW_ISSUES)
-  private flowIssues!: FlowIssue[];
+  @fromStore(
+    zustand,
+    (state: AppState) => state.flowInfo?.issues ?? EMPTY_FLOW_ISSUES
+  )
+  public flowIssues!: FlowIssue[];
 
   // Drag state (managed by DragManager, kept on Editor for Lit reactivity)
   @state()
@@ -278,30 +265,19 @@ export class Editor extends RapidElement {
   public connectionSourceY: number | null = null;
 
   @state()
-  private issuesWindowHidden = true;
-
-
-  @state()
-  private revisionsWindowHidden = true;
+  public issuesWindowHidden = true;
 
   @state()
-  private revisions: Revision[] = [];
+  public revisionsWindowHidden = true;
 
   @state()
-  private viewingRevision: Revision | null = null;
-
-  @state()
-  private isLoadingRevisions = false;
-
-  @state()
-  private isSaving = false;
+  public isSaving = false;
 
   @state()
   private saveError: string | null = null;
 
   @state()
   public zoom = 1.0;
-
 
   // Non-reactive flag set in willUpdate to suppress the debouncedSave
   // call in updated() when the dirtyDate change comes from a reflow/copy
@@ -347,12 +323,6 @@ export class Editor extends RapidElement {
     }
     this.pendingPositions = saved;
   }
-
-  private preRevertState: {
-    definition: FlowDefinition;
-    dirtyDate: Date | null;
-  } | null = null;
-  private revisionsBrowseLanguageCode: string | null = null;
 
   public deleteDialog: Dialog | null = null;
 
@@ -437,12 +407,11 @@ export class Editor extends RapidElement {
     position: FlowPosition;
   } | null = null;
 
-
-
   // Bound event handlers to maintain proper 'this' context
   private boundCanvasContextMenu = this.handleCanvasContextMenu.bind(this);
   private boundWheel = (e: WheelEvent) => this.zoomManager.handleWheel(e);
-  private boundWindowResize = () => this.zoomManager.updateZoomControlPositioning();
+  private boundWindowResize = () =>
+    this.zoomManager.updateZoomControlPositioning();
 
   static get styles() {
     return css`
@@ -865,7 +834,6 @@ export class Editor extends RapidElement {
         color: #6b7280;
       }
 
-
       .translation-settings-arrow {
         width: 8px;
         height: 8px;
@@ -1181,8 +1149,12 @@ export class Editor extends RapidElement {
       }
 
       @keyframes drag-hint-in {
-        from { opacity: 0; }
-        to { opacity: 1; }
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
       }
 
       .reflow-card {
@@ -1256,6 +1228,8 @@ export class Editor extends RapidElement {
     super();
     this.dragManager = new DragManager(this);
     this.zoomManager = new ZoomManager(this);
+    this.issuesWindow = new IssuesWindow(this);
+    this.revisionsWindow = new RevisionsWindow(this);
   }
 
   protected firstUpdated(
@@ -1288,7 +1262,6 @@ export class Editor extends RapidElement {
           return;
         }
         getStore().getState().fetchRevision(`/flow/revisions/${this.flow}`);
-        this.fetchRevisions();
       }, 0);
     }
 
@@ -1434,12 +1407,12 @@ export class Editor extends RapidElement {
   }
 
   private setSimulatorTabHidden(hidden: boolean): void {
-    const simulator = document.querySelector('temba-simulator') as HTMLElement & {
+    const simulator = document.querySelector(
+      'temba-simulator'
+    ) as HTMLElement & {
       shadowRoot?: ShadowRoot;
     };
-    const phoneTab = simulator?.shadowRoot?.querySelector(
-      '#phone-tab'
-    ) as any;
+    const phoneTab = simulator?.shadowRoot?.querySelector('#phone-tab') as any;
     if (phoneTab) {
       phoneTab.hidden = hidden;
     }
@@ -1459,7 +1432,11 @@ export class Editor extends RapidElement {
       this.zoomManager.updateZoomControlPositioning();
     }
 
-    if (changes.has('showMessageTable') && !this.showMessageTable && this.plumber) {
+    if (
+      changes.has('showMessageTable') &&
+      !this.showMessageTable &&
+      this.plumber
+    ) {
       // Canvas was re-added to the DOM; rebind the plumber, listeners, and repaint
       requestAnimationFrame(() => {
         const canvas = this.querySelector('#canvas');
@@ -1536,7 +1513,6 @@ export class Editor extends RapidElement {
         this.saveError = null;
       }, 0);
     }
-
   }
 
   /**
@@ -1627,7 +1603,7 @@ export class Editor extends RapidElement {
     };
   }
 
-  private saveChanges(definitionOverride?: FlowDefinition): Promise<void> {
+  public saveChanges(definitionOverride?: FlowDefinition): Promise<void> {
     const definition = this.definitionForSave(
       definitionOverride || this.definition
     );
@@ -1652,9 +1628,6 @@ export class Editor extends RapidElement {
           if (response.json.revision?.revision !== undefined) {
             state.setRevision(response.json.revision.revision);
           }
-
-          // Refresh revisions list so the tab visibility stays up to date
-          this.fetchRevisions();
         }
 
         getStore().getState().setDirtyDate(null);
@@ -1762,7 +1735,7 @@ export class Editor extends RapidElement {
     });
   }
 
-  private handleLanguageChange(languageCode: string): void {
+  public handleLanguageChange(languageCode: string): void {
     zustand.getState().setLanguageCode(languageCode);
   }
 
@@ -1905,9 +1878,8 @@ export class Editor extends RapidElement {
     });
   }
 
-
   private openFlowSearch(): void {
-    if (this.viewingRevision) {
+    if (this.revisionsWindow.isViewingRevision) {
       return;
     }
 
@@ -1927,13 +1899,12 @@ export class Editor extends RapidElement {
     search.show();
   }
 
-  private closeFlowSearch(): void {
+  public closeFlowSearch(): void {
     const search = this.querySelector('temba-flow-search') as FlowSearch;
     if (search?.open) {
       search.hide();
     }
   }
-
 
   // Called by DragManager for non-drag keyboard handling
   public handleKeyDown(event: KeyboardEvent): void {
@@ -2041,7 +2012,6 @@ export class Editor extends RapidElement {
     if (!this.flow) return undefined;
     return this.getFlowSettings()[this.flow]?.[key];
   }
-
 
   private showDeleteConfirmation(): void {
     const itemCount = this.selectedItems.size;
@@ -2286,7 +2256,6 @@ export class Editor extends RapidElement {
     this.selectedItems.clear();
   }
 
-
   private renderCanvasDropPreview(): TemplateResult | string {
     if (!this.canvasDropPreview) return '';
 
@@ -2474,7 +2443,6 @@ export class Editor extends RapidElement {
     const el = document.elementFromPoint(clientX, clientY);
     return el?.closest('temba-flow-node') ?? null;
   }
-
 
   private updateCanvasSize(): void {
     if (!this.definition) return;
@@ -3162,7 +3130,9 @@ export class Editor extends RapidElement {
         this.actionDragIsCopy = true;
         this.showActionOriginal(true);
       } else {
-        (this.querySelector('#drag-hint') as HTMLElement)?.classList.add('visible');
+        (this.querySelector('#drag-hint') as HTMLElement)?.classList.add(
+          'visible'
+        );
       }
     }
 
@@ -3325,7 +3295,9 @@ export class Editor extends RapidElement {
     this.actionDragTargetNodeUuid = null;
     this.isActionExternalDrag = false;
     this.actionDragIsCopy = false;
-    (this.querySelector('#drag-hint') as HTMLElement)?.classList.remove('visible');
+    (this.querySelector('#drag-hint') as HTMLElement)?.classList.remove(
+      'visible'
+    );
     this.actionDragLastDetail = null;
   }
 
@@ -3411,7 +3383,9 @@ export class Editor extends RapidElement {
     this.actionDragIsCopy = false;
     this.actionDragLastDetail = null;
     this.previousActionDragTargetNodeUuid = null;
-    (this.querySelector('#drag-hint') as HTMLElement)?.classList.remove('visible');
+    (this.querySelector('#drag-hint') as HTMLElement)?.classList.remove(
+      'visible'
+    );
 
     // Check if we're dropping on an existing execute_actions node
     const targetNodeUuid = this.actionDragTargetNodeUuid;
@@ -3479,9 +3453,7 @@ export class Editor extends RapidElement {
 
     // create a new execute_actions node with the dropped action
     // When copying, generate a fresh UUID so the clone doesn't share the original's
-    const droppedAction = isCopy
-      ? { ...action, uuid: generateUUID() }
-      : action;
+    const droppedAction = isCopy ? { ...action, uuid: generateUUID() } : action;
     const newNode: Node = {
       uuid: generateUUID(),
       actions: [droppedAction],
@@ -3538,15 +3510,12 @@ export class Editor extends RapidElement {
     }
   }
 
-
-
-
-  private closeOpenWindows(): void {
-    if (!this.issuesWindowHidden) {
-      this.handleIssuesWindowClosed();
+  public closeOpenWindows(): void {
+    if (this.issuesWindow.isOpen) {
+      this.issuesWindow.close();
     }
-    if (!this.revisionsWindowHidden) {
-      this.handleRevisionsWindowClosed();
+    if (this.revisionsWindow.isOpen) {
+      this.revisionsWindow.close();
     }
     if (this.simulatorActive) {
       const simulator = document.querySelector('temba-simulator') as any;
@@ -3555,335 +3524,13 @@ export class Editor extends RapidElement {
   }
 
   private closeFloatingWindows(): void {
-    if (!this.issuesWindowHidden) {
-      this.handleIssuesWindowClosed();
+    if (this.issuesWindow.isOpen) {
+      this.issuesWindow.close();
     }
-    if (!this.revisionsWindowHidden) {
-      this.handleRevisionsWindowClosed();
-    }
-  }
-
-  private handleIssuesTabClick(): void {
-    if (!this.issuesWindowHidden) {
-      this.handleIssuesWindowClosed();
-      return;
-    }
-    this.closeOpenWindows();
-    this.issuesWindowHidden = false;
-  }
-
-  private handleIssuesWindowClosed(): void {
-    this.issuesWindowHidden = true;
-  }
-
-  private handleIssueItemClick(issue: FlowIssue): void {
-    const issuesWindow = document.getElementById(
-      'issues-window'
-    ) as FloatingWindow;
-    issuesWindow?.handleClose();
-    this.issuesWindowHidden = true;
-
-    this.focusNode(issue.node_uuid);
-
-    const node = this.definition.nodes.find((n) => n.uuid === issue.node_uuid);
-    if (!node) return;
-
-    if (issue.action_uuid) {
-      const action = node.actions?.find((a) => a.uuid === issue.action_uuid);
-      if (action) {
-        this.editingAction = action;
-        this.editingNode = node;
-        this.editingNodeUI = this.definition._ui.nodes[issue.node_uuid];
-      }
-    } else {
-      this.editingNode = node;
-      this.editingNodeUI = this.definition._ui.nodes[issue.node_uuid];
+    if (this.revisionsWindow.isOpen) {
+      this.revisionsWindow.close();
     }
   }
-
-  private handleRevisionsTabClick(): void {
-    if (!this.revisionsWindowHidden) {
-      this.handleRevisionsWindowClosed();
-      return;
-    }
-    this.closeOpenWindows();
-    this.fetchRevisions();
-    this.revisionsWindowHidden = false;
-  }
-
-  private handleRevisionsWindowClosed(): void {
-    this.resetRevisionsScroll();
-    this.revisionsWindowHidden = true;
-    if (this.viewingRevision) {
-      this.handleCancelRevisionView();
-    }
-  }
-
-  private resetRevisionsScroll() {
-    const list =
-      this.querySelector('#revisions-window').shadowRoot?.querySelector(
-        '.body'
-      );
-    if (list) {
-      list.scrollTop = 0;
-    }
-  }
-
-  private async fetchRevisions() {
-    this.isLoadingRevisions = true;
-    try {
-      const results = await fetchResults(
-        `/flow/revisions/${this.flow}/?version=${FLOW_SPEC_VERSION}`
-      );
-      this.revisions = results.slice(1);
-    } catch (e) {
-      console.error('Error fetching revisions', e);
-    } finally {
-      this.isLoadingRevisions = false;
-    }
-  }
-
-  private async handleRevisionClick(revision: Revision) {
-    if (this.viewingRevision?.id === revision.id) {
-      return;
-    }
-
-    if (!this.viewingRevision) {
-      // Save current state first
-      this.preRevertState = {
-        definition: this.definition,
-        dirtyDate: this.dirtyDate
-      };
-      this.revisionsBrowseLanguageCode = this.languageCode;
-    }
-
-    this.viewingRevision = revision;
-    this.closeFlowSearch();
-    this.isLoadingRevisions = true;
-    this.plumber?.reset();
-
-    try {
-      await getStore()
-        .getState()
-        .fetchRevision(`/flow/revisions/${this.flow}`, revision.id.toString());
-      if (this.revisionsBrowseLanguageCode) {
-        this.handleLanguageChange(this.revisionsBrowseLanguageCode);
-      }
-    } catch (e) {
-      console.error('Error fetching revision details', e);
-      this.handleCancelRevisionView();
-    } finally {
-      this.isLoadingRevisions = false;
-    }
-  }
-
-  private handleCancelRevisionView() {
-    this.plumber?.reset();
-    const preservedLanguageCode =
-      this.revisionsBrowseLanguageCode || this.languageCode;
-    if (this.preRevertState) {
-      const currentInfo = getStore().getState().flowInfo;
-      getStore().getState().setFlowContents({
-        definition: this.preRevertState.definition,
-        info: currentInfo
-      });
-      if (this.preRevertState.dirtyDate) {
-        getStore().getState().setDirtyDate(this.preRevertState.dirtyDate);
-      }
-      if (preservedLanguageCode) {
-        this.handleLanguageChange(preservedLanguageCode);
-      }
-    } else {
-      // Fallback if no pre-revert definition
-      getStore()
-        .getState()
-        .fetchRevision(`/flow/revisions/${this.flow}`)
-        .finally(() => {
-          if (preservedLanguageCode) {
-            this.handleLanguageChange(preservedLanguageCode);
-          }
-        });
-    }
-
-    this.viewingRevision = null;
-    this.preRevertState = null;
-    this.revisionsBrowseLanguageCode = null;
-  }
-
-  private async handleRevertClick() {
-    if (!this.viewingRevision || !this.preRevertState) return;
-    this.plumber?.reset();
-    const preservedLanguageCode =
-      this.revisionsBrowseLanguageCode || this.languageCode;
-
-    // Use the content of the viewing revision (this.definition)
-    // but the revision number of the current head (preRevertState)
-    // so the server accepts it as a valid update
-    const definitionToSave = {
-      ...this.definition,
-      revision: this.preRevertState.definition.revision
-    };
-
-    await this.saveChanges(definitionToSave);
-    this.viewingRevision = null;
-    this.preRevertState = null;
-    this.revisionsWindowHidden = true;
-
-    const revisionsWindow = document.getElementById(
-      'revisions-window'
-    ) as FloatingWindow;
-    revisionsWindow.handleClose();
-
-    // Refresh revisions list to show the new one
-    this.fetchRevisions();
-
-    // Fetch the latest version of the flow to ensure the store is up to date
-    getStore()
-      .getState()
-      .fetchRevision(`/flow/revisions/${this.flow}`)
-      .finally(() => {
-        if (preservedLanguageCode) {
-          this.handleLanguageChange(preservedLanguageCode);
-        }
-      });
-    this.revisionsBrowseLanguageCode = null;
-  }
-
-  private renderIssuesTab(): TemplateResult | string {
-    if (!this.flowIssues?.length) return '';
-    return html`
-      <temba-floating-tab
-        id="issues-tab"
-        icon="alert_warning"
-        label="Flow Issues"
-        color="tomato"
-        order="2"
-        .active=${!this.issuesWindowHidden}
-        @temba-button-clicked=${this.handleIssuesTabClick}
-      ></temba-floating-tab>
-    `;
-  }
-
-  private renderIssuesWindow(): TemplateResult | string {
-    if (!this.flowIssues?.length) return '';
-    return html`
-      <temba-floating-window
-        id="issues-window"
-        name="issues"
-        header="Flow Issues"
-        icon="alert_warning"
-        .width=${360}
-        .maxHeight=${600}
-        .top=${120}
-        color="tomato"
-        .hidden=${this.issuesWindowHidden}
-        @temba-dialog-hidden=${this.handleIssuesWindowClosed}
-      >
-        <div style="display:flex; flex-direction:column; gap:2px;">
-          ${this.flowIssues.map(
-            (issue) => html`
-              <div
-                class="issue-list-item"
-                @click=${() => this.handleIssueItemClick(issue)}
-              >
-                <temba-icon name="alert_warning" size="1.2"></temba-icon>
-                <span>${formatIssueMessage(issue)}</span>
-              </div>
-            `
-          )}
-        </div>
-      </temba-floating-window>
-    `;
-  }
-
-  private renderRevisionsWindow(): TemplateResult | string {
-    return html`
-      <temba-floating-window
-        id="revisions-window"
-        name="revisions"
-        header="Revisions"
-        icon="revisions"
-        .width=${240}
-        .maxHeight=${400}
-        .top=${120}
-        color="rgb(142, 94, 167)"
-        .saving=${this.isSaving}
-        .hidden=${this.revisionsWindowHidden}
-        @temba-dialog-hidden=${this.handleRevisionsWindowClosed}
-      >
-        <div class="localization-window-content">
-          <div
-            class="revisions-list"
-            style="display:flex; flex-direction:column; gap:8px; overflow-y:auto; padding-bottom:10px;"
-          >
-            ${this.isLoadingRevisions && !this.revisions.length
-              ? html`<temba-loading></temba-loading>`
-              : this.revisions.map((rev) => {
-                  const isSelected = this.viewingRevision?.id === rev.id;
-                  return html`
-                    <div
-                      class="revision-item ${isSelected ? 'selected' : ''}"
-                      style="padding:8px; border-radius:4px; cursor:pointer; background:${
-                        isSelected
-                          ? '#f0f6ff' // Light blue bg for selected
-                          : '#f9fafb'
-                      }; border:1px solid ${
-                        isSelected ? '#a4cafe' : '#e5e7eb'
-                      }; transition: all 0.2s ease;"
-                      @click=${() => this.handleRevisionClick(rev)}
-                    >
-                      <div
-                        style="display:flex; justify-content:space-between; align-items:center;"
-                      >
-                        <div
-                          class="revision-header"
-                          style="margin-bottom: 2px;"
-                        >
-                          <div
-                            style="font-weight:600; font-size:13px; color:#111827;"
-                          >
-                            <temba-date value=${
-                              rev.created_on
-                            } display="duration"></temba-date>
-                            
-                          </div>
-                          <div style="font-size:11px; color:#6b7280;">
-                            ${rev.user.name || rev.user.username}
-                          </div>
-                        </div>
-                        ${
-                          isSelected
-                            ? html`<button
-                                class="revert-button"
-                                @click=${this.handleRevertClick}
-                              >
-                                Revert
-                              </button>`
-                            : html``
-                        }
-                        
-                        </button>
-                      </div>
-
-                      ${
-                        rev.comment
-                          ? html`<div
-                              style="font-size:12px; color:#4b5563; margin-top:4px;"
-                            >
-                              ${rev.comment}
-                            </div>`
-                          : ''
-                      }
-                      
-                    </div>
-                  `;
-                })}
-          </div>
-        </div>
-      </temba-floating-window>
-    `;
-  }
-
 
   private renderToolbarElement(): TemplateResult {
     return html`
@@ -3894,7 +3541,7 @@ export class Editor extends RapidElement {
         ?zoom-fitted=${this.zoomManager.isZoomFitted}
         ?revisions-active=${!this.revisionsWindowHidden}
         ?is-saving=${this.isSaving}
-        ?search-disabled=${!!this.viewingRevision}
+        ?search-disabled=${this.revisionsWindow.isViewingRevision}
         @temba-button-clicked=${this.handleToolbarAction}
       ></temba-editor-toolbar>
     `;
@@ -3919,7 +3566,11 @@ export class Editor extends RapidElement {
         this.zoomManager.zoomToFull();
         break;
       case 'revisions':
-        this.handleRevisionsTabClick();
+        if (this.revisionsWindow.isOpen) {
+          this.revisionsWindow.close();
+        } else {
+          this.revisionsWindow.open();
+        }
         break;
       case 'search':
         this.openFlowSearch();
@@ -3978,9 +3629,7 @@ export class Editor extends RapidElement {
       return;
     }
 
-    const node = this.definition.nodes.find(
-      (n) => n.uuid === result.nodeUuid
-    );
+    const node = this.definition.nodes.find((n) => n.uuid === result.nodeUuid);
     if (!node) return;
 
     const nodeUI = this.definition._ui?.nodes[result.nodeUuid];
@@ -4058,7 +3707,7 @@ export class Editor extends RapidElement {
   }
 
   public isReadOnly(): boolean {
-    return this.viewingRevision !== null || this.isTranslating;
+    return this.revisionsWindow.isViewingRevision || this.isTranslating;
   }
 
   public render(): TemplateResult {
@@ -4076,142 +3725,152 @@ export class Editor extends RapidElement {
     const hasCorruptedUI =
       this.definition &&
       this.definition.nodes.length > 0 &&
-      this.definition.nodes.some(
-        (n) => !this.definition._ui?.nodes[n.uuid]
-      );
+      this.definition.nodes.some((n) => !this.definition._ui?.nodes[n.uuid]);
 
-    return html`${style} ${this.renderIssuesWindow()}
-      ${this.renderRevisionsWindow()}
+    return html`${style} ${this.issuesWindow.renderWindow()}
+      ${this.revisionsWindow.renderWindow()}
       <div id="editor-container">
         ${this.renderToolbarElement()}
         <div id="editor">
           ${this.showMessageTable
             ? html`<temba-message-table></temba-message-table>`
             : html`
-          ${hasCorruptedUI
-            ? html`<div class="empty-flow">
-                <div class="empty-flow-content">
-                  <div class="empty-flow-title">
-                    Unable to display this flow
-                  </div>
-                  <div class="empty-flow-description">
-                    This flow's layout data does not match its nodes. It may
-                    have been corrupted during an export or migration. Please
-                    re-export the flow from the original workspace and try
-                    importing it again.
+                ${hasCorruptedUI
+                  ? html`<div class="empty-flow">
+                      <div class="empty-flow-content">
+                        <div class="empty-flow-title">
+                          Unable to display this flow
+                        </div>
+                        <div class="empty-flow-description">
+                          This flow's layout data does not match its nodes. It
+                          may have been corrupted during an export or migration.
+                          Please re-export the flow from the original workspace
+                          and try importing it again.
+                        </div>
+                      </div>
+                    </div>`
+                  : this.definition &&
+                      this.definition.nodes.length === 0 &&
+                      !this.isReadOnly()
+                    ? html`<div class="empty-flow">
+                        <div class="empty-flow-content">
+                          <div class="empty-flow-title">This flow is empty</div>
+                          <div class="empty-flow-description">
+                            Get started by adding your first action or split to
+                            define how this flow will work.
+                          </div>
+                          <button
+                            class="empty-flow-button"
+                            @click=${this.handleEmptyFlowClick}
+                          >
+                            Add first step
+                          </button>
+                        </div>
+                      </div>`
+                    : ''}
+                <div
+                  id="grid"
+                  class="${this.revisionsWindow.isViewingRevision
+                    ? 'viewing-revision'
+                    : ''}"
+                  style="min-width:${100 / this.zoom}%;min-height:${100 /
+                  this.zoom}%;width:${this.canvasSize.width}px; height:${this
+                    .canvasSize.height}px;transform:scale(${this.zoom})"
+                >
+                  <div
+                    id="canvas"
+                    class="${getClasses({
+                      'viewing-revision':
+                        this.revisionsWindow.isViewingRevision,
+                      'read-only-connections':
+                        this.revisionsWindow.isViewingRevision ||
+                        this.isTranslating
+                    })}"
+                  >
+                    ${this.definition && !hasCorruptedUI
+                      ? repeat(
+                          [...this.definition.nodes].sort((a, b) =>
+                            a.uuid.localeCompare(b.uuid)
+                          ),
+                          (node) => node.uuid,
+                          (node) => {
+                            const nodeUI = this.definition._ui?.nodes[
+                              node.uuid
+                            ] || {
+                              position: { left: 0, top: 0 },
+                              type: node.router?.wait
+                                ? 'wait_for_response'
+                                : 'execute_actions'
+                            };
+                            const position = nodeUI.position;
+
+                            const dragging =
+                              this.isDragging &&
+                              this.currentDragItem?.uuid === node.uuid;
+
+                            const selected = this.selectedItems.has(node.uuid);
+
+                            // first node is the flow start (nodes are sorted by position)
+                            const isFlowStart =
+                              this.definition.nodes.length > 0 &&
+                              this.definition.nodes[0].uuid === node.uuid;
+
+                            return html`<temba-flow-node
+                              class="draggable ${dragging
+                                ? 'dragging'
+                                : ''} ${selected
+                                ? 'selected'
+                                : ''} ${isFlowStart ? 'flow-start' : ''}"
+                              @mousedown=${(e: MouseEvent) =>
+                                this.dragManager.handleMouseDown(e)}
+                              @touchstart=${(e: TouchEvent) =>
+                                this.dragManager.handleItemTouchStart(e)}
+                              uuid=${node.uuid}
+                              data-node-uuid=${node.uuid}
+                              style="left:${position.left}px; top:${position.top}px;transition: all 0.2s ease-in-out;"
+                              .plumber=${this.plumber}
+                              .node=${node}
+                              .ui=${nodeUI}
+                              @temba-node-deleted=${(event) => {
+                                this.deleteNodes([event.detail.uuid]);
+                              }}
+                            ></temba-flow-node>`;
+                          }
+                        )
+                      : hasCorruptedUI
+                        ? ''
+                        : html`<temba-loading></temba-loading>`}
+                    ${repeat(
+                      Object.entries(stickies),
+                      ([uuid]) => uuid,
+                      ([uuid, sticky]) => {
+                        const position = sticky.position || { left: 0, top: 0 };
+                        const dragging =
+                          this.isDragging &&
+                          this.currentDragItem?.uuid === uuid;
+                        const selected = this.selectedItems.has(uuid);
+                        return html`<temba-sticky-note
+                          class="draggable ${dragging
+                            ? 'dragging'
+                            : ''} ${selected ? 'selected' : ''}"
+                          @mousedown=${(e: MouseEvent) =>
+                            this.dragManager.handleMouseDown(e)}
+                          @touchstart=${(e: TouchEvent) =>
+                            this.dragManager.handleItemTouchStart(e)}
+                          style="left:${position.left}px; top:${position.top}px;"
+                          uuid=${uuid}
+                          .data=${sticky}
+                          .dragging=${dragging}
+                          .selected=${selected}
+                        ></temba-sticky-note>`;
+                      }
+                    )}
+                    ${this.dragManager.renderSelectionBox()}
+                    ${this.renderCanvasDropPreview()}
+                    ${this.renderConnectionPlaceholder()}
                   </div>
                 </div>
-              </div>`
-            : this.definition &&
-                this.definition.nodes.length === 0 &&
-                !this.isReadOnly()
-              ? html`<div class="empty-flow">
-                  <div class="empty-flow-content">
-                    <div class="empty-flow-title">This flow is empty</div>
-                    <div class="empty-flow-description">
-                      Get started by adding your first action or split to define
-                      how this flow will work.
-                    </div>
-                    <button
-                      class="empty-flow-button"
-                      @click=${this.handleEmptyFlowClick}
-                    >
-                      Add first step
-                    </button>
-                  </div>
-                </div>`
-              : ''}
-          <div
-            id="grid"
-            class="${this.viewingRevision ? 'viewing-revision' : ''}"
-            style="min-width:${100 / this.zoom}%;min-height:${100 /
-            this.zoom}%;width:${this.canvasSize.width}px; height:${this
-              .canvasSize.height}px;transform:scale(${this.zoom})"
-          >
-            <div
-              id="canvas"
-              class="${getClasses({
-                'viewing-revision': !!this.viewingRevision,
-                'read-only-connections':
-                  !!this.viewingRevision || this.isTranslating
-              })}"
-            >
-              ${this.definition && !hasCorruptedUI
-                ? repeat(
-                    [...this.definition.nodes].sort((a, b) =>
-                      a.uuid.localeCompare(b.uuid)
-                    ),
-                    (node) => node.uuid,
-                    (node) => {
-                      const nodeUI = this.definition._ui?.nodes[node.uuid] || {
-                        position: { left: 0, top: 0 },
-                        type: node.router?.wait
-                          ? 'wait_for_response'
-                          : 'execute_actions'
-                      };
-                      const position = nodeUI.position;
-
-                      const dragging =
-                        this.isDragging &&
-                        this.currentDragItem?.uuid === node.uuid;
-
-                      const selected = this.selectedItems.has(node.uuid);
-
-                      // first node is the flow start (nodes are sorted by position)
-                      const isFlowStart =
-                        this.definition.nodes.length > 0 &&
-                        this.definition.nodes[0].uuid === node.uuid;
-
-                      return html`<temba-flow-node
-                        class="draggable ${dragging
-                          ? 'dragging'
-                          : ''} ${selected ? 'selected' : ''} ${isFlowStart
-                          ? 'flow-start'
-                          : ''}"
-                        @mousedown=${(e: MouseEvent) => this.dragManager.handleMouseDown(e)}
-                        @touchstart=${(e: TouchEvent) => this.dragManager.handleItemTouchStart(e)}
-                        uuid=${node.uuid}
-                        data-node-uuid=${node.uuid}
-                        style="left:${position.left}px; top:${position.top}px;transition: all 0.2s ease-in-out;"
-                        .plumber=${this.plumber}
-                        .node=${node}
-                        .ui=${nodeUI}
-                        @temba-node-deleted=${(event) => {
-                          this.deleteNodes([event.detail.uuid]);
-                        }}
-                      ></temba-flow-node>`;
-                    }
-                  )
-                : hasCorruptedUI
-                  ? ''
-                  : html`<temba-loading></temba-loading>`}
-              ${repeat(
-                Object.entries(stickies),
-                ([uuid]) => uuid,
-                ([uuid, sticky]) => {
-                  const position = sticky.position || { left: 0, top: 0 };
-                  const dragging =
-                    this.isDragging && this.currentDragItem?.uuid === uuid;
-                  const selected = this.selectedItems.has(uuid);
-                  return html`<temba-sticky-note
-                    class="draggable ${dragging ? 'dragging' : ''} ${selected
-                      ? 'selected'
-                      : ''}"
-                    @mousedown=${(e: MouseEvent) => this.dragManager.handleMouseDown(e)}
-                    @touchstart=${(e: TouchEvent) => this.dragManager.handleItemTouchStart(e)}
-                    style="left:${position.left}px; top:${position.top}px;"
-                    uuid=${uuid}
-                    .data=${sticky}
-                    .dragging=${dragging}
-                    .selected=${selected}
-                  ></temba-sticky-note>`;
-                }
-              )}
-              ${this.dragManager.renderSelectionBox()} ${this.renderCanvasDropPreview()}
-              ${this.renderConnectionPlaceholder()}
-            </div>
-          </div>
-          `}
+              `}
         </div>
         ${this.renderPendingCard()}
         <div class="drag-hint" id="drag-hint">Hold ⇧ to duplicate</div>
@@ -4238,7 +3897,7 @@ export class Editor extends RapidElement {
         : ''}
 
       <temba-canvas-menu></temba-canvas-menu>
-      ${!this.viewingRevision
+      ${!this.revisionsWindow.isViewingRevision
         ? html`<temba-node-type-selector
             .flowType=${this.flowType}
             .features=${this.features}
@@ -4249,8 +3908,6 @@ export class Editor extends RapidElement {
         .includeCategories=${false}
         @temba-search-result-selected=${this.handleSearchResultSelected}
       ></temba-flow-search>
-      ${!this.showMessageTable ? html`
-        ${this.renderIssuesTab()}
-      ` : ''} `;
+      ${!this.showMessageTable ? html` ${this.issuesWindow.renderTab()} ` : ''} `;
   }
 }

--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -29,8 +29,7 @@ import {
 } from './utils';
 import { ACTION_CONFIG, NODE_CONFIG } from './config';
 import { calculateLayeredLayout, placeStickyNotes } from './reflow';
-import { IssuesWindow } from './IssuesWindow';
-import { RevisionsWindow } from './RevisionsWindow';
+import type { RevisionsWindow } from './RevisionsWindow';
 
 import { ACTION_GROUP_METADATA } from './types';
 
@@ -172,9 +171,6 @@ export class Editor extends RapidElement {
   // zoom/pan/loupe manager
   public zoomManager: ZoomManager;
 
-  public issuesWindow: IssuesWindow;
-  public revisionsWindow: RevisionsWindow;
-
   // timer for debounced saving
   private saveTimer: number | null = null;
 
@@ -203,10 +199,10 @@ export class Editor extends RapidElement {
   private canvasSize!: { width: number; height: number };
 
   @fromStore(zustand, (state: AppState) => state.dirtyDate)
-  public dirtyDate!: Date;
+  private dirtyDate!: Date;
 
   @fromStore(zustand, (state: AppState) => state.languageCode)
-  public languageCode!: string;
+  private languageCode!: string;
 
   @fromStore(zustand, (state: AppState) => state.isTranslating)
   private isTranslating!: boolean;
@@ -221,7 +217,7 @@ export class Editor extends RapidElement {
     zustand,
     (state: AppState) => state.flowInfo?.issues ?? EMPTY_FLOW_ISSUES
   )
-  public flowIssues!: FlowIssue[];
+  private flowIssues!: FlowIssue[];
 
   // Drag state (managed by DragManager, kept on Editor for Lit reactivity)
   @state()
@@ -265,10 +261,13 @@ export class Editor extends RapidElement {
   public connectionSourceY: number | null = null;
 
   @state()
-  public issuesWindowHidden = true;
+  private issuesWindowHidden = true;
 
   @state()
-  public revisionsWindowHidden = true;
+  private revisionsWindowHidden = true;
+
+  @state()
+  private viewingRevision = false;
 
   @state()
   public isSaving = false;
@@ -1228,8 +1227,6 @@ export class Editor extends RapidElement {
     super();
     this.dragManager = new DragManager(this);
     this.zoomManager = new ZoomManager(this);
-    this.issuesWindow = new IssuesWindow(this);
-    this.revisionsWindow = new RevisionsWindow(this);
   }
 
   protected firstUpdated(
@@ -1603,7 +1600,7 @@ export class Editor extends RapidElement {
     };
   }
 
-  public saveChanges(definitionOverride?: FlowDefinition): Promise<void> {
+  private saveChanges(definitionOverride?: FlowDefinition): Promise<void> {
     const definition = this.definitionForSave(
       definitionOverride || this.definition
     );
@@ -1735,7 +1732,7 @@ export class Editor extends RapidElement {
     });
   }
 
-  public handleLanguageChange(languageCode: string): void {
+  private handleLanguageChange(languageCode: string): void {
     zustand.getState().setLanguageCode(languageCode);
   }
 
@@ -1879,7 +1876,7 @@ export class Editor extends RapidElement {
   }
 
   private openFlowSearch(): void {
-    if (this.revisionsWindow.isViewingRevision) {
+    if (this.viewingRevision) {
       return;
     }
 
@@ -1899,7 +1896,7 @@ export class Editor extends RapidElement {
     search.show();
   }
 
-  public closeFlowSearch(): void {
+  private closeFlowSearch(): void {
     const search = this.querySelector('temba-flow-search') as FlowSearch;
     if (search?.open) {
       search.hide();
@@ -3510,12 +3507,13 @@ export class Editor extends RapidElement {
     }
   }
 
-  public closeOpenWindows(): void {
-    if (this.issuesWindow.isOpen) {
-      this.issuesWindow.close();
+  private closeOpenWindows(): void {
+    if (!this.issuesWindowHidden) {
+      this.issuesWindowHidden = true;
     }
-    if (this.revisionsWindow.isOpen) {
-      this.revisionsWindow.close();
+    if (!this.revisionsWindowHidden) {
+      this.getRevisionsWindow()?.close();
+      this.revisionsWindowHidden = true;
     }
     if (this.simulatorActive) {
       const simulator = document.querySelector('temba-simulator') as any;
@@ -3524,12 +3522,90 @@ export class Editor extends RapidElement {
   }
 
   private closeFloatingWindows(): void {
-    if (this.issuesWindow.isOpen) {
-      this.issuesWindow.close();
+    if (!this.issuesWindowHidden) {
+      this.issuesWindowHidden = true;
     }
-    if (this.revisionsWindow.isOpen) {
-      this.revisionsWindow.close();
+    if (!this.revisionsWindowHidden) {
+      this.getRevisionsWindow()?.close();
+      this.revisionsWindowHidden = true;
     }
+  }
+
+  private getRevisionsWindow(): RevisionsWindow | null {
+    return this.querySelector(
+      'temba-revisions-window'
+    ) as RevisionsWindow | null;
+  }
+
+  // --- Issues window event handlers ---
+
+  private handleIssuesTabClick(): void {
+    if (!this.issuesWindowHidden) {
+      this.issuesWindowHidden = true;
+      return;
+    }
+    this.closeOpenWindows();
+    this.issuesWindowHidden = false;
+  }
+
+  private handleIssueSelected(e: CustomEvent): void {
+    const { issue } = e.detail;
+    this.issuesWindowHidden = true;
+
+    this.focusNode(issue.node_uuid);
+
+    const node = this.definition.nodes.find(
+      (n) => n.uuid === issue.node_uuid
+    );
+    if (!node) return;
+
+    if (issue.action_uuid) {
+      const action = node.actions?.find((a) => a.uuid === issue.action_uuid);
+      if (action) {
+        this.editingAction = action;
+        this.editingNode = node;
+        this.editingNodeUI = this.definition._ui.nodes[issue.node_uuid];
+      }
+    } else {
+      this.editingNode = node;
+      this.editingNodeUI = this.definition._ui.nodes[issue.node_uuid];
+    }
+  }
+
+  // --- Revisions window event handlers ---
+
+  private handleRevisionViewed(): void {
+    this.viewingRevision = true;
+    this.closeFlowSearch();
+    this.plumber?.reset();
+  }
+
+  private handleRevisionCancelled(): void {
+    this.viewingRevision = false;
+    this.plumber?.reset();
+  }
+
+  private handleRevisionsClosed(): void {
+    this.viewingRevision = false;
+    this.revisionsWindowHidden = true;
+  }
+
+  private async handleRevisionReverted(e: CustomEvent): Promise<void> {
+    const { definition, languageCode } = e.detail;
+    this.viewingRevision = false;
+    this.revisionsWindowHidden = true;
+    this.plumber?.reset();
+
+    await this.saveChanges(definition);
+
+    getStore()
+      .getState()
+      .fetchRevision(`/flow/revisions/${this.flow}`)
+      .finally(() => {
+        if (languageCode) {
+          this.handleLanguageChange(languageCode);
+        }
+      });
   }
 
   private renderToolbarElement(): TemplateResult {
@@ -3541,7 +3617,7 @@ export class Editor extends RapidElement {
         ?zoom-fitted=${this.zoomManager.isZoomFitted}
         ?revisions-active=${!this.revisionsWindowHidden}
         ?is-saving=${this.isSaving}
-        ?search-disabled=${this.revisionsWindow.isViewingRevision}
+        ?search-disabled=${this.getRevisionsWindow()?.isViewingRevision ?? false}
         @temba-button-clicked=${this.handleToolbarAction}
       ></temba-editor-toolbar>
     `;
@@ -3566,10 +3642,12 @@ export class Editor extends RapidElement {
         this.zoomManager.zoomToFull();
         break;
       case 'revisions':
-        if (this.revisionsWindow.isOpen) {
-          this.revisionsWindow.close();
+        if (!this.revisionsWindowHidden) {
+          this.getRevisionsWindow()?.close();
+          this.revisionsWindowHidden = true;
         } else {
-          this.revisionsWindow.open();
+          this.closeOpenWindows();
+          this.revisionsWindowHidden = false;
         }
         break;
       case 'search':
@@ -3707,7 +3785,7 @@ export class Editor extends RapidElement {
   }
 
   public isReadOnly(): boolean {
-    return this.revisionsWindow.isViewingRevision || this.isTranslating;
+    return this.viewingRevision || this.isTranslating;
   }
 
   public render(): TemplateResult {
@@ -3727,8 +3805,22 @@ export class Editor extends RapidElement {
       this.definition.nodes.length > 0 &&
       this.definition.nodes.some((n) => !this.definition._ui?.nodes[n.uuid]);
 
-    return html`${style} ${this.issuesWindow.renderWindow()}
-      ${this.revisionsWindow.renderWindow()}
+    return html`${style}
+      <temba-issues-window
+        .issues=${this.flowIssues}
+        ?hidden=${this.issuesWindowHidden}
+        @temba-issue-selected=${this.handleIssueSelected}
+        @temba-issues-closed=${() => (this.issuesWindowHidden = true)}
+      ></temba-issues-window>
+      <temba-revisions-window
+        .flow=${this.flow}
+        ?hidden=${this.revisionsWindowHidden}
+        ?saving=${this.isSaving}
+        @temba-revision-viewed=${this.handleRevisionViewed}
+        @temba-revision-cancelled=${this.handleRevisionCancelled}
+        @temba-revision-reverted=${this.handleRevisionReverted}
+        @temba-revisions-closed=${this.handleRevisionsClosed}
+      ></temba-revisions-window>
       <div id="editor-container">
         ${this.renderToolbarElement()}
         <div id="editor">
@@ -3770,7 +3862,7 @@ export class Editor extends RapidElement {
                     : ''}
                 <div
                   id="grid"
-                  class="${this.revisionsWindow.isViewingRevision
+                  class="${this.viewingRevision
                     ? 'viewing-revision'
                     : ''}"
                   style="min-width:${100 / this.zoom}%;min-height:${100 /
@@ -3781,9 +3873,9 @@ export class Editor extends RapidElement {
                     id="canvas"
                     class="${getClasses({
                       'viewing-revision':
-                        this.revisionsWindow.isViewingRevision,
+                        this.viewingRevision,
                       'read-only-connections':
-                        this.revisionsWindow.isViewingRevision ||
+                        this.viewingRevision ||
                         this.isTranslating
                     })}"
                   >
@@ -3897,7 +3989,7 @@ export class Editor extends RapidElement {
         : ''}
 
       <temba-canvas-menu></temba-canvas-menu>
-      ${!this.revisionsWindow.isViewingRevision
+      ${!this.viewingRevision
         ? html`<temba-node-type-selector
             .flowType=${this.flowType}
             .features=${this.features}
@@ -3908,6 +4000,18 @@ export class Editor extends RapidElement {
         .includeCategories=${false}
         @temba-search-result-selected=${this.handleSearchResultSelected}
       ></temba-flow-search>
-      ${!this.showMessageTable ? html` ${this.issuesWindow.renderTab()} ` : ''} `;
+      ${!this.showMessageTable && this.flowIssues?.length
+        ? html`
+            <temba-floating-tab
+              id="issues-tab"
+              icon="alert_warning"
+              label="Flow Issues"
+              color="tomato"
+              order="2"
+              .active=${!this.issuesWindowHidden}
+              @temba-button-clicked=${() => this.handleIssuesTabClick()}
+            ></temba-floating-tab>
+          `
+        : ''} `;
   }
 }

--- a/src/flow/IssuesWindow.ts
+++ b/src/flow/IssuesWindow.ts
@@ -1,0 +1,112 @@
+import { html, TemplateResult } from 'lit-html';
+import { FlowIssue } from '../store/AppState';
+import { FloatingWindow } from '../layout/FloatingWindow';
+import { formatIssueMessage } from './utils';
+import type { Editor } from './Editor';
+
+export class IssuesWindow {
+  constructor(private editor: Editor) {}
+
+  // --- Public API ---
+
+  public open(): void {
+    this.editor.issuesWindowHidden = false;
+  }
+
+  public close(): void {
+    this.editor.issuesWindowHidden = true;
+  }
+
+  public get isOpen(): boolean {
+    return !this.editor.issuesWindowHidden;
+  }
+
+  public handleItemClick(issue: FlowIssue): void {
+    const issuesWindow = document.getElementById(
+      'issues-window'
+    ) as FloatingWindow;
+    issuesWindow?.handleClose();
+    this.editor.issuesWindowHidden = true;
+
+    this.editor.focusNode(issue.node_uuid);
+
+    const node = this.editor.definition.nodes.find(
+      (n) => n.uuid === issue.node_uuid
+    );
+    if (!node) return;
+
+    if (issue.action_uuid) {
+      const action = node.actions?.find((a) => a.uuid === issue.action_uuid);
+      if (action) {
+        this.editor.editingAction = action;
+        this.editor.editingNode = node;
+        this.editor.editingNodeUI =
+          this.editor.definition._ui.nodes[issue.node_uuid];
+      }
+    } else {
+      this.editor.editingNode = node;
+      this.editor.editingNodeUI =
+        this.editor.definition._ui.nodes[issue.node_uuid];
+    }
+  }
+
+  // --- Rendering ---
+
+  public renderTab(): TemplateResult | string {
+    if (!this.editor.flowIssues?.length) return '';
+    return html`
+      <temba-floating-tab
+        id="issues-tab"
+        icon="alert_warning"
+        label="Flow Issues"
+        color="tomato"
+        order="2"
+        .active=${!this.editor.issuesWindowHidden}
+        @temba-button-clicked=${() => this.handleTabClick()}
+      ></temba-floating-tab>
+    `;
+  }
+
+  public renderWindow(): TemplateResult | string {
+    if (!this.editor.flowIssues?.length) return '';
+    return html`
+      <temba-floating-window
+        id="issues-window"
+        name="issues"
+        header="Flow Issues"
+        icon="alert_warning"
+        .width=${360}
+        .maxHeight=${600}
+        .top=${120}
+        color="tomato"
+        .hidden=${this.editor.issuesWindowHidden}
+        @temba-dialog-hidden=${() => this.close()}
+      >
+        <div style="display:flex; flex-direction:column; gap:2px;">
+          ${this.editor.flowIssues.map(
+            (issue) => html`
+              <div
+                class="issue-list-item"
+                @click=${() => this.handleItemClick(issue)}
+              >
+                <temba-icon name="alert_warning" size="1.2"></temba-icon>
+                <span>${formatIssueMessage(issue)}</span>
+              </div>
+            `
+          )}
+        </div>
+      </temba-floating-window>
+    `;
+  }
+
+  // --- Private ---
+
+  private handleTabClick(): void {
+    if (!this.editor.issuesWindowHidden) {
+      this.close();
+      return;
+    }
+    this.editor.closeOpenWindows();
+    this.editor.issuesWindowHidden = false;
+  }
+}

--- a/src/flow/IssuesWindow.ts
+++ b/src/flow/IssuesWindow.ts
@@ -1,74 +1,45 @@
 import { html, TemplateResult } from 'lit-html';
+import { css } from 'lit';
+import { property } from 'lit/decorators.js';
+import { RapidElement } from '../RapidElement';
+import { CustomEventType } from '../interfaces';
 import { FlowIssue } from '../store/AppState';
-import { FloatingWindow } from '../layout/FloatingWindow';
 import { formatIssueMessage } from './utils';
-import type { Editor } from './Editor';
 
-export class IssuesWindow {
-  constructor(private editor: Editor) {}
-
-  // --- Public API ---
-
-  public open(): void {
-    this.editor.issuesWindowHidden = false;
-  }
-
-  public close(): void {
-    this.editor.issuesWindowHidden = true;
-  }
-
-  public get isOpen(): boolean {
-    return !this.editor.issuesWindowHidden;
-  }
-
-  public handleItemClick(issue: FlowIssue): void {
-    const issuesWindow = document.getElementById(
-      'issues-window'
-    ) as FloatingWindow;
-    issuesWindow?.handleClose();
-    this.editor.issuesWindowHidden = true;
-
-    this.editor.focusNode(issue.node_uuid);
-
-    const node = this.editor.definition.nodes.find(
-      (n) => n.uuid === issue.node_uuid
-    );
-    if (!node) return;
-
-    if (issue.action_uuid) {
-      const action = node.actions?.find((a) => a.uuid === issue.action_uuid);
-      if (action) {
-        this.editor.editingAction = action;
-        this.editor.editingNode = node;
-        this.editor.editingNodeUI =
-          this.editor.definition._ui.nodes[issue.node_uuid];
+export class IssuesWindow extends RapidElement {
+  static get styles() {
+    return css`
+      :host {
+        display: contents;
       }
-    } else {
-      this.editor.editingNode = node;
-      this.editor.editingNodeUI =
-        this.editor.definition._ui.nodes[issue.node_uuid];
-    }
-  }
 
-  // --- Rendering ---
+      .issue-list-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px;
+        border-radius: 4px;
+        cursor: pointer;
+      }
 
-  public renderTab(): TemplateResult | string {
-    if (!this.editor.flowIssues?.length) return '';
-    return html`
-      <temba-floating-tab
-        id="issues-tab"
-        icon="alert_warning"
-        label="Flow Issues"
-        color="tomato"
-        order="2"
-        .active=${!this.editor.issuesWindowHidden}
-        @temba-button-clicked=${() => this.handleTabClick()}
-      ></temba-floating-tab>
+      .issue-list-item:hover {
+        background: #fff1f0;
+      }
     `;
   }
 
-  public renderWindow(): TemplateResult | string {
-    if (!this.editor.flowIssues?.length) return '';
+  @property({ type: Array })
+  issues: FlowIssue[] = [];
+
+  @property({ type: Boolean })
+  hidden = true;
+
+  private handleItemClick(issue: FlowIssue): void {
+    this.fireCustomEvent(CustomEventType.IssueSelected, { issue });
+  }
+
+  public render(): TemplateResult | string {
+    if (!this.issues?.length) return '';
     return html`
       <temba-floating-window
         id="issues-window"
@@ -79,11 +50,12 @@ export class IssuesWindow {
         .maxHeight=${600}
         .top=${120}
         color="tomato"
-        .hidden=${this.editor.issuesWindowHidden}
-        @temba-dialog-hidden=${() => this.close()}
+        .hidden=${this.hidden}
+        @temba-dialog-hidden=${() =>
+          this.fireCustomEvent(CustomEventType.IssuesClosed)}
       >
         <div style="display:flex; flex-direction:column; gap:2px;">
-          ${this.editor.flowIssues.map(
+          ${this.issues.map(
             (issue) => html`
               <div
                 class="issue-list-item"
@@ -97,16 +69,5 @@ export class IssuesWindow {
         </div>
       </temba-floating-window>
     `;
-  }
-
-  // --- Private ---
-
-  private handleTabClick(): void {
-    if (!this.editor.issuesWindowHidden) {
-      this.close();
-      return;
-    }
-    this.editor.closeOpenWindows();
-    this.editor.issuesWindowHidden = false;
   }
 }

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -1,0 +1,270 @@
+import { html, TemplateResult } from 'lit-html';
+import { getStore } from '../store/Store';
+import { FlowDefinition } from '../store/flow-definition';
+import { FloatingWindow } from '../layout/FloatingWindow';
+import { fetchResults } from '../utils';
+import { FLOW_SPEC_VERSION } from '../store/AppState';
+import type { Editor } from './Editor';
+
+export interface Revision {
+  id: number;
+  user: {
+    id: number;
+    username: string;
+    first_name: string;
+    last_name: string;
+    name?: string;
+  };
+  created_on: string;
+  comment?: string;
+}
+
+export class RevisionsWindow {
+  private revisions: Revision[] = [];
+  private viewingRevision: Revision | null = null;
+  private isLoading = false;
+  private preRevertState: {
+    definition: FlowDefinition;
+    dirtyDate: Date | null;
+  } | null = null;
+  private browseLanguageCode: string | null = null;
+
+  constructor(private editor: Editor) {}
+
+  // --- Public API ---
+
+  public get isOpen(): boolean {
+    return !this.editor.revisionsWindowHidden;
+  }
+
+  public get isViewingRevision(): boolean {
+    return this.viewingRevision !== null;
+  }
+
+  public open(): void {
+    this.editor.closeOpenWindows();
+    this.fetchRevisions();
+    this.editor.revisionsWindowHidden = false;
+  }
+
+  public close(): void {
+    this.resetScroll();
+    this.editor.revisionsWindowHidden = true;
+    if (this.viewingRevision) {
+      this.cancelRevisionView();
+    }
+  }
+
+  // --- Rendering ---
+
+  public renderWindow(): TemplateResult | string {
+    return html`
+      <temba-floating-window
+        id="revisions-window"
+        name="revisions"
+        header="Revisions"
+        icon="revisions"
+        .width=${240}
+        .maxHeight=${400}
+        .top=${120}
+        color="rgb(142, 94, 167)"
+        .saving=${this.editor.isSaving}
+        .hidden=${this.editor.revisionsWindowHidden}
+        @temba-dialog-hidden=${() => this.close()}
+      >
+        <div class="localization-window-content">
+          <div
+            class="revisions-list"
+            style="display:flex; flex-direction:column; gap:8px; overflow-y:auto; padding-bottom:10px;"
+          >
+            ${this.isLoading && !this.revisions.length
+              ? html`<temba-loading></temba-loading>`
+              : this.revisions.map((rev) => {
+                  const isSelected = this.viewingRevision?.id === rev.id;
+                  return html`
+                    <div
+                      class="revision-item ${isSelected ? 'selected' : ''}"
+                      style="padding:8px; border-radius:4px; cursor:pointer; background:${isSelected
+                        ? '#f0f6ff' // Light blue bg for selected
+                        : '#f9fafb'}; border:1px solid ${isSelected
+                        ? '#a4cafe'
+                        : '#e5e7eb'}; transition: all 0.2s ease;"
+                      @click=${() => this.handleRevisionClick(rev)}
+                    >
+                      <div
+                        style="display:flex; justify-content:space-between; align-items:center;"
+                      >
+                        <div
+                          class="revision-header"
+                          style="margin-bottom: 2px;"
+                        >
+                          <div
+                            style="font-weight:600; font-size:13px; color:#111827;"
+                          >
+                            <temba-date
+                              value=${rev.created_on}
+                              display="duration"
+                            ></temba-date>
+                          </div>
+                          <div style="font-size:11px; color:#6b7280;">
+                            ${rev.user.name || rev.user.username}
+                          </div>
+                        </div>
+                        ${isSelected
+                          ? html`<button
+                              class="revert-button"
+                              @click=${() => this.handleRevertClick()}
+                            >
+                              Revert
+                            </button>`
+                          : html``}
+                      </div>
+
+                      ${rev.comment
+                        ? html`<div
+                            style="font-size:12px; color:#4b5563; margin-top:4px;"
+                          >
+                            ${rev.comment}
+                          </div>`
+                        : ''}
+                    </div>
+                  `;
+                })}
+          </div>
+        </div>
+      </temba-floating-window>
+    `;
+  }
+
+  // --- Private ---
+
+  private async fetchRevisions() {
+    this.isLoading = true;
+    this.editor.requestUpdate();
+    try {
+      const results = await fetchResults(
+        `/flow/revisions/${this.editor.flow}/?version=${FLOW_SPEC_VERSION}`
+      );
+      this.revisions = results.slice(1);
+    } catch (e) {
+      console.error('Error fetching revisions', e);
+    } finally {
+      this.isLoading = false;
+      this.editor.requestUpdate();
+    }
+  }
+
+  private async handleRevisionClick(revision: Revision) {
+    if (this.viewingRevision?.id === revision.id) {
+      return;
+    }
+
+    if (!this.viewingRevision) {
+      this.preRevertState = {
+        definition: this.editor.definition,
+        dirtyDate: this.editor.dirtyDate
+      };
+      this.browseLanguageCode = this.editor.languageCode;
+    }
+
+    this.viewingRevision = revision;
+    this.editor.closeFlowSearch();
+    this.isLoading = true;
+    this.editor.plumber?.reset();
+    this.editor.requestUpdate();
+
+    try {
+      await getStore()
+        .getState()
+        .fetchRevision(
+          `/flow/revisions/${this.editor.flow}`,
+          revision.id.toString()
+        );
+      if (this.browseLanguageCode) {
+        this.editor.handleLanguageChange(this.browseLanguageCode);
+      }
+    } catch (e) {
+      console.error('Error fetching revision details', e);
+      this.cancelRevisionView();
+    } finally {
+      this.isLoading = false;
+      this.editor.requestUpdate();
+    }
+  }
+
+  private cancelRevisionView() {
+    this.editor.plumber?.reset();
+    const preservedLanguageCode =
+      this.browseLanguageCode || this.editor.languageCode;
+    if (this.preRevertState) {
+      const currentInfo = getStore().getState().flowInfo;
+      getStore().getState().setFlowContents({
+        definition: this.preRevertState.definition,
+        info: currentInfo
+      });
+      if (this.preRevertState.dirtyDate) {
+        getStore().getState().setDirtyDate(this.preRevertState.dirtyDate);
+      }
+      if (preservedLanguageCode) {
+        this.editor.handleLanguageChange(preservedLanguageCode);
+      }
+    } else {
+      getStore()
+        .getState()
+        .fetchRevision(`/flow/revisions/${this.editor.flow}`)
+        .finally(() => {
+          if (preservedLanguageCode) {
+            this.editor.handleLanguageChange(preservedLanguageCode);
+          }
+        });
+    }
+
+    this.viewingRevision = null;
+    this.preRevertState = null;
+    this.browseLanguageCode = null;
+    this.editor.requestUpdate();
+  }
+
+  private async handleRevertClick() {
+    if (!this.viewingRevision || !this.preRevertState) return;
+    this.editor.plumber?.reset();
+    const preservedLanguageCode =
+      this.browseLanguageCode || this.editor.languageCode;
+
+    const definitionToSave = {
+      ...this.editor.definition,
+      revision: this.preRevertState.definition.revision
+    };
+
+    await this.editor.saveChanges(definitionToSave);
+    this.viewingRevision = null;
+    this.preRevertState = null;
+    this.editor.revisionsWindowHidden = true;
+
+    const revisionsWindow = document.getElementById(
+      'revisions-window'
+    ) as FloatingWindow;
+    revisionsWindow.handleClose();
+
+    this.fetchRevisions();
+
+    getStore()
+      .getState()
+      .fetchRevision(`/flow/revisions/${this.editor.flow}`)
+      .finally(() => {
+        if (preservedLanguageCode) {
+          this.editor.handleLanguageChange(preservedLanguageCode);
+        }
+      });
+    this.browseLanguageCode = null;
+  }
+
+  private resetScroll() {
+    const list = this.editor
+      .querySelector('#revisions-window')
+      ?.shadowRoot?.querySelector('.body');
+    if (list) {
+      list.scrollTop = 0;
+    }
+  }
+}

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -1,10 +1,12 @@
 import { html, TemplateResult } from 'lit-html';
+import { css, PropertyValues } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import { RapidElement } from '../RapidElement';
+import { CustomEventType } from '../interfaces';
 import { getStore } from '../store/Store';
 import { FlowDefinition } from '../store/flow-definition';
-import { FloatingWindow } from '../layout/FloatingWindow';
 import { fetchResults } from '../utils';
 import { FLOW_SPEC_VERSION } from '../store/AppState';
-import type { Editor } from './Editor';
 
 export interface Revision {
   id: number;
@@ -19,45 +21,63 @@ export interface Revision {
   comment?: string;
 }
 
-export class RevisionsWindow {
+export class RevisionsWindow extends RapidElement {
+  static get styles() {
+    return css`
+      :host {
+        display: contents;
+      }
+    `;
+  }
+
+  @property({ type: String })
+  flow = '';
+
+  @property({ type: Boolean })
+  hidden = true;
+
+  @property({ type: Boolean })
+  saving = false;
+
+  @state()
   private revisions: Revision[] = [];
+
+  @state()
   private viewingRevision: Revision | null = null;
+
+  @state()
   private isLoading = false;
+
   private preRevertState: {
     definition: FlowDefinition;
     dirtyDate: Date | null;
   } | null = null;
   private browseLanguageCode: string | null = null;
 
-  constructor(private editor: Editor) {}
-
-  // --- Public API ---
-
-  public get isOpen(): boolean {
-    return !this.editor.revisionsWindowHidden;
-  }
-
   public get isViewingRevision(): boolean {
     return this.viewingRevision !== null;
   }
 
-  public open(): void {
-    this.editor.closeOpenWindows();
-    this.fetchRevisions();
-    this.editor.revisionsWindowHidden = false;
+  protected updated(changes: PropertyValues): void {
+    super.updated(changes);
+    if (
+      changes.has('hidden') &&
+      !this.hidden &&
+      changes.get('hidden') === true
+    ) {
+      this.fetchRevisions();
+    }
   }
 
   public close(): void {
     this.resetScroll();
-    this.editor.revisionsWindowHidden = true;
     if (this.viewingRevision) {
       this.cancelRevisionView();
     }
+    this.fireCustomEvent(CustomEventType.RevisionsClosed);
   }
 
-  // --- Rendering ---
-
-  public renderWindow(): TemplateResult | string {
+  public render(): TemplateResult {
     return html`
       <temba-floating-window
         id="revisions-window"
@@ -68,8 +88,8 @@ export class RevisionsWindow {
         .maxHeight=${400}
         .top=${120}
         color="rgb(142, 94, 167)"
-        .saving=${this.editor.isSaving}
-        .hidden=${this.editor.revisionsWindowHidden}
+        .saving=${this.saving}
+        .hidden=${this.hidden}
         @temba-dialog-hidden=${() => this.close()}
       >
         <div class="localization-window-content">
@@ -85,7 +105,7 @@ export class RevisionsWindow {
                     <div
                       class="revision-item ${isSelected ? 'selected' : ''}"
                       style="padding:8px; border-radius:4px; cursor:pointer; background:${isSelected
-                        ? '#f0f6ff' // Light blue bg for selected
+                        ? '#f0f6ff'
                         : '#f9fafb'}; border:1px solid ${isSelected
                         ? '#a4cafe'
                         : '#e5e7eb'}; transition: all 0.2s ease;"
@@ -113,7 +133,10 @@ export class RevisionsWindow {
                         ${isSelected
                           ? html`<button
                               class="revert-button"
-                              @click=${() => this.handleRevertClick()}
+                              @click=${(e: Event) => {
+                                e.stopPropagation();
+                                this.handleRevertClick();
+                              }}
                             >
                               Revert
                             </button>`
@@ -140,17 +163,15 @@ export class RevisionsWindow {
 
   private async fetchRevisions() {
     this.isLoading = true;
-    this.editor.requestUpdate();
     try {
       const results = await fetchResults(
-        `/flow/revisions/${this.editor.flow}/?version=${FLOW_SPEC_VERSION}`
+        `/flow/revisions/${this.flow}/?version=${FLOW_SPEC_VERSION}`
       );
       this.revisions = results.slice(1);
     } catch (e) {
       console.error('Error fetching revisions', e);
     } finally {
       this.isLoading = false;
-      this.editor.requestUpdate();
     }
   }
 
@@ -159,110 +180,93 @@ export class RevisionsWindow {
       return;
     }
 
+    const store = getStore().getState();
+
     if (!this.viewingRevision) {
       this.preRevertState = {
-        definition: this.editor.definition,
-        dirtyDate: this.editor.dirtyDate
+        definition: store.flowDefinition,
+        dirtyDate: store.dirtyDate
       };
-      this.browseLanguageCode = this.editor.languageCode;
+      this.browseLanguageCode = store.languageCode;
     }
 
     this.viewingRevision = revision;
-    this.editor.closeFlowSearch();
     this.isLoading = true;
-    this.editor.plumber?.reset();
-    this.editor.requestUpdate();
+
+    this.fireCustomEvent(CustomEventType.RevisionViewed, { revision });
 
     try {
-      await getStore()
-        .getState()
-        .fetchRevision(
-          `/flow/revisions/${this.editor.flow}`,
-          revision.id.toString()
-        );
+      await store.fetchRevision(
+        `/flow/revisions/${this.flow}`,
+        revision.id.toString()
+      );
       if (this.browseLanguageCode) {
-        this.editor.handleLanguageChange(this.browseLanguageCode);
+        store.setLanguageCode(this.browseLanguageCode);
       }
     } catch (e) {
       console.error('Error fetching revision details', e);
       this.cancelRevisionView();
     } finally {
       this.isLoading = false;
-      this.editor.requestUpdate();
     }
   }
 
   private cancelRevisionView() {
-    this.editor.plumber?.reset();
+    const store = getStore().getState();
     const preservedLanguageCode =
-      this.browseLanguageCode || this.editor.languageCode;
+      this.browseLanguageCode || store.languageCode;
+
     if (this.preRevertState) {
-      const currentInfo = getStore().getState().flowInfo;
-      getStore().getState().setFlowContents({
+      const currentInfo = store.flowInfo;
+      store.setFlowContents({
         definition: this.preRevertState.definition,
         info: currentInfo
       });
       if (this.preRevertState.dirtyDate) {
-        getStore().getState().setDirtyDate(this.preRevertState.dirtyDate);
+        store.setDirtyDate(this.preRevertState.dirtyDate);
       }
       if (preservedLanguageCode) {
-        this.editor.handleLanguageChange(preservedLanguageCode);
+        store.setLanguageCode(preservedLanguageCode);
       }
     } else {
-      getStore()
-        .getState()
-        .fetchRevision(`/flow/revisions/${this.editor.flow}`)
-        .finally(() => {
-          if (preservedLanguageCode) {
-            this.editor.handleLanguageChange(preservedLanguageCode);
-          }
-        });
+      store.fetchRevision(`/flow/revisions/${this.flow}`).finally(() => {
+        if (preservedLanguageCode) {
+          store.setLanguageCode(preservedLanguageCode);
+        }
+      });
     }
 
     this.viewingRevision = null;
     this.preRevertState = null;
     this.browseLanguageCode = null;
-    this.editor.requestUpdate();
+    this.fireCustomEvent(CustomEventType.RevisionCancelled);
   }
 
   private async handleRevertClick() {
     if (!this.viewingRevision || !this.preRevertState) return;
-    this.editor.plumber?.reset();
+
+    const store = getStore().getState();
     const preservedLanguageCode =
-      this.browseLanguageCode || this.editor.languageCode;
+      this.browseLanguageCode || store.languageCode;
 
     const definitionToSave = {
-      ...this.editor.definition,
+      ...store.flowDefinition,
       revision: this.preRevertState.definition.revision
     };
 
-    await this.editor.saveChanges(definitionToSave);
     this.viewingRevision = null;
     this.preRevertState = null;
-    this.editor.revisionsWindowHidden = true;
-
-    const revisionsWindow = document.getElementById(
-      'revisions-window'
-    ) as FloatingWindow;
-    revisionsWindow.handleClose();
-
-    this.fetchRevisions();
-
-    getStore()
-      .getState()
-      .fetchRevision(`/flow/revisions/${this.editor.flow}`)
-      .finally(() => {
-        if (preservedLanguageCode) {
-          this.editor.handleLanguageChange(preservedLanguageCode);
-        }
-      });
     this.browseLanguageCode = null;
+
+    this.fireCustomEvent(CustomEventType.RevisionReverted, {
+      definition: definitionToSave,
+      languageCode: preservedLanguageCode
+    });
   }
 
   private resetScroll() {
-    const list = this.editor
-      .querySelector('#revisions-window')
-      ?.shadowRoot?.querySelector('.body');
+    const win = this.shadowRoot?.querySelector('temba-floating-window');
+    const list = win?.shadowRoot?.querySelector('.body');
     if (list) {
       list.scrollTop = 0;
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -315,5 +315,12 @@ export enum CustomEventType {
   FlowClicked = 'temba-flow-clicked',
   GroupClicked = 'temba-group-clicked',
   ShowIssue = 'temba-show-issue',
-  SizeChanged = 'temba-size-changed'
+  SizeChanged = 'temba-size-changed',
+  IssueSelected = 'temba-issue-selected',
+  IssuesClosed = 'temba-issues-closed',
+  IssuesTabClicked = 'temba-issues-tab-clicked',
+  RevisionViewed = 'temba-revision-viewed',
+  RevisionCancelled = 'temba-revision-cancelled',
+  RevisionReverted = 'temba-revision-reverted',
+  RevisionsClosed = 'temba-revisions-closed'
 }

--- a/temba-modules.ts
+++ b/temba-modules.ts
@@ -83,6 +83,8 @@ import { Accordion } from './src/layout/Accordion';
 import { AccordionSection } from './src/layout/AccordionSection';
 import { Simulator } from './src/simulator/Simulator';
 import { FlowSearch } from './src/flow/FlowSearch';
+import { IssuesWindow } from './src/flow/IssuesWindow';
+import { RevisionsWindow } from './src/flow/RevisionsWindow';
 import { MessageTable } from './src/flow/MessageTable';
 
 export function addCustomElement(name: string, comp: any) {
@@ -178,3 +180,5 @@ addCustomElement('temba-floating-tab', FloatingTab);
 addCustomElement('temba-floating-window', FloatingWindow);
 addCustomElement('temba-simulator', Simulator);
 addCustomElement('temba-flow-search', FlowSearch);
+addCustomElement('temba-issues-window', IssuesWindow);
+addCustomElement('temba-revisions-window', RevisionsWindow);

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -1,11 +1,20 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import { Editor } from '../src/flow/Editor';
+import { IssuesWindow } from '../src/flow/IssuesWindow';
+import { RevisionsWindow } from '../src/flow/RevisionsWindow';
 import { stub, restore, SinonStub } from 'sinon';
 
 customElements.define('temba-flow-editor-revisions', Editor);
+if (!customElements.get('temba-issues-window')) {
+  customElements.define('temba-issues-window', IssuesWindow);
+}
+if (!customElements.get('temba-revisions-window')) {
+  customElements.define('temba-revisions-window', RevisionsWindow);
+}
 
 describe('Editor Revisions', () => {
   let element: Editor;
+  let revisionsWindow: RevisionsWindow;
   let fetchStub: SinonStub;
 
   beforeEach(async () => {
@@ -16,6 +25,9 @@ describe('Editor Revisions', () => {
       html`<temba-flow-editor-revisions></temba-flow-editor-revisions>`
     );
     element.flow = 'test-flow';
+    revisionsWindow = element.querySelector(
+      'temba-revisions-window'
+    ) as RevisionsWindow;
   });
 
   afterEach(() => {
@@ -52,10 +64,9 @@ describe('Editor Revisions', () => {
 
     fetchStub.resolves(mockResponse);
 
-    // Call fetchRevisions via the revisionsWindow manager
-    await (element.revisionsWindow as any).fetchRevisions();
+    await (revisionsWindow as any).fetchRevisions();
 
-    const revisions = (element.revisionsWindow as any).revisions;
+    const revisions = (revisionsWindow as any).revisions;
     expect(revisions.length).to.equal(2);
     expect(revisions[0].id).to.equal(2);
     expect(revisions[1].id).to.equal(1);
@@ -67,8 +78,8 @@ describe('Editor Revisions', () => {
     });
     fetchStub.resolves(mockResponse);
 
-    await (element.revisionsWindow as any).fetchRevisions();
-    const revisions = (element.revisionsWindow as any).revisions;
+    await (revisionsWindow as any).fetchRevisions();
+    const revisions = (revisionsWindow as any).revisions;
     expect(revisions.length).to.equal(0);
   });
 
@@ -86,15 +97,15 @@ describe('Editor Revisions', () => {
     );
     fetchStub.resolves(mockResponse);
 
-    await (element.revisionsWindow as any).fetchRevisions();
-    const revisions = (element.revisionsWindow as any).revisions;
+    await (revisionsWindow as any).fetchRevisions();
+    const revisions = (revisionsWindow as any).revisions;
     expect(revisions.length).to.equal(0);
   });
 
   it('should have purple color for revisions window and blue for selected item', async () => {
     // Force revisions window to show
     (element as any).revisionsWindowHidden = false;
-    (element as any).localizationWindowHidden = true;
+    await element.requestUpdate();
 
     // Mock revisions so we can see list items
     const mockRevisions = [
@@ -109,18 +120,21 @@ describe('Editor Revisions', () => {
         user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' }
       }
     ];
-    (element.revisionsWindow as any).revisions = mockRevisions;
-    (element.revisionsWindow as any).viewingRevision = mockRevisions[0]; // Select the first one
+    (revisionsWindow as any).revisions = mockRevisions;
+    (revisionsWindow as any).viewingRevision = mockRevisions[0]; // Select the first one
 
-    await element.requestUpdate();
+    await revisionsWindow.updateComplete;
 
-    // Check revisions window color
-    const revisionsWindow = element.querySelector('#revisions-window');
-    expect(revisionsWindow).to.exist;
-    expect(revisionsWindow.getAttribute('color')).to.equal('rgb(142, 94, 167)');
+    // Check revisions window color - now inside the component's shadow DOM
+    const floatingWindow =
+      revisionsWindow.shadowRoot?.querySelector('temba-floating-window');
+    expect(floatingWindow).to.exist;
+    expect(floatingWindow.getAttribute('color')).to.equal(
+      'rgb(142, 94, 167)'
+    );
 
-    // Check selected item styles
-    const selectedItem = element.querySelector(
+    // Check selected item styles - inside the component's shadow DOM
+    const selectedItem = revisionsWindow.shadowRoot?.querySelector(
       '.revision-item.selected'
     ) as HTMLElement;
     expect(selectedItem).to.exist;

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -52,11 +52,10 @@ describe('Editor Revisions', () => {
 
     fetchStub.resolves(mockResponse);
 
-    // Call fetchRevisions (private)
-    // Note: fetchRevisions calls fetchResults -> fetchResultsPage -> fetch
-    await (element as any).fetchRevisions();
+    // Call fetchRevisions via the revisionsWindow manager
+    await (element.revisionsWindow as any).fetchRevisions();
 
-    const revisions = (element as any).revisions;
+    const revisions = (element.revisionsWindow as any).revisions;
     expect(revisions.length).to.equal(2);
     expect(revisions[0].id).to.equal(2);
     expect(revisions[1].id).to.equal(1);
@@ -68,8 +67,8 @@ describe('Editor Revisions', () => {
     });
     fetchStub.resolves(mockResponse);
 
-    await (element as any).fetchRevisions();
-    const revisions = (element as any).revisions;
+    await (element.revisionsWindow as any).fetchRevisions();
+    const revisions = (element.revisionsWindow as any).revisions;
     expect(revisions.length).to.equal(0);
   });
 
@@ -87,8 +86,8 @@ describe('Editor Revisions', () => {
     );
     fetchStub.resolves(mockResponse);
 
-    await (element as any).fetchRevisions();
-    const revisions = (element as any).revisions;
+    await (element.revisionsWindow as any).fetchRevisions();
+    const revisions = (element.revisionsWindow as any).revisions;
     expect(revisions.length).to.equal(0);
   });
 
@@ -110,8 +109,8 @@ describe('Editor Revisions', () => {
         user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' }
       }
     ];
-    (element as any).revisions = mockRevisions;
-    (element as any).viewingRevision = mockRevisions[0]; // Select the first one
+    (element.revisionsWindow as any).revisions = mockRevisions;
+    (element.revisionsWindow as any).viewingRevision = mockRevisions[0]; // Select the first one
 
     await element.requestUpdate();
 

--- a/test/temba-flow-editor-zoom.test.ts
+++ b/test/temba-flow-editor-zoom.test.ts
@@ -1,9 +1,17 @@
 import { expect } from '@open-wc/testing';
 import { Editor } from '../src/flow/Editor';
+import { IssuesWindow } from '../src/flow/IssuesWindow';
+import { RevisionsWindow } from '../src/flow/RevisionsWindow';
 import { stub, restore, spy } from 'sinon';
 import { getCookie, setCookie } from '../src/utils';
 
 customElements.define('temba-flow-editor-zoom', Editor);
+if (!customElements.get('temba-issues-window')) {
+  customElements.define('temba-issues-window', IssuesWindow);
+}
+if (!customElements.get('temba-revisions-window')) {
+  customElements.define('temba-revisions-window', RevisionsWindow);
+}
 
 /** Create an Editor instance with a mock plumber, suitable for unit-testing
  *  zoom methods without needing a full flow definition. */

--- a/test/temba-flow-editor.test.ts
+++ b/test/temba-flow-editor.test.ts
@@ -1,6 +1,8 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import { Editor } from '../src/flow/Editor';
 import { EditorToolbar } from '../src/flow/EditorToolbar';
+import { IssuesWindow } from '../src/flow/IssuesWindow';
+import { RevisionsWindow } from '../src/flow/RevisionsWindow';
 import { Plumber } from '../src/flow/Plumber';
 import { stub, restore, useFakeTimers } from 'sinon';
 import { zustand } from '../src/store/AppState';
@@ -10,6 +12,12 @@ import { TEMBA_COMPONENTS_VERSION } from '../src/version';
 customElements.define('temba-flow-editor', Editor);
 if (!customElements.get('temba-editor-toolbar')) {
   customElements.define('temba-editor-toolbar', EditorToolbar);
+}
+if (!customElements.get('temba-issues-window')) {
+  customElements.define('temba-issues-window', IssuesWindow);
+}
+if (!customElements.get('temba-revisions-window')) {
+  customElements.define('temba-revisions-window', RevisionsWindow);
 }
 
 async function getToolbarButton(
@@ -933,7 +941,6 @@ describe('Editor', () => {
       `);
 
       (editor as any).canvasSize = { width: 800, height: 600 };
-      (editor as any).revisions = [];
       (editor as any).isSaving = false;
       await editor.updateComplete;
 
@@ -974,17 +981,20 @@ describe('Editor', () => {
       } as any;
 
       (editor as any).definition = definition;
-      (editor.revisionsWindow as any).preRevertState = {
+      const revisionsWindow = editor.querySelector(
+        'temba-revisions-window'
+      ) as any;
+      (revisionsWindow as any).preRevertState = {
         definition,
         dirtyDate: null
       };
-      (editor.revisionsWindow as any).viewingRevision = {
+      (revisionsWindow as any).viewingRevision = {
         id: 2,
         created_on: '2024-01-02',
         user: { id: 1, username: 'tester' }
       };
 
-      (editor.revisionsWindow as any).cancelRevisionView();
+      (revisionsWindow as any).cancelRevisionView();
 
       expect(zustand.getState().viewingRevision).to.be.false;
     });
@@ -997,10 +1007,6 @@ describe('Editor', () => {
       `);
 
       (editor as any).canvasSize = { width: 800, height: 600 };
-      (editor as any).revisions = [
-        { id: 1, created_on: '2024-01-01', user: { name: 'A' } },
-        { id: 2, created_on: '2024-01-02', user: { name: 'B' } }
-      ];
       (editor as any).isSaving = true;
       await editor.updateComplete;
 
@@ -1018,16 +1024,13 @@ describe('Editor', () => {
       `);
 
       (editor as any).canvasSize = { width: 800, height: 600 };
-      (editor as any).revisions = [
-        { id: 1, created_on: '2024-01-01', user: { name: 'A' } },
-        { id: 2, created_on: '2024-01-02', user: { name: 'B' } }
-      ];
       (editor as any).isSaving = true;
       await editor.updateComplete;
 
-      const revisionsWindow = editor.querySelector('#revisions-window') as any;
+      const revisionsWindow = editor.querySelector(
+        'temba-revisions-window'
+      ) as any;
       expect(revisionsWindow).to.exist;
-      expect(revisionsWindow.getAttribute('icon')).to.equal('revisions');
       expect(revisionsWindow.saving).to.be.true;
     });
 
@@ -1039,10 +1042,6 @@ describe('Editor', () => {
       `);
 
       (editor as any).canvasSize = { width: 800, height: 600 };
-      (editor as any).revisions = [
-        { id: 1, created_on: '2024-01-01', user: { name: 'A' } },
-        { id: 2, created_on: '2024-01-02', user: { name: 'B' } }
-      ];
       (editor as any).isSaving = false;
       await editor.updateComplete;
 

--- a/test/temba-flow-editor.test.ts
+++ b/test/temba-flow-editor.test.ts
@@ -12,11 +12,16 @@ if (!customElements.get('temba-editor-toolbar')) {
   customElements.define('temba-editor-toolbar', EditorToolbar);
 }
 
-async function getToolbarButton(editor: Editor, ariaLabel: string): Promise<HTMLElement | null> {
+async function getToolbarButton(
+  editor: Editor,
+  ariaLabel: string
+): Promise<HTMLElement | null> {
   const toolbar = editor.querySelector('temba-editor-toolbar');
   if (!toolbar) return null;
   await (toolbar as any).updateComplete;
-  return toolbar.shadowRoot?.querySelector(`.toolbar-btn[aria-label="${ariaLabel}"]`) as HTMLElement | null;
+  return toolbar.shadowRoot?.querySelector(
+    `.toolbar-btn[aria-label="${ariaLabel}"]`
+  ) as HTMLElement | null;
 }
 
 describe('Editor', () => {
@@ -969,17 +974,17 @@ describe('Editor', () => {
       } as any;
 
       (editor as any).definition = definition;
-      (editor as any).preRevertState = {
+      (editor.revisionsWindow as any).preRevertState = {
         definition,
         dirtyDate: null
       };
-      (editor as any).viewingRevision = {
+      (editor.revisionsWindow as any).viewingRevision = {
         id: 2,
         created_on: '2024-01-02',
         user: { id: 1, username: 'tester' }
       };
 
-      (editor as any).handleCancelRevisionView();
+      (editor.revisionsWindow as any).cancelRevisionView();
 
       expect(zustand.getState().viewingRevision).to.be.false;
     });

--- a/test/temba-flow-self-routing.test.ts
+++ b/test/temba-flow-self-routing.test.ts
@@ -1,10 +1,18 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import { stub, restore, useFakeTimers, SinonFakeTimers } from 'sinon';
 import { Editor } from '../src/flow/Editor';
+import { IssuesWindow } from '../src/flow/IssuesWindow';
+import { RevisionsWindow } from '../src/flow/RevisionsWindow';
 import { FlowDefinition } from '../src/store/flow-definition';
 
 // Register the component
 customElements.define('temba-flow-editor-test', Editor);
+if (!customElements.get('temba-issues-window')) {
+  customElements.define('temba-issues-window', IssuesWindow);
+}
+if (!customElements.get('temba-revisions-window')) {
+  customElements.define('temba-revisions-window', RevisionsWindow);
+}
 
 describe('Flow Editor Self-Routing Prevention', () => {
   let editor: Editor;


### PR DESCRIPTION
## Summary
- Extracts issues and revisions floating windows from Editor.ts into dedicated `IssuesWindow` and `RevisionsWindow` Lit components (`temba-issues-window`, `temba-revisions-window`)
- Components own their own reactive state and rendering; Editor communicates via properties and custom events
- Editor.ts properties that were made public solely for manager access are reverted to private

## Test plan
- [x] All tests pass (1639 passed; 1 pre-existing unrelated slider failure on main)
- [x] TypeScript compiles cleanly
- [ ] Manually verify issues tab and revisions window open/close correctly
- [ ] Verify revision preview and revert functionality works end-to-end