### PR TITLE
Restore toolbar language selector and localization helpers

### DIFF
--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -22,12 +22,15 @@ import {
 } from '../utils';
 import { TEMBA_COMPONENTS_VERSION } from '../version';
 import {
+  getLanguageDisplayName,
   getNodeBounds,
   calculateReflowPositions,
   NodeBounds,
   snapToGrid
 } from './utils';
 import { ACTION_CONFIG, NODE_CONFIG } from './config';
+import { getTranslatableCategoriesForNode } from './categoryLocalization';
+import { PRIMARY_LANGUAGE_OPTION_VALUE } from './EditorToolbar';
 import { calculateLayeredLayout, placeStickyNotes } from './reflow';
 import type { RevisionsWindow } from './RevisionsWindow';
 
@@ -77,6 +80,22 @@ export interface SelectionBox {
   endY: number;
 }
 
+type TranslationType = 'property' | 'category';
+
+interface TranslationEntry {
+  uuid: string;
+  type: TranslationType;
+  attribute: string;
+  from: string;
+  to: string | null;
+}
+
+interface TranslationBundle {
+  nodeUuid: string;
+  actionUuid?: string;
+  translations: TranslationEntry[];
+}
+
 export type ToolbarAction =
   | { action: 'view-change'; view: 'flow' | 'table' }
   | { action: 'zoom-in' }
@@ -84,7 +103,8 @@ export type ToolbarAction =
   | { action: 'zoom-to-fit' }
   | { action: 'zoom-to-full' }
   | { action: 'revisions' }
-  | { action: 'search' };
+  | { action: 'search' }
+  | { action: 'language-change'; isPrimary?: boolean; languageCode?: string };
 const EMPTY_FLOW_ISSUES: FlowIssue[] = [];
 
 // How long the pending-changes auto-save countdown runs (in ms).
@@ -1736,6 +1756,287 @@ export class Editor extends RapidElement {
     zustand.getState().setLanguageCode(languageCode);
   }
 
+  private getAvailableLanguages(): Array<{ code: string; name: string }> {
+    // Use languages from workspace if available
+    if (this.workspace?.languages && this.workspace.languages.length > 0) {
+      return this.workspace.languages
+        .map((code) => ({ code, name: getLanguageDisplayName(code) }))
+        .filter((lang) => lang.code && lang.name);
+    }
+
+    // Fall back to flow definition languages if available
+    if (
+      this.definition?._ui?.languages &&
+      this.definition._ui.languages.length > 0
+    ) {
+      return this.definition._ui.languages.map((lang: any) => ({
+        code: typeof lang === 'string' ? lang : lang.iso || lang.code,
+        name: typeof lang === 'string' ? lang : lang.name
+      }));
+    }
+
+    // No languages available
+    return [];
+  }
+
+  private getLocalizationLanguages(): Array<{ code: string; name: string }> {
+    if (!this.definition) {
+      return [];
+    }
+
+    const baseLanguage = this.definition.language;
+    return this.getAvailableLanguages().filter(
+      (lang) => lang.code !== baseLanguage
+    );
+  }
+
+  private getLocalizationProgress(languageCode: string): {
+    total: number;
+    localized: number;
+  } {
+    if (
+      !this.definition ||
+      !languageCode ||
+      languageCode === this.definition.language
+    ) {
+      return { total: 0, localized: 0 };
+    }
+
+    const bundles = this.buildTranslationBundles(languageCode);
+    return this.getTranslationCounts(bundles);
+  }
+
+  private getLanguageLocalization(languageCode: string): Record<string, any> {
+    if (!this.definition?.localization) {
+      return {};
+    }
+    return this.definition.localization[languageCode] || {};
+  }
+
+  private buildTranslationBundles(
+    languageCode: string = this.languageCode
+  ): TranslationBundle[] {
+    if (
+      !this.definition ||
+      !languageCode ||
+      languageCode === this.definition.language
+    ) {
+      return [];
+    }
+
+    const languageLocalization = this.getLanguageLocalization(languageCode);
+    const bundles: TranslationBundle[] = [];
+
+    this.definition.nodes.forEach((node) => {
+      node.actions?.forEach((action) => {
+        const config = ACTION_CONFIG[action.type];
+        if (!config?.localizable || config.localizable.length === 0) {
+          return;
+        }
+
+        // For send_msg actions, only count 'text' for progress tracking
+        // (quick_replies and attachments are still localizable but don't count toward progress)
+        const localizableKeys =
+          action.type === 'send_msg'
+            ? config.localizable.filter((key) => key === 'text')
+            : config.localizable;
+
+        const translations = this.findTranslations(
+          'property',
+          action.uuid,
+          localizableKeys,
+          action,
+          languageLocalization
+        );
+
+        if (translations.length > 0) {
+          bundles.push({
+            nodeUuid: node.uuid,
+            actionUuid: action.uuid,
+            translations
+          });
+        }
+      });
+
+      const nodeUI = this.definition._ui?.nodes?.[node.uuid];
+      const nodeType = nodeUI?.type;
+      if (!nodeType) {
+        return;
+      }
+
+      // Include rule (case argument) translations when localizeRules is set
+      if (nodeUI?.config?.localizeRules && node.router?.cases?.length) {
+        const ruleTranslations = node.router.cases
+          .filter((c) => c.arguments?.length > 0 && c.arguments.some((a) => a))
+          .flatMap((c) =>
+            this.findTranslations(
+              'property',
+              c.uuid,
+              ['arguments'],
+              c,
+              languageLocalization
+            )
+          );
+
+        if (ruleTranslations.length > 0) {
+          bundles.push({
+            nodeUuid: node.uuid,
+            translations: ruleTranslations
+          });
+        }
+      }
+
+      const nodeConfig = NODE_CONFIG[nodeType];
+      if (
+        nodeUI?.config?.localizeCategories &&
+        nodeConfig?.localizable === 'categories' &&
+        node.router?.categories?.length
+      ) {
+        const translatableCategories = getTranslatableCategoriesForNode(
+          nodeType,
+          node.router.categories
+        );
+        const categoryTranslations = translatableCategories.flatMap(
+          (category) =>
+            this.findTranslations(
+              'category',
+              category.uuid,
+              ['name'],
+              category,
+              languageLocalization
+            )
+        );
+
+        if (categoryTranslations.length > 0) {
+          bundles.push({
+            nodeUuid: node.uuid,
+            translations: categoryTranslations
+          });
+        }
+      }
+    });
+
+    return bundles;
+  }
+
+  private findTranslations(
+    type: TranslationType,
+    uuid: string,
+    localizeableKeys: string[],
+    source: any,
+    localization: Record<string, any>
+  ): TranslationEntry[] {
+    const translations: TranslationEntry[] = [];
+
+    localizeableKeys.forEach((attribute) => {
+      if (attribute === 'quick_replies') {
+        return;
+      }
+
+      const pathSegments = attribute.split('.');
+      let from: any = source;
+      let to: any = [];
+
+      while (pathSegments.length > 0 && from) {
+        if (from.uuid) {
+          to = localization[from.uuid];
+        }
+
+        const path = pathSegments.shift();
+        if (!path) {
+          break;
+        }
+
+        if (to) {
+          to = to[path];
+        }
+        from = from[path];
+      }
+
+      if (!from) {
+        return;
+      }
+
+      const fromValue = this.formatTranslationValue(from);
+      if (!fromValue) {
+        return;
+      }
+
+      const toValue = to ? this.formatTranslationValue(to) : null;
+
+      translations.push({
+        uuid,
+        type,
+        attribute,
+        from: fromValue,
+        to: toValue
+      });
+    });
+
+    return translations;
+  }
+
+  private formatTranslationValue(value: any): string | null {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (Array.isArray(value)) {
+      const normalized = value
+        .map((entry) => this.formatTranslationValue(entry))
+        .filter((entry) => !!entry) as string[];
+      return normalized.length > 0 ? normalized.join(', ') : null;
+    }
+
+    if (typeof value === 'object') {
+      if ('name' in value && value.name) {
+        return String(value.name);
+      }
+
+      if ('arguments' in value && Array.isArray(value.arguments)) {
+        return value.arguments.join(' ');
+      }
+
+      return null;
+    }
+
+    if (typeof value === 'number') {
+      return value.toString();
+    }
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    }
+
+    return null;
+  }
+
+  private getTranslationCounts(bundles: TranslationBundle[]): {
+    total: number;
+    localized: number;
+  } {
+    return bundles.reduce(
+      (counts, bundle) => {
+        bundle.translations.forEach((translation) => {
+          counts.total += 1;
+          if (translation.to && translation.to.trim().length > 0) {
+            counts.localized += 1;
+          }
+        });
+        return counts;
+      },
+      { total: 0, localized: 0 }
+    );
+  }
+
+  private hasAnyNodeWithLocalizeCategories(): boolean {
+    if (!this.definition?._ui?.nodes) return false;
+    return Object.values(this.definition._ui.nodes).some(
+      (nodeUI: any) => nodeUI?.config?.localizeCategories
+    );
+  }
+
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.zoomManager.teardownLoupe();
@@ -1892,7 +2193,7 @@ export class Editor extends RapidElement {
     search.definition = this.definition;
     search.languageCode = this.languageCode || '';
     search.scope = this.showMessageTable ? 'table' : 'flow';
-    search.includeCategories = false;
+    search.includeCategories = this.isTranslating && this.hasAnyNodeWithLocalizeCategories();
     search.show();
   }
 
@@ -3609,6 +3910,50 @@ export class Editor extends RapidElement {
   }
 
   private renderToolbarElement(): TemplateResult {
+    const languages = this.getLocalizationLanguages();
+    const availableLanguages = this.getAvailableLanguages();
+    const baseLanguage = this.definition?.language;
+    const baseLanguageName =
+      availableLanguages.find((lang) => lang.code === baseLanguage)?.name ||
+      baseLanguage ||
+      'Primary language';
+    const isBaseSelected =
+      !this.languageCode ||
+      this.languageCode === baseLanguage ||
+      !languages.some((lang) => lang.code === this.languageCode);
+    const activeLanguage = !isBaseSelected
+      ? languages.find((lang) => lang.code === this.languageCode)
+      : null;
+    const currentLanguage = activeLanguage || {
+      code: baseLanguage || '',
+      name: baseLanguageName
+    };
+    const progress = this.getLocalizationProgress(
+      isBaseSelected ? '' : this.languageCode
+    );
+    const percent = Math.round(
+      (progress.localized / Math.max(progress.total, 1)) * 100
+    );
+    const languageOptions = [
+      {
+        name: baseLanguageName,
+        value: PRIMARY_LANGUAGE_OPTION_VALUE
+      },
+      ...languages.map((lang) => {
+        const localizationProgress = this.getLocalizationProgress(lang.code);
+        const localizationPercent = Math.round(
+          (localizationProgress.localized /
+            Math.max(localizationProgress.total, 1)) *
+            100
+        );
+        return {
+          name: lang.name,
+          value: lang.code,
+          percent: localizationPercent
+        };
+      })
+    ];
+
     return html`
       <temba-editor-toolbar
         ?message-view=${this.showMessageTable}
@@ -3618,6 +3963,11 @@ export class Editor extends RapidElement {
         ?revisions-active=${!this.revisionsWindowHidden}
         ?is-saving=${this.isSaving}
         ?search-disabled=${this.getRevisionsWindow()?.isViewingRevision ?? false}
+        .languageOptions=${languageOptions}
+        current-language-name=${currentLanguage.name}
+        ?is-base-language=${isBaseSelected}
+        .languagePercent=${percent}
+        ?show-localization-tools=${Boolean(activeLanguage)}
         @temba-button-clicked=${this.handleToolbarAction}
       ></temba-editor-toolbar>
     `;
@@ -3652,6 +4002,13 @@ export class Editor extends RapidElement {
         break;
       case 'search':
         this.openFlowSearch();
+        break;
+      case 'language-change':
+        if (detail.isPrimary) {
+          this.handleLanguageChange(this.definition?.language || '');
+        } else if (detail.languageCode) {
+          this.handleLanguageChange(detail.languageCode);
+        }
         break;
     }
   }
@@ -3997,7 +4354,7 @@ export class Editor extends RapidElement {
         : ''}
       <temba-flow-search
         .scope=${this.showMessageTable ? 'table' : 'flow'}
-        .includeCategories=${false}
+        .includeCategories=${this.isTranslating && this.hasAnyNodeWithLocalizeCategories()}
         @temba-search-result-selected=${this.handleSearchResultSelected}
       ></temba-flow-search>
       ${!this.showMessageTable && this.flowIssues?.length

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -90,7 +90,9 @@ describe('Localization Editing', () => {
   ): Promise<void> => {
     const toolbar = await getToolbar(flowEditor);
     // Open language options dropdown
-    const languageBtn = toolbar.shadowRoot.querySelector('#language-btn') as HTMLElement;
+    const languageBtn = toolbar.shadowRoot.querySelector(
+      '#language-btn'
+    ) as HTMLElement;
     languageBtn.click();
     await toolbar.updateComplete;
 
@@ -186,7 +188,9 @@ describe('Localization Editing', () => {
   it('should show language options with non-base languages', async () => {
     const toolbar = await getToolbar(editor);
     // Open language dropdown
-    const languageBtn = toolbar.shadowRoot.querySelector('#language-btn') as HTMLElement;
+    const languageBtn = toolbar.shadowRoot.querySelector(
+      '#language-btn'
+    ) as HTMLElement;
     languageBtn.click();
     await toolbar.updateComplete;
 
@@ -268,9 +272,11 @@ describe('Localization Editing', () => {
   it.skip('should open auto translate dialog when clicking auto translate', async () => {
     await selectLanguageInToolbar(editor, 'French', 'fra');
 
-    const autoTranslateBtn = editor.querySelector('temba-editor-toolbar')?.shadowRoot?.querySelector(
-      '.toolbar-btn[aria-label="Auto translate"]'
-    ) as HTMLButtonElement;
+    const autoTranslateBtn = editor
+      .querySelector('temba-editor-toolbar')
+      ?.shadowRoot?.querySelector(
+        '.toolbar-btn[aria-label="Auto translate"]'
+      ) as HTMLButtonElement;
     expect(autoTranslateBtn).to.exist;
     expect(autoTranslateBtn.disabled).to.be.false;
 

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -1,0 +1,597 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { Editor } from '../src/flow/Editor';
+import { NodeEditor } from '../src/flow/NodeEditor';
+import { SendMsg, FlowDefinition } from '../src/store/flow-definition';
+import { zustand } from '../src/store/AppState';
+import { send_msg } from '../src/flow/actions/send_msg';
+import '../temba-modules';
+
+describe('Localization Editing', () => {
+  let editor: Editor;
+  let storeElement: HTMLElement;
+
+  const languageNames: Record<string, string> = {
+    eng: 'English',
+    fra: 'French',
+    spa: 'Spanish'
+  };
+
+  const setupWorkspace = () => {
+    zustand.setState({
+      workspace: {
+        uuid: 'test-workspace',
+        name: 'Test Workspace',
+        languages: ['eng', 'fra', 'spa'],
+        primary_language: 'eng',
+        timezone: 'UTC',
+        date_style: 'day_first',
+        country: 'US',
+        anon: false
+      }
+    });
+  };
+
+  const buildCategoryFlowDefinition = (
+    localization: Record<string, any> = {}
+  ): FlowDefinition => ({
+    uuid: 'category-flow',
+    name: 'Category Flow',
+    language: 'eng',
+    type: 'messaging',
+    revision: 1,
+    spec_version: '14.3',
+    localization,
+    nodes: [
+      {
+        uuid: 'split-node',
+        actions: [],
+        exits: [
+          { uuid: 'split-exit-1', destination_uuid: null },
+          { uuid: 'split-exit-2', destination_uuid: null }
+        ],
+        router: {
+          type: 'random',
+          categories: [
+            {
+              uuid: 'cat-1',
+              name: 'First bucket',
+              exit_uuid: 'split-exit-1'
+            },
+            {
+              uuid: 'cat-2',
+              name: 'Second bucket',
+              exit_uuid: 'split-exit-2'
+            }
+          ]
+        }
+      }
+    ],
+    _ui: {
+      nodes: {
+        'split-node': {
+          position: { left: 0, top: 0 },
+          type: 'split_by_random'
+        }
+      },
+      languages: []
+    }
+  });
+
+  const getToolbar = async (flowEditor: Editor) => {
+    const toolbar = flowEditor.querySelector('temba-editor-toolbar') as any;
+    if (toolbar) await toolbar.updateComplete;
+    return toolbar;
+  };
+
+  const selectLanguageInToolbar = async (
+    flowEditor: Editor,
+    languageName: string,
+    languageCode: string
+  ): Promise<void> => {
+    const toolbar = await getToolbar(flowEditor);
+    // Open language options dropdown
+    const languageBtn = toolbar.shadowRoot.querySelector('#language-btn') as HTMLElement;
+    languageBtn.click();
+    await toolbar.updateComplete;
+
+    // Select the language via the toolbar's handler
+    (toolbar as any).handleLanguageOptionSelected(
+      new CustomEvent('temba-selection', {
+        detail: { selected: { name: languageName, value: languageCode } }
+      })
+    );
+    await flowEditor.updateComplete;
+  };
+
+  before(() => {
+    storeElement = document.createElement('temba-store');
+    (storeElement as any).getLanguageName = (code: string) =>
+      languageNames[code];
+    document.body.appendChild(storeElement);
+  });
+
+  after(() => {
+    storeElement?.remove();
+  });
+
+  afterEach(() => {
+    editor?.remove();
+  });
+
+  beforeEach(async () => {
+    // Set workspace with languages
+    setupWorkspace();
+
+    // Create a flow definition with localization data
+    const flowDefinition: FlowDefinition = {
+      uuid: 'test-flow',
+      name: 'Test Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {
+        spa: {
+          'action-1': {
+            text: ['Hola mundo'],
+            quick_replies: ['Sí', 'No']
+          }
+        }
+      },
+      nodes: [
+        {
+          uuid: 'node-1',
+          actions: [
+            {
+              type: 'send_msg',
+              uuid: 'action-1',
+              text: 'Hello world',
+              quick_replies: ['Yes', 'No']
+            } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-1' }]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-1': {
+            position: { left: 100, top: 100 }
+          }
+        },
+        languages: []
+      }
+    };
+
+    // Initialize store with flow definition
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 1, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    await editor.updateComplete;
+  });
+
+  it('should render language controls in toolbar when translations exist', async () => {
+    const toolbar = await getToolbar(editor);
+    const languageBtn = toolbar.shadowRoot.querySelector('#language-btn');
+    expect(languageBtn).to.exist;
+  });
+
+  it('should show language options with non-base languages', async () => {
+    const toolbar = await getToolbar(editor);
+    // Open language dropdown
+    const languageBtn = toolbar.shadowRoot.querySelector('#language-btn') as HTMLElement;
+    languageBtn.click();
+    await toolbar.updateComplete;
+
+    // The options should contain non-base languages
+    const options = toolbar.shadowRoot.querySelector('temba-options');
+    expect(options).to.exist;
+  });
+
+  it('should include category translations when per-node localizeCategories is set', async () => {
+    editor?.remove();
+
+    setupWorkspace();
+
+    const categoryFlowDefinition: FlowDefinition =
+      buildCategoryFlowDefinition();
+    // Set localizeCategories on the node's UI config
+    categoryFlowDefinition._ui.nodes['split-node'].config = {
+      localizeCategories: true
+    };
+
+    zustand.getState().setFlowContents({
+      definition: categoryFlowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 1, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    await editor.updateComplete;
+
+    // Switch to a non-base language
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+
+    // Check that progress includes the 2 categories
+    const progress = (editor as any).getLocalizationProgress('fra');
+    expect(progress.total).to.equal(2);
+  });
+
+  it('should allow switching translation languages via toolbar', async () => {
+    await selectLanguageInToolbar(editor, 'Spanish', 'spa');
+
+    const state = zustand.getState();
+    expect(state.languageCode).to.equal('spa');
+  });
+
+  it('should exclude categories from progress when localizeCategories is not set', async () => {
+    editor?.remove();
+
+    setupWorkspace();
+
+    // Flow with categories but no localizeCategories config
+    const categoryFlowDefinition: FlowDefinition =
+      buildCategoryFlowDefinition();
+
+    zustand.getState().setFlowContents({
+      definition: categoryFlowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 1, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    await editor.updateComplete;
+
+    // Switch to a non-base language
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+
+    // Without localizeCategories, progress should not include categories
+    const progress = (editor as any).getLocalizationProgress('fra');
+    expect(progress.total).to.equal(0);
+  });
+
+  it.skip('should open auto translate dialog when clicking auto translate', async () => {
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+
+    const autoTranslateBtn = editor.querySelector('temba-editor-toolbar')?.shadowRoot?.querySelector(
+      '.toolbar-btn[aria-label="Auto translate"]'
+    ) as HTMLButtonElement;
+    expect(autoTranslateBtn).to.exist;
+    expect(autoTranslateBtn.disabled).to.be.false;
+
+    autoTranslateBtn.click();
+    await editor.updateComplete;
+
+    expect((editor as any).autoTranslateDialogOpen).to.be.true;
+    const dialog = editor.querySelector(
+      'temba-dialog[header="Auto translate"]'
+    );
+    const modelSelect = dialog?.querySelector(
+      '.auto-translate-model-select'
+    ) as HTMLElement;
+    expect(modelSelect).to.exist;
+    expect(modelSelect.getAttribute('endpoint')).to.equal(
+      '/api/internal/llms.json'
+    );
+  });
+
+  it('should preserve selected language across renders', async () => {
+    await selectLanguageInToolbar(editor, 'Spanish', 'spa');
+
+    expect(zustand.getState().languageCode).to.equal('spa');
+
+    // Trigger a re-render
+    await editor.requestUpdate();
+    await editor.updateComplete;
+
+    // Language should remain as Spanish
+    const state = zustand.getState();
+    expect(state.languageCode).to.equal('spa');
+  });
+
+  it('should load base language values when in English', () => {
+    const action: SendMsg = {
+      type: 'send_msg',
+      uuid: 'action-1',
+      text: 'Hello world',
+      quick_replies: ['Yes', 'No']
+    };
+
+    const formData = send_msg.toFormData(action);
+
+    expect(formData.text).to.equal('Hello world');
+    expect(formData.quick_replies).to.have.lengthOf(2);
+    expect(formData.quick_replies[0].value).to.equal('Yes');
+    expect(formData.quick_replies[1].value).to.equal('No');
+  });
+
+  it('should load localized values when in Spanish', () => {
+    const action: SendMsg = {
+      type: 'send_msg',
+      uuid: 'action-1',
+      text: 'Hello world',
+      quick_replies: ['Yes', 'No']
+    };
+
+    const localization = {
+      text: ['Hola mundo'],
+      quick_replies: ['Sí', 'No']
+    };
+
+    const formData = send_msg.toLocalizationFormData(action, localization);
+
+    expect(formData.text).to.equal('Hola mundo');
+    expect(formData.quick_replies).to.have.lengthOf(2);
+    expect(formData.quick_replies[0].value).to.equal('Sí');
+    expect(formData.quick_replies[1].value).to.equal('No');
+  });
+
+  it('should fall back to base language if no localization exists', () => {
+    const action: SendMsg = {
+      type: 'send_msg',
+      uuid: 'action-1',
+      text: 'Hello world',
+      quick_replies: ['Yes', 'No']
+    };
+
+    const localization = {}; // Empty localization
+
+    const formData = send_msg.toLocalizationFormData(action, localization);
+
+    // Should show base language values (but empty since localization is empty)
+    expect(formData.text).to.equal('');
+    expect(formData.quick_replies).to.be.undefined;
+  });
+
+  it('should convert form data to localization format', () => {
+    const action: SendMsg = {
+      type: 'send_msg',
+      uuid: 'action-1',
+      text: 'Hello world',
+      quick_replies: ['Yes', 'No']
+    };
+
+    const formData = {
+      uuid: 'action-1',
+      text: 'Bonjour le monde',
+      quick_replies: [
+        { name: 'Oui', value: 'Oui' },
+        { name: 'Non', value: 'Non' }
+      ]
+    };
+
+    const localization = send_msg.fromLocalizationFormData(formData, action);
+
+    expect(localization.text).to.deep.equal(['Bonjour le monde']);
+    expect(localization.quick_replies).to.deep.equal(['Oui', 'Non']);
+  });
+
+  it('should not include unchanged values in localization', () => {
+    const action: SendMsg = {
+      type: 'send_msg',
+      uuid: 'action-1',
+      text: 'Hello world',
+      quick_replies: ['Yes', 'No']
+    };
+
+    const formData = {
+      uuid: 'action-1',
+      text: 'Hello world', // Same as base
+      quick_replies: [
+        { name: 'Yes', value: 'Yes' },
+        { name: 'No', value: 'No' }
+      ] // Same as base
+    };
+
+    const localization = send_msg.fromLocalizationFormData(formData, action);
+
+    // should not include unchanged values
+    expect(localization.text).to.be.undefined;
+    expect(localization.quick_replies).to.be.undefined;
+  });
+
+  it('should include language name in dialog header when translating', async () => {
+    // Switch to Spanish
+    zustand.getState().setLanguageCode('spa');
+
+    const action: SendMsg = {
+      type: 'send_msg',
+      uuid: 'action-1',
+      text: 'Hello world',
+      quick_replies: []
+    };
+
+    const nodeEditor: NodeEditor = await fixture(html`
+      <temba-node-editor .action=${action} .isOpen=${true}> </temba-node-editor>
+    `);
+
+    await nodeEditor.updateComplete;
+
+    // Check dialog header
+    const dialog = nodeEditor.shadowRoot.querySelector('temba-dialog');
+    expect(dialog).to.exist;
+    expect(dialog.getAttribute('header')).to.equal('Spanish - Send Message');
+  });
+
+  it('should handle attachments in localization', () => {
+    const action: SendMsg = {
+      type: 'send_msg',
+      uuid: 'action-1',
+      text: 'Hello',
+      attachments: ['image/jpeg:http://example.com/image.jpg']
+    };
+
+    const localization = {
+      text: ['Hola'],
+      attachments: ['image/jpeg:http://example.com/imagen.jpg']
+    };
+
+    const formData = send_msg.toLocalizationFormData(action, localization);
+
+    expect(formData.text).to.equal('Hola');
+    expect(formData.attachments).to.have.lengthOf(1);
+    expect(formData.attachments[0]).to.equal(
+      'image/jpeg:http://example.com/imagen.jpg'
+    );
+  });
+
+  it('should handle runtime attachments in localization', () => {
+    const action: SendMsg = {
+      type: 'send_msg',
+      uuid: 'action-1',
+      text: 'Hello',
+      attachments: ['image:@fields.profile_pic']
+    };
+
+    const localization = {
+      text: ['Hola'],
+      attachments: ['image:@fields.foto_perfil']
+    };
+
+    const formData = send_msg.toLocalizationFormData(action, localization);
+
+    expect(formData.text).to.equal('Hola');
+    expect(formData.runtime_attachments).to.have.lengthOf(1);
+    expect(formData.runtime_attachments[0].expression).to.equal(
+      '@fields.foto_perfil'
+    );
+  });
+
+  it('should identify localizable fields', () => {
+    expect(send_msg.localizable).to.exist;
+    expect(send_msg.localizable).to.include('text');
+    expect(send_msg.localizable).to.include('quick_replies');
+    expect(send_msg.localizable).to.include('attachments');
+  });
+
+  it('should save empty localization when all values match base', () => {
+    const action: SendMsg = {
+      type: 'send_msg',
+      uuid: 'action-1',
+      text: 'Hello world',
+      quick_replies: []
+    };
+
+    const formData = {
+      uuid: 'action-1',
+      text: 'Hello world' // Same as base, so shouldn't be saved
+    };
+
+    const localization = send_msg.fromLocalizationFormData(formData, action);
+
+    // empty localization when nothing changed
+    expect(Object.keys(localization)).to.have.lengthOf(0);
+  });
+
+  it('should remove category localization when translation is cleared', async () => {
+    editor?.remove();
+    editor = null;
+
+    setupWorkspace();
+
+    const flowDefinition = buildCategoryFlowDefinition({
+      fra: {
+        'cat-1': { name: ['Premier choix'] },
+        'cat-2': { name: ['Deuxième choix'] }
+      }
+    });
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 1, languages: 2 },
+        locals: []
+      }
+    });
+    zustand.getState().setLanguageCode('fra');
+
+    const state = zustand.getState();
+    const node = state.flowDefinition.nodes[0];
+    const nodeUI = state.flowDefinition._ui.nodes[node.uuid];
+
+    const nodeEditor: NodeEditor = await fixture(html`
+      <temba-node-editor
+        .node=${node}
+        .nodeUI=${nodeUI}
+        .isOpen=${true}
+      ></temba-node-editor>
+    `);
+    await nodeEditor.updateComplete;
+
+    const formData = (nodeEditor as any).formData;
+    formData.categories['cat-1'].localizedName = '';
+
+    (nodeEditor as any).handleSave();
+
+    const localization =
+      zustand.getState().flowDefinition.localization?.fra || {};
+    expect(localization['cat-1']).to.be.undefined;
+    expect(localization['cat-2']).to.deep.equal({ name: ['Deuxième choix'] });
+
+    nodeEditor.remove();
+  });
+
+  it('should remove empty localization entries when all category translations are cleared', async () => {
+    editor?.remove();
+    editor = null;
+
+    setupWorkspace();
+
+    const flowDefinition = buildCategoryFlowDefinition({
+      fra: {
+        'cat-1': { name: ['Premier choix'] }
+      }
+    });
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 1, languages: 2 },
+        locals: []
+      }
+    });
+    zustand.getState().setLanguageCode('fra');
+
+    const state = zustand.getState();
+    const node = state.flowDefinition.nodes[0];
+    const nodeUI = state.flowDefinition._ui.nodes[node.uuid];
+
+    const nodeEditor: NodeEditor = await fixture(html`
+      <temba-node-editor
+        .node=${node}
+        .nodeUI=${nodeUI}
+        .isOpen=${true}
+      ></temba-node-editor>
+    `);
+    await nodeEditor.updateComplete;
+
+    const formData = (nodeEditor as any).formData;
+    formData.categories['cat-1'].localizedName = '';
+
+    (nodeEditor as any).handleSave();
+
+    const localization = zustand.getState().flowDefinition.localization;
+    expect(localization).to.be.undefined;
+
+    nodeEditor.remove();
+  });
+});


### PR DESCRIPTION
## Summary

PR #973 inadvertently removed the toolbar language selector along with the retired floating localization window. Only the floating window was meant to go — localization is still managed from the toolbar. This restores the language-selection pill and the helpers it relies on.

## Changes

- Re-introduce `getAvailableLanguages`, `getLocalizationLanguages`, `getLocalizationProgress`, `buildTranslationBundles`, `findTranslations`, `formatTranslationValue`, `getTranslationCounts`, and `hasAnyNodeWithLocalizeCategories` on `Editor`.
- Pass `languageOptions`, `currentLanguageName`, `isBaseLanguage`, `languagePercent`, and `showLocalizationTools` back into `<temba-editor-toolbar>` from `renderToolbarElement`.
- Handle the toolbar's `language-change` action (primary + specific language) in `handleToolbarAction`.
- Have flow search include categories when translating a flow that has `localizeCategories` nodes.
- Add `test/temba-localization.test.ts` covering the toolbar language pill, progress, language switching, and category translation flows.

## Test plan

- [x] `pnpm test:fast` (1672 passed / 7 skipped)
- [x] `pnpm test:fast --files test/temba-localization.test.ts` (18 passed / 1 skipped)