### PR TITLE
Show "Unknown" instead of "und" in remaining language displays

### DIFF
--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -1769,10 +1769,10 @@ export class Editor extends RapidElement {
       this.definition?._ui?.languages &&
       this.definition._ui.languages.length > 0
     ) {
-      return this.definition._ui.languages.map((lang: any) => ({
-        code: typeof lang === 'string' ? lang : lang.iso || lang.code,
-        name: typeof lang === 'string' ? lang : lang.name
-      }));
+      return this.definition._ui.languages.map((lang: any) => {
+        const code = typeof lang === 'string' ? lang : lang.iso || lang.code;
+        return { code, name: getLanguageDisplayName(code) };
+      });
     }
 
     // No languages available
@@ -3915,7 +3915,7 @@ export class Editor extends RapidElement {
     const baseLanguage = this.definition?.language;
     const baseLanguageName =
       availableLanguages.find((lang) => lang.code === baseLanguage)?.name ||
-      baseLanguage ||
+      (baseLanguage ? getLanguageDisplayName(baseLanguage) : '') ||
       'Primary language';
     const isBaseSelected =
       !this.languageCode ||

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -30,6 +30,7 @@ import { sourceLocale, targetLocales } from '../locales/locale-codes';
 import { getFullName } from '../display/TembaUser';
 import { AppState, zustand } from './AppState';
 import { StoreApi } from 'zustand/vanilla';
+import { getLanguageDisplayName } from '../flow/utils';
 
 const { setLocale } = configureLocalization({
   sourceLocale,
@@ -379,7 +380,11 @@ export class Store extends RapidElement {
   }
 
   public getLanguageName(iso: string) {
-    return this.languages[iso];
+    const name = this.languages[iso];
+    if (!name || name === 'und' || iso === 'und') {
+      return getLanguageDisplayName(iso);
+    }
+    return name;
   }
 
   public isDynamicGroup(uuid: string): boolean {

--- a/test/temba-flow-utils.test.ts
+++ b/test/temba-flow-utils.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@open-wc/testing';
 import { zustand } from '../src/store/AppState';
 import { shouldExcludeFlow } from '../src/flow/flow-utils';
+import { getLanguageDisplayName } from '../src/flow/utils';
 
 function setFlowType(type: string) {
   const state = zustand.getState();
@@ -44,5 +45,21 @@ describe('shouldExcludeFlow', () => {
   it('returns false when flow definition is null', () => {
     zustand.setState({ ...zustand.getState(), flowDefinition: null });
     expect(shouldExcludeFlow({ type: 'message' })).to.be.false;
+  });
+});
+
+describe('getLanguageDisplayName', () => {
+  it('returns "Unknown" for the "und" code', () => {
+    expect(getLanguageDisplayName('und')).to.equal('Unknown');
+  });
+
+  it('returns the display name for known codes', () => {
+    expect(getLanguageDisplayName('eng')).to.equal('English');
+  });
+
+  it('falls back to the raw code for unknown codes', () => {
+    expect(getLanguageDisplayName('xx-invalid-code')).to.equal(
+      'xx-invalid-code'
+    );
   });
 });

--- a/test/temba-store.test.ts
+++ b/test/temba-store.test.ts
@@ -42,4 +42,22 @@ describe('temba-store', () => {
     const response = await store.postUrl('/no-endpoint');
     assert.equal(response.status, 404);
   });
+
+  describe('getLanguageName', () => {
+    it('returns "Unknown" for the "und" code', async () => {
+      const store = await createStore('<temba-store></temba-store>');
+      assert.equal(store.getLanguageName('und'), 'Unknown');
+    });
+
+    it('returns "Unknown" when stored name is "und"', async () => {
+      const store = await createStore('<temba-store></temba-store>');
+      (store as any).languages = { und: 'und' };
+      assert.equal(store.getLanguageName('und'), 'Unknown');
+    });
+
+    it('falls back to Intl display name for unknown codes', async () => {
+      const store = await createStore('<temba-store></temba-store>');
+      assert.equal(store.getLanguageName('eng'), 'English');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The previous fix for `und` → `Unknown` only covered the primary code paths. This closes the remaining fallback paths that still leaked the raw `und` code:

- `Editor.getAvailableLanguages()` now runs codes from the `_ui.languages` fallback through `getLanguageDisplayName`.
- `Editor.renderToolbarElement()` runs the `baseLanguageName` fallback through `getLanguageDisplayName` when the base language isn't in the available list.
- `Store.getLanguageName()` now delegates to `getLanguageDisplayName` when the stored name is missing or is literally `und`, or when the ISO code is `und` — fixing contact language displays (`ContactBadges`, `ContactDetails`) and the NodeEditor dialog header during translation.

## Test plan

- [x] Unit tests added for `getLanguageDisplayName` and `Store.getLanguageName`
- [x] Full test suite (1678 tests) passes