### PR TITLE
DRY up flow editor node and action configs

### DIFF
--- a/src/flow/NodeEditor.ts
+++ b/src/flow/NodeEditor.ts
@@ -21,7 +21,11 @@ import {
 } from './types';
 import { CustomEventType } from '../interfaces';
 import { generateUUID } from '../utils';
-import { formatIssueMessage } from './utils';
+import {
+  formatIssueMessage,
+  resolveToLocalizationFormData,
+  resolveFromLocalizationFormData
+} from './utils';
 import { getTranslatableCategoriesForNode } from './categoryLocalization';
 import { FieldRenderer } from '../form/FieldRenderer';
 import { renderMarkdownInline } from '../markdown';
@@ -587,21 +591,17 @@ export class NodeEditor extends RapidElement {
       const actionConfig = ACTION_CONFIG[this.action.type];
 
       // Check if we're in localization mode
-      if (
-        this.isTranslating &&
-        actionConfig?.localizable &&
-        actionConfig.toLocalizationFormData
-      ) {
+      const actionToLocalization = actionConfig
+        ? resolveToLocalizationFormData(actionConfig)
+        : undefined;
+      if (this.isTranslating && actionToLocalization) {
         // Get localized values for this action
         const localization =
           this.flowDefinition?.localization?.[this.languageCode]?.[
             this.action.uuid
           ] || {};
 
-        this.formData = actionConfig.toLocalizationFormData(
-          this.action,
-          localization
-        );
+        this.formData = actionToLocalization(this.action, localization);
       } else if (actionConfig?.toFormData) {
         this.formData = actionConfig.toFormData(this.action);
       } else {
@@ -618,19 +618,19 @@ export class NodeEditor extends RapidElement {
       const nodeConfig = this.getNodeConfig();
 
       // Check if we're in localization mode for a node with localizable categories
+      const nodeToLocalization = nodeConfig
+        ? resolveToLocalizationFormData(nodeConfig)
+        : undefined;
       if (
         this.isTranslating &&
         nodeConfig?.localizable === 'categories' &&
-        nodeConfig.toLocalizationFormData
+        nodeToLocalization
       ) {
         // Get localized values for this node's categories
         const localization =
           this.flowDefinition?.localization?.[this.languageCode] || {};
 
-        this.formData = nodeConfig.toLocalizationFormData(
-          this.node,
-          localization
-        );
+        this.formData = nodeToLocalization(this.node, localization);
 
         const translatableCategoryUuids = new Set(
           getTranslatableCategoriesForNode(
@@ -648,8 +648,8 @@ export class NodeEditor extends RapidElement {
           this.formData = {
             ...this.formData,
             categories: Object.fromEntries(
-              Object.entries(this.formData.categories).filter(([categoryUuid]) =>
-                translatableCategoryUuids.has(categoryUuid)
+              Object.entries(this.formData.categories).filter(
+                ([categoryUuid]) => translatableCategoryUuids.has(categoryUuid)
               )
             )
           };
@@ -690,9 +690,7 @@ export class NodeEditor extends RapidElement {
         this.flowInfo?.results &&
         !this.flowDefinition?._ui?.nodes?.[this.node.uuid]
       ) {
-        const existingNames = new Set(
-          this.flowInfo.results.map((r) => r.name)
-        );
+        const existingNames = new Set(this.flowInfo.results.map((r) => r.name));
         let candidate = 'Result';
         let i = 2;
         while (existingNames.has(candidate)) {
@@ -906,12 +904,12 @@ export class NodeEditor extends RapidElement {
       if (this.action) {
         const actionConfig = ACTION_CONFIG[this.action.type];
 
-        if (
-          actionConfig?.localizable &&
-          actionConfig.fromLocalizationFormData
-        ) {
+        const actionFromLocalization = actionConfig
+          ? resolveFromLocalizationFormData(actionConfig)
+          : undefined;
+        if (actionFromLocalization) {
           // Save to localization structure
-          const localizationData = actionConfig.fromLocalizationFormData(
+          const localizationData = actionFromLocalization(
             processedFormData,
             this.action
           );
@@ -933,11 +931,11 @@ export class NodeEditor extends RapidElement {
       if (this.node) {
         const nodeConfig = this.getNodeConfig();
 
-        if (
-          nodeConfig?.localizable === 'categories' &&
-          nodeConfig.fromLocalizationFormData
-        ) {
-          const localizationData = nodeConfig.fromLocalizationFormData(
+        const nodeFromLocalization = nodeConfig
+          ? resolveFromLocalizationFormData(nodeConfig)
+          : undefined;
+        if (nodeConfig?.localizable === 'categories' && nodeFromLocalization) {
+          const localizationData = nodeFromLocalization(
             processedFormData,
             this.node
           );
@@ -1673,14 +1671,17 @@ export class NodeEditor extends RapidElement {
                         ? html`
                             <div class="category-localization-row">
                               <div class="original-name">
-                                <span class="rule-operator">${ruleData.operatorName}</span>
+                                <span class="rule-operator"
+                                  >${ruleData.operatorName}</span
+                                >
                                 <span>${arg}</span>
                               </div>
                               <div class="localized-name">
                                 <temba-textinput
                                   name="rule-${caseUuid}-${i}"
                                   placeholder=""
-                                  value="${ruleData.localizedArguments?.[i] || ''}"
+                                  value="${ruleData.localizedArguments?.[i] ||
+                                  ''}"
                                   @change=${(e: Event) =>
                                     this.handleRuleLocalizationChange(
                                       caseUuid,
@@ -1750,7 +1751,10 @@ export class NodeEditor extends RapidElement {
       this.formData.rules = {};
     }
     if (!this.formData.rules[caseUuid]) {
-      this.formData.rules[caseUuid] = { originalArguments: [], localizedArguments: [] };
+      this.formData.rules[caseUuid] = {
+        originalArguments: [],
+        localizedArguments: []
+      };
     }
     if (!this.formData.rules[caseUuid].localizedArguments) {
       this.formData.rules[caseUuid].localizedArguments = [];
@@ -2200,9 +2204,15 @@ export class NodeEditor extends RapidElement {
             : undefined}
         >
           <div class="form-group-info">
-            <div class="form-group-title">${icon
-                ? html`<temba-icon name=${icon} size="1" style="margin-right:6px;color:#999;"></temba-icon>`
-                : ''}${label}</div>
+            <div class="form-group-title">
+              ${icon
+                ? html`<temba-icon
+                    name=${icon}
+                    size="1"
+                    style="margin-right:6px;color:#999;"
+                  ></temba-icon>`
+                : ''}${label}
+            </div>
             ${helpText
               ? html`<div class="form-group-help">
                   ${renderMarkdownInline(helpText)}
@@ -2248,7 +2258,9 @@ export class NodeEditor extends RapidElement {
           style="${[
             contentPadding ? `--group-content-padding: ${contentPadding}` : '',
             gap ? `gap: ${gap}` : ''
-          ].filter(Boolean).join(';')}"
+          ]
+            .filter(Boolean)
+            .join(';')}"
         >
           ${items.map((item) =>
             this.renderLayoutItem(item, config, renderedFields)
@@ -2288,7 +2300,10 @@ export class NodeEditor extends RapidElement {
     }
 
     return html`
-      <temba-accordion ?multi=${multi} @toggle=${this.handleAccordionSectionToggle}>
+      <temba-accordion
+        ?multi=${multi}
+        @toggle=${this.handleAccordionSectionToggle}
+      >
         ${visibleSections.map((section) => {
           const { label, collapsed = true, getValueCount } = section;
           const stateKey = `accordion:${label}`;

--- a/src/flow/actions/play_audio.ts
+++ b/src/flow/actions/play_audio.ts
@@ -42,32 +42,5 @@ export const play_audio: ActionConfig = {
       audio_url: (data.audio_url || '').trim()
     } as PlayAudio;
   },
-  localizable: ['audio_url'],
-  toLocalizationFormData: (
-    action: PlayAudio,
-    localization: Record<string, any>
-  ) => {
-    const formData: FormData = {
-      uuid: action.uuid
-    };
-
-    if (localization.audio_url && Array.isArray(localization.audio_url)) {
-      formData.audio_url = localization.audio_url[0] || '';
-    } else {
-      formData.audio_url = '';
-    }
-
-    return formData;
-  },
-  fromLocalizationFormData: (formData: FormData, action: PlayAudio) => {
-    const localization: Record<string, any> = {};
-
-    if (formData.audio_url && formData.audio_url.trim() !== '') {
-      if (formData.audio_url !== action.audio_url) {
-        localization.audio_url = [formData.audio_url];
-      }
-    }
-
-    return localization;
-  }
+  localizable: ['audio_url']
 };

--- a/src/flow/actions/say_msg.ts
+++ b/src/flow/actions/say_msg.ts
@@ -63,44 +63,5 @@ export const say_msg: ActionConfig = {
       formData.text = formData.text.trim();
     }
   },
-  localizable: ['text', 'audio_url'],
-  toLocalizationFormData: (
-    action: SayMsg,
-    localization: Record<string, any>
-  ) => {
-    const formData: FormData = {
-      uuid: action.uuid
-    };
-
-    if (localization.text && Array.isArray(localization.text)) {
-      formData.text = localization.text[0] || '';
-    } else {
-      formData.text = '';
-    }
-
-    if (localization.audio_url && Array.isArray(localization.audio_url)) {
-      formData.audio_url = localization.audio_url[0] || '';
-    } else {
-      formData.audio_url = '';
-    }
-
-    return formData;
-  },
-  fromLocalizationFormData: (formData: FormData, action: SayMsg) => {
-    const localization: Record<string, any> = {};
-
-    if (formData.text && formData.text.trim() !== '') {
-      if (formData.text !== action.text) {
-        localization.text = [formData.text];
-      }
-    }
-
-    if (formData.audio_url && formData.audio_url.trim() !== '') {
-      if (formData.audio_url !== action.audio_url) {
-        localization.audio_url = [formData.audio_url];
-      }
-    }
-
-    return localization;
-  }
+  localizable: ['text', 'audio_url']
 };

--- a/src/flow/actions/send_email.ts
+++ b/src/flow/actions/send_email.ts
@@ -1,16 +1,11 @@
 import { html } from 'lit-html';
-import {
-  ActionConfig,
-  ACTION_GROUPS,
-  FormData,
-  ValidationResult,
-  FlowTypes
-} from '../types';
+import { ActionConfig, ACTION_GROUPS, FormData, FlowTypes } from '../types';
 import { Node, SendEmail } from '../../store/flow-definition';
 import {
   renderStringList,
   renderClamped,
-  renderHighlightedText
+  renderHighlightedText,
+  validateWith
 } from '../utils';
 import { Icon } from '../../Icons';
 
@@ -67,55 +62,9 @@ export const send_email: ActionConfig = {
     };
   },
   localizable: ['subject', 'body'],
-  toLocalizationFormData: (
-    action: SendEmail,
-    localization: Record<string, any>
-  ) => {
-    const formData: FormData = {
-      uuid: action.uuid
-    };
-
-    if (localization.subject && Array.isArray(localization.subject)) {
-      formData.subject = localization.subject[0] || '';
-    } else {
-      formData.subject = '';
-    }
-
-    if (localization.body && Array.isArray(localization.body)) {
-      formData.body = localization.body[0] || '';
-    } else {
-      formData.body = '';
-    }
-
-    return formData;
-  },
-  fromLocalizationFormData: (formData: FormData, action: SendEmail) => {
-    const localization: Record<string, any> = {};
-
-    if (formData.subject && formData.subject.trim() !== '') {
-      if (formData.subject !== action.subject) {
-        localization.subject = [formData.subject];
-      }
-    }
-
-    if (formData.body && formData.body.trim() !== '') {
-      if (formData.body !== action.body) {
-        localization.body = [formData.body];
-      }
-    }
-
-    return localization;
-  },
-  validate: (formData: FormData): ValidationResult => {
-    const errors: { [key: string]: string } = {};
-
+  validate: validateWith((formData, errors) => {
     if (!formData.addresses || formData.addresses.length === 0) {
       errors.addresses = 'At least one recipient email address is required';
     }
-
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors
-    };
-  }
+  })
 };

--- a/src/flow/nodes/shared.ts
+++ b/src/flow/nodes/shared.ts
@@ -4,8 +4,9 @@ import {
   AccordionLayoutConfig,
   CheckboxFieldConfig
 } from '../types';
-import { Node } from '../../store/flow-definition';
+import { Node, Category, Exit, Case } from '../../store/flow-definition';
 import { getOperatorConfig } from '../operators';
+import { generateUUID } from '../../utils';
 
 /**
  * Shared result_name field configuration for router nodes.
@@ -124,10 +125,9 @@ export function categoriesToLocalizationFormData(
     rulesData[c.uuid] = {
       operatorName,
       originalArguments: [...c.arguments],
-      localizedArguments:
-        caseLocalization?.arguments
-          ? [...caseLocalization.arguments]
-          : c.arguments.map(() => '')
+      localizedArguments: caseLocalization?.arguments
+        ? [...caseLocalization.arguments]
+        : c.arguments.map(() => '')
     };
   });
 
@@ -173,7 +173,8 @@ export function localizationFormDataToCategories(
 
       // Save if any argument differs from original and is non-empty
       const hasLocalization = localized.some(
-        (arg: string, i: number) => arg?.trim() && arg.trim() !== (original[i] || '')
+        (arg: string, i: number) =>
+          arg?.trim() && arg.trim() !== (original[i] || '')
       );
 
       if (hasLocalization) {
@@ -185,4 +186,109 @@ export function localizationFormDataToCategories(
   }
 
   return localizationData;
+}
+
+/**
+ * Describes a category to build for a router node. When `case` is provided,
+ * a matching switch-router case is also built and linked to the category.
+ */
+export interface CategoryEntry {
+  name: string;
+  case?: {
+    type: string;
+    arguments: string[];
+  };
+}
+
+/**
+ * Builds categories, exits, and (optionally) cases for a router node,
+ * preserving UUIDs and exit destinations from existing data when possible.
+ * Categories/exits are matched by category name; cases by their first argument.
+ */
+export function buildCategoriesExitsCases(
+  entries: CategoryEntry[],
+  existingCategories: Category[],
+  existingExits: Exit[],
+  existingCases: Case[] = []
+): { categories: Category[]; exits: Exit[]; cases: Case[] } {
+  const categories: Category[] = [];
+  const exits: Exit[] = [];
+  const cases: Case[] = [];
+
+  entries.forEach((entry) => {
+    const existingCategory = existingCategories.find(
+      (cat) => cat.name === entry.name
+    );
+    const existingExit = existingCategory
+      ? existingExits.find((exit) => exit.uuid === existingCategory.exit_uuid)
+      : null;
+
+    const exitUuid = existingExit?.uuid || generateUUID();
+    const categoryUuid = existingCategory?.uuid || generateUUID();
+
+    categories.push({
+      uuid: categoryUuid,
+      name: entry.name,
+      exit_uuid: exitUuid
+    });
+
+    exits.push({
+      uuid: exitUuid,
+      destination_uuid: existingExit?.destination_uuid || null
+    });
+
+    if (entry.case) {
+      const matchArg = entry.case.arguments[0];
+      const existingCase = existingCases.find(
+        (c) => c.arguments?.[0] === matchArg
+      );
+      cases.push({
+        uuid: existingCase?.uuid || generateUUID(),
+        type: entry.case.type,
+        arguments: entry.case.arguments,
+        category_uuid: categoryUuid
+      });
+    }
+  });
+
+  return { categories, exits, cases };
+}
+
+/**
+ * Appends a default "Other" category and its exit to the given arrays,
+ * preserving the UUID/destination of an existing "Other" unless the user
+ * selected an item also named "Other" (in which case the existing one was
+ * already consumed by buildCategoriesExitsCases). Returns the Other category
+ * UUID for use as `default_category_uuid`.
+ */
+export function appendOtherCategory(
+  categories: Category[],
+  exits: Exit[],
+  existingCategories: Category[],
+  existingExits: Exit[],
+  userItemNames: string[]
+): string {
+  const userHasOther = userItemNames.includes('Other');
+  const existingOther = userHasOther
+    ? null
+    : existingCategories.find((cat) => cat.name === 'Other');
+  const existingOtherExit = existingOther
+    ? existingExits.find((exit) => exit.uuid === existingOther.exit_uuid)
+    : null;
+
+  const otherExitUuid = existingOtherExit?.uuid || generateUUID();
+  const otherCategoryUuid = existingOther?.uuid || generateUUID();
+
+  categories.push({
+    uuid: otherCategoryUuid,
+    name: 'Other',
+    exit_uuid: otherExitUuid
+  });
+
+  exits.push({
+    uuid: otherExitUuid,
+    destination_uuid: existingOtherExit?.destination_uuid || null
+  });
+
+  return otherCategoryUuid;
 }

--- a/src/flow/nodes/split_by_airtime.ts
+++ b/src/flow/nodes/split_by_airtime.ts
@@ -7,13 +7,10 @@ import {
 } from '../types';
 import { TransferAirtime, Node } from '../../store/flow-definition';
 import { generateUUID, createSuccessFailureRouter } from '../../utils';
+import { validateWith } from '../utils';
 import { html } from 'lit';
 import { CURRENCY_OPTIONS, CURRENCIES } from '../currencies';
-import {
-  resultNameField,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
-} from './shared';
+import { resultNameField } from './shared';
 
 export const split_by_airtime: NodeConfig = {
   type: 'split_by_airtime',
@@ -55,68 +52,51 @@ export const split_by_airtime: NodeConfig = {
     result_name: resultNameField
   },
   layout: ['amounts', 'result_name'],
-  validate: (formData: FormData) => {
-    const errors: { [key: string]: string } = {};
-
-    // Validate that we have at least one amount
-    if (formData.amounts && Array.isArray(formData.amounts)) {
-      const validAmounts = formData.amounts.filter(
-        (item: any) =>
-          item?.currency && item?.amount && item.amount.trim() !== ''
-      );
-
-      if (validAmounts.length === 0) {
-        errors.amounts = 'At least one currency and amount is required';
-        return {
-          valid: false,
-          errors
-        };
-      }
-
-      // Check for duplicate currencies
-      const currencies = new Set();
-      const duplicates: string[] = [];
-
-      validAmounts.forEach((item: any) => {
-        // Extract currency code from selection
-        const currencyCode =
-          Array.isArray(item.currency) && item.currency.length > 0
-            ? item.currency[0].value
-            : typeof item.currency === 'string'
-              ? item.currency
-              : item.currency?.value;
-
-        if (currencies.has(currencyCode)) {
-          duplicates.push(currencyCode);
-        } else {
-          currencies.add(currencyCode);
-        }
-      });
-
-      if (duplicates.length > 0) {
-        errors.amounts = `Duplicate currencies found: ${duplicates.join(', ')}`;
-      }
-
-      // Validate amounts are numeric
-      for (const item of validAmounts) {
-        const amount = item.amount.trim();
-        if (isNaN(Number(amount)) || Number(amount) <= 0) {
-          errors.amounts = 'All amounts must be valid positive numbers';
-          return {
-            valid: false,
-            errors
-          };
-        }
-      }
-    } else {
+  validate: validateWith((formData, errors) => {
+    if (!formData.amounts || !Array.isArray(formData.amounts)) {
       errors.amounts = 'At least one currency and amount is required';
+      return;
     }
 
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors
-    };
-  },
+    const validAmounts = formData.amounts.filter(
+      (item: any) => item?.currency && item?.amount && item.amount.trim() !== ''
+    );
+
+    if (validAmounts.length === 0) {
+      errors.amounts = 'At least one currency and amount is required';
+      return;
+    }
+
+    const currencies = new Set();
+    const duplicates: string[] = [];
+
+    validAmounts.forEach((item: any) => {
+      const currencyCode =
+        Array.isArray(item.currency) && item.currency.length > 0
+          ? item.currency[0].value
+          : typeof item.currency === 'string'
+            ? item.currency
+            : item.currency?.value;
+
+      if (currencies.has(currencyCode)) {
+        duplicates.push(currencyCode);
+      } else {
+        currencies.add(currencyCode);
+      }
+    });
+
+    if (duplicates.length > 0) {
+      errors.amounts = `Duplicate currencies found: ${duplicates.join(', ')}`;
+    }
+
+    for (const item of validAmounts) {
+      const amount = item.amount.trim();
+      if (isNaN(Number(amount)) || Number(amount) <= 0) {
+        errors.amounts = 'All amounts must be valid positive numbers';
+        return;
+      }
+    }
+  }),
   render: (node: Node) => {
     const transferAirtimeAction = node.actions?.find(
       (action) => action.type === 'transfer_airtime'
@@ -254,7 +234,5 @@ export const split_by_airtime: NodeConfig = {
 
   // Localization support for categories
   localizable: 'categories',
-  nonTranslatableCategories: 'all',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  nonTranslatableCategories: 'all'
 };

--- a/src/flow/nodes/split_by_contact_field.ts
+++ b/src/flow/nodes/split_by_contact_field.ts
@@ -10,16 +10,14 @@ import {
   resultNameField,
   localizeRulesField,
   localizeCategoriesField,
-  nodeOptionsAccordion,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
+  nodeOptionsAccordion
 } from './shared';
 import {
   createRulesArrayConfig,
   extractUserRules,
   casesToFormRules
 } from './shared-rules';
-import { SCHEMES } from '../utils';
+import { SCHEMES, validateWith } from '../utils';
 import { html } from 'lit';
 
 // System contact properties that can be split on
@@ -89,18 +87,11 @@ export const split_by_contact_field: NodeConfig = {
     localizeCategories: localizeCategoriesField
   },
   layout: ['field', 'rules', nodeOptionsAccordion],
-  validate: (formData: FormData) => {
-    const errors: { [key: string]: string } = {};
-
+  validate: validateWith((formData, errors) => {
     if (!formData.field || formData.field.length === 0) {
       errors.field = 'A field is required';
     }
-
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors
-    };
-  },
+  }),
   toFormData: (node: Node, nodeUI?: any) => {
     // Get the field from the UI config operand (source of truth)
     const operand = nodeUI?.config?.operand || CONTACT_PROPERTIES.name;
@@ -206,7 +197,9 @@ export const split_by_contact_field: NodeConfig = {
       }
     };
     config.localizeRules = !!formData.localizeRules;
-    config.localizeCategories = formData.result_name ? !!formData.localizeCategories : false;
+    config.localizeCategories = formData.result_name
+      ? !!formData.localizeCategories
+      : false;
     return config;
   },
   renderTitle: (node: Node, nodeUI?: any) => {
@@ -214,7 +207,5 @@ export const split_by_contact_field: NodeConfig = {
   },
 
   // Localization support for categories
-  localizable: 'categories',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  localizable: 'categories'
 };

--- a/src/flow/nodes/split_by_expression.ts
+++ b/src/flow/nodes/split_by_expression.ts
@@ -10,15 +10,14 @@ import {
   resultNameField,
   localizeRulesField,
   localizeCategoriesField,
-  nodeOptionsAccordion,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
+  nodeOptionsAccordion
 } from './shared';
 import {
   createRulesArrayConfig,
   extractUserRules,
   casesToFormRules
 } from './shared-rules';
+import { validateWith } from '../utils';
 
 export const split_by_expression: NodeConfig = {
   type: 'split_by_expression',
@@ -44,19 +43,11 @@ export const split_by_expression: NodeConfig = {
     localizeCategories: localizeCategoriesField
   },
   layout: ['operand', 'rules', nodeOptionsAccordion],
-  validate: (formData: FormData) => {
-    const errors: { [key: string]: string } = {};
-
-    // Validate operand is provided
+  validate: validateWith((formData, errors) => {
     if (!formData.operand || formData.operand.trim() === '') {
       errors.operand = 'Expression is required';
     }
-
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors
-    };
-  },
+  }),
   toFormData: (node: Node, nodeUI?: any) => {
     // Extract rules from router cases using shared function
     const rules = casesToFormRules(node);
@@ -73,7 +64,9 @@ export const split_by_expression: NodeConfig = {
   toUIConfig: (formData: FormData) => {
     const config: Record<string, any> = {};
     config.localizeRules = !!formData.localizeRules;
-    config.localizeCategories = formData.result_name ? !!formData.localizeCategories : false;
+    config.localizeCategories = formData.result_name
+      ? !!formData.localizeCategories
+      : false;
     return config;
   },
   fromFormData: (formData: FormData, originalNode: Node): Node => {
@@ -116,7 +109,5 @@ export const split_by_expression: NodeConfig = {
   },
 
   // Localization support for categories
-  localizable: 'categories',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  localizable: 'categories'
 };

--- a/src/flow/nodes/split_by_groups.ts
+++ b/src/flow/nodes/split_by_groups.ts
@@ -1,99 +1,13 @@
 import { SPLIT_GROUPS, FormData, NodeConfig, FlowTypes } from '../types';
-import { Node, Category, Exit, Case } from '../../store/flow-definition.d';
+import { Node, Case } from '../../store/flow-definition.d';
 import { generateUUID } from '../../utils';
+import { validateWith } from '../utils';
 import {
   resultNameField,
   nodeOptionsAccordionSimple,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
+  buildCategoriesExitsCases,
+  appendOtherCategory
 } from './shared';
-
-// Helper function to create a switch router with group cases
-const createGroupRouter = (
-  userGroups: { uuid: string; name: string }[],
-  existingCategories: Category[] = [],
-  existingExits: Exit[] = [],
-  existingCases: Case[] = [],
-  resultName: string = ''
-) => {
-  const categories: Category[] = [];
-  const exits: Exit[] = [];
-  const cases: Case[] = [];
-
-  // Create categories, exits, and cases for each selected group
-  userGroups.forEach((group) => {
-    // Try to find existing category by group name
-    const existingCategory = existingCategories.find(
-      (cat) => cat.name === group.name
-    );
-    const existingExit = existingCategory
-      ? existingExits.find((exit) => exit.uuid === existingCategory.exit_uuid)
-      : null;
-    const existingCase = existingCases.find(
-      (c) => c.arguments?.[0] === group.uuid
-    );
-
-    const exitUuid = existingExit?.uuid || generateUUID();
-    const categoryUuid = existingCategory?.uuid || generateUUID();
-    const caseUuid = existingCase?.uuid || generateUUID();
-
-    categories.push({
-      uuid: categoryUuid,
-      name: group.name,
-      exit_uuid: exitUuid
-    });
-
-    exits.push({
-      uuid: exitUuid,
-      destination_uuid: existingExit?.destination_uuid || null
-    });
-
-    cases.push({
-      uuid: caseUuid,
-      type: 'has_group',
-      arguments: [group.uuid, group.name],
-      category_uuid: categoryUuid
-    });
-  });
-
-  // Add default "Other" category for contacts not in any selected group
-  const existingOtherCategory = existingCategories.find(
-    (cat) =>
-      cat.name === 'Other' &&
-      !userGroups.some((group) => group.name === cat.name)
-  );
-  const existingOtherExit = existingOtherCategory
-    ? existingExits.find(
-        (exit) => exit.uuid === existingOtherCategory.exit_uuid
-      )
-    : null;
-
-  const otherExitUuid = existingOtherExit?.uuid || generateUUID();
-  const otherCategoryUuid = existingOtherCategory?.uuid || generateUUID();
-
-  categories.push({
-    uuid: otherCategoryUuid,
-    name: 'Other',
-    exit_uuid: otherExitUuid
-  });
-
-  exits.push({
-    uuid: otherExitUuid,
-    destination_uuid: existingOtherExit?.destination_uuid || null
-  });
-
-  return {
-    router: {
-      type: 'switch' as const,
-      cases: cases,
-      categories: categories,
-      default_category_uuid: otherCategoryUuid,
-      operand: '@contact.groups',
-      result_name: resultName
-    },
-    exits: exits
-  };
-};
 
 export const split_by_groups: NodeConfig = {
   type: 'split_by_groups',
@@ -133,9 +47,7 @@ export const split_by_groups: NodeConfig = {
     result_name: resultNameField
   },
   layout: ['groups', nodeOptionsAccordionSimple],
-  validate: (formData: FormData) => {
-    const errors: { [key: string]: string } = {};
-
+  validate: validateWith((formData, errors) => {
     if (
       !formData.groups ||
       !Array.isArray(formData.groups) ||
@@ -143,12 +55,7 @@ export const split_by_groups: NodeConfig = {
     ) {
       errors.groups = 'At least one group is required';
     }
-
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors
-    };
-  },
+  }),
   toFormData: (node: Node) => {
     // Extract groups from the existing node structure
     const groups: { uuid: string; name: string }[] = [];
@@ -171,33 +78,50 @@ export const split_by_groups: NodeConfig = {
     };
   },
   fromFormData: (formData: FormData, originalNode: Node): Node => {
-    // Get selected groups
     const selectedGroups = (formData.groups || [])
       .filter((group: any) => group?.uuid || group?.arbitrary)
       .map((group: any) => ({
-        uuid: group.uuid || generateUUID(), // Generate UUID for arbitrary groups
+        uuid: group.uuid || generateUUID(),
         name: group.name
       }));
 
-    // Create router and exits using existing data when possible
     const existingCategories = originalNode.router?.categories || [];
     const existingExits = originalNode.exits || [];
     const existingCases = originalNode.router?.cases || [];
 
-    const { router, exits } = createGroupRouter(
-      selectedGroups,
+    const { categories, exits, cases } = buildCategoriesExitsCases(
+      selectedGroups.map((group) => ({
+        name: group.name,
+        case: {
+          type: 'has_group',
+          arguments: [group.uuid, group.name]
+        }
+      })),
       existingCategories,
       existingExits,
-      existingCases,
-      formData.result_name || ''
+      existingCases
     );
 
-    // Return the complete node
+    const defaultCategoryUuid = appendOtherCategory(
+      categories,
+      exits,
+      existingCategories,
+      existingExits,
+      selectedGroups.map((g) => g.name)
+    );
+
     return {
       uuid: originalNode.uuid,
       actions: originalNode.actions || [],
-      router: router,
-      exits: exits
+      router: {
+        type: 'switch',
+        cases,
+        categories,
+        default_category_uuid: defaultCategoryUuid,
+        operand: '@contact.groups',
+        result_name: formData.result_name || ''
+      },
+      exits
     };
   },
   router: {
@@ -206,7 +130,5 @@ export const split_by_groups: NodeConfig = {
   },
 
   // Localization support for categories
-  localizable: 'categories',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  localizable: 'categories'
 };

--- a/src/flow/nodes/split_by_llm.ts
+++ b/src/flow/nodes/split_by_llm.ts
@@ -3,10 +3,6 @@ import { CallLLM, Node } from '../../store/flow-definition';
 import { generateUUID, createSuccessFailureRouter } from '../../utils';
 import { html } from 'lit';
 import {
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
-} from './shared';
-import {
   renderClamped,
   renderHighlightedText,
   renderLineItem,
@@ -141,7 +137,5 @@ export const split_by_llm: NodeConfig = {
 
   // Localization support for categories
   localizable: 'categories',
-  nonTranslatableCategories: 'all',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  nonTranslatableCategories: 'all'
 };

--- a/src/flow/nodes/split_by_llm_categorize.ts
+++ b/src/flow/nodes/split_by_llm_categorize.ts
@@ -2,10 +2,7 @@ import { FormData, NodeConfig, ACTION_GROUPS, Features } from '../types';
 import { CallLLM, Node } from '../../store/flow-definition';
 import { generateUUID, createMultiCategoryRouter } from '../../utils';
 import { html } from 'lit';
-import {
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
-} from './shared';
+import { validateWith } from '../utils';
 
 export const split_by_llm_categorize: NodeConfig = {
   type: 'split_by_llm_categorize',
@@ -53,48 +50,37 @@ export const split_by_llm_categorize: NodeConfig = {
     }
   },
   layout: ['llm', 'input', 'categories'],
-  validate: (formData: FormData) => {
-    const errors: { [key: string]: string } = {};
+  validate: validateWith((formData, errors) => {
+    if (!formData.categories || !Array.isArray(formData.categories)) return;
 
-    // Check for duplicate category names
-    if (formData.categories && Array.isArray(formData.categories)) {
-      const categories = formData.categories.filter(
-        (item: any) => item?.name && item.name.trim() !== ''
-      );
+    const categories = formData.categories.filter(
+      (item: any) => item?.name && item.name.trim() !== ''
+    );
 
-      // Find all categories that have duplicates (case-insensitive)
-      const duplicateCategories = [];
-      const lowerCaseMap = new Map();
+    const duplicateCategories: string[] = [];
+    const lowerCaseMap = new Map<string, string[]>();
 
-      // First pass: map lowercase names to all original cases
-      categories.forEach((category) => {
-        const lowerName = category.name.trim().toLowerCase();
-        if (!lowerCaseMap.has(lowerName)) {
-          lowerCaseMap.set(lowerName, []);
-        }
-        lowerCaseMap.get(lowerName).push(category.name.trim());
-      });
-
-      // Second pass: collect all names that appear more than once
-      lowerCaseMap.forEach((originalNames) => {
-        if (originalNames.length > 1) {
-          duplicateCategories.push(...originalNames);
-        }
-      });
-
-      if (duplicateCategories.length > 0) {
-        const uniqueDuplicates = [...new Set(duplicateCategories)];
-        errors.categories = `Duplicate category names found: ${uniqueDuplicates.join(
-          ', '
-        )}`;
+    categories.forEach((category) => {
+      const lowerName = category.name.trim().toLowerCase();
+      if (!lowerCaseMap.has(lowerName)) {
+        lowerCaseMap.set(lowerName, []);
       }
-    }
+      lowerCaseMap.get(lowerName).push(category.name.trim());
+    });
 
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors
-    };
-  },
+    lowerCaseMap.forEach((originalNames) => {
+      if (originalNames.length > 1) {
+        duplicateCategories.push(...originalNames);
+      }
+    });
+
+    if (duplicateCategories.length > 0) {
+      const uniqueDuplicates = [...new Set(duplicateCategories)];
+      errors.categories = `Duplicate category names found: ${uniqueDuplicates.join(
+        ', '
+      )}`;
+    }
+  }),
   render: (node: Node) => {
     const callLlmAction = node.actions?.find(
       (action) => action.type === 'call_llm'
@@ -181,7 +167,5 @@ export const split_by_llm_categorize: NodeConfig = {
 
   // Localization support for categories
   localizable: 'categories',
-  nonTranslatableCategories: ['Failure'],
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  nonTranslatableCategories: ['Failure']
 };

--- a/src/flow/nodes/split_by_random.ts
+++ b/src/flow/nodes/split_by_random.ts
@@ -1,53 +1,7 @@
 import { SPLIT_GROUPS, FormData, NodeConfig, FlowTypes } from '../types';
-import { Node, Category, Exit } from '../../store/flow-definition.d';
-import { generateUUID } from '../../utils';
-import {
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
-} from './shared';
-
-// Helper function to create a random router with categories
-const createRandomRouter = (
-  userCategories: string[],
-  existingCategories: Category[] = [],
-  existingExits: Exit[] = []
-) => {
-  const categories: Category[] = [];
-  const exits: Exit[] = [];
-
-  // Create categories and exits for user-defined buckets
-  userCategories.forEach((categoryName) => {
-    // Try to find existing category by name
-    const existingCategory = existingCategories.find(
-      (cat) => cat.name === categoryName
-    );
-    const existingExit = existingCategory
-      ? existingExits.find((exit) => exit.uuid === existingCategory.exit_uuid)
-      : null;
-
-    const exitUuid = existingExit?.uuid || generateUUID();
-    const categoryUuid = existingCategory?.uuid || generateUUID();
-
-    categories.push({
-      uuid: categoryUuid,
-      name: categoryName,
-      exit_uuid: exitUuid
-    });
-
-    exits.push({
-      uuid: exitUuid,
-      destination_uuid: existingExit?.destination_uuid || null
-    });
-  });
-
-  return {
-    router: {
-      type: 'random' as const,
-      categories: categories
-    },
-    exits: exits
-  };
-};
+import { Node } from '../../store/flow-definition.d';
+import { validateWith } from '../utils';
+import { buildCategoriesExitsCases } from './shared';
 
 export const split_by_random: NodeConfig = {
   type: 'split_by_random',
@@ -76,53 +30,41 @@ export const split_by_random: NodeConfig = {
     }
   },
   layout: ['categories'],
-  validate: (formData: FormData) => {
-    const errors: { [key: string]: string } = {};
+  validate: validateWith((formData, errors) => {
+    if (!formData.categories || !Array.isArray(formData.categories)) return;
 
-    // Check for duplicate category names
-    if (formData.categories && Array.isArray(formData.categories)) {
-      const categories = formData.categories.filter(
-        (item: any) => item?.name && item.name.trim() !== ''
-      );
+    const categories = formData.categories.filter(
+      (item: any) => item?.name && item.name.trim() !== ''
+    );
 
-      // Ensure minimum buckets
-      if (categories.length < 2) {
-        errors.categories = 'At least 2 buckets are required for random split';
-      }
-
-      // Find all categories that have duplicates (case-insensitive)
-      const duplicateCategories = [];
-      const lowerCaseMap = new Map();
-
-      // First pass: map lowercase names to all original cases
-      categories.forEach((category) => {
-        const lowerName = category.name.trim().toLowerCase();
-        if (!lowerCaseMap.has(lowerName)) {
-          lowerCaseMap.set(lowerName, []);
-        }
-        lowerCaseMap.get(lowerName).push(category.name.trim());
-      });
-
-      // Second pass: collect all names that appear more than once
-      lowerCaseMap.forEach((originalNames) => {
-        if (originalNames.length > 1) {
-          duplicateCategories.push(...originalNames);
-        }
-      });
-
-      if (duplicateCategories.length > 0) {
-        const uniqueDuplicates = [...new Set(duplicateCategories)];
-        errors.categories = `Duplicate bucket names found: ${uniqueDuplicates.join(
-          ', '
-        )}`;
-      }
+    if (categories.length < 2) {
+      errors.categories = 'At least 2 buckets are required for random split';
     }
 
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors
-    };
-  },
+    const duplicateCategories: string[] = [];
+    const lowerCaseMap = new Map<string, string[]>();
+
+    categories.forEach((category) => {
+      const lowerName = category.name.trim().toLowerCase();
+      if (!lowerCaseMap.has(lowerName)) {
+        lowerCaseMap.set(lowerName, []);
+      }
+      lowerCaseMap.get(lowerName).push(category.name.trim());
+    });
+
+    lowerCaseMap.forEach((originalNames) => {
+      if (originalNames.length > 1) {
+        duplicateCategories.push(...originalNames);
+      }
+    });
+
+    if (duplicateCategories.length > 0) {
+      const uniqueDuplicates = [...new Set(duplicateCategories)];
+      errors.categories = `Duplicate bucket names found: ${uniqueDuplicates.join(
+        ', '
+      )}`;
+    }
+  }),
   toFormData: (node: Node) => {
     // Extract categories from the existing node structure
     const categories =
@@ -134,27 +76,27 @@ export const split_by_random: NodeConfig = {
     };
   },
   fromFormData: (formData: FormData, originalNode: Node): Node => {
-    // Get user categories
     const userCategories = (formData.categories || [])
       .filter((item: any) => item?.name?.trim())
       .map((item: any) => item.name.trim());
 
-    // Create router and exits using existing data when possible
     const existingCategories = originalNode.router?.categories || [];
     const existingExits = originalNode.exits || [];
 
-    const { router, exits } = createRandomRouter(
-      userCategories,
+    const { categories, exits } = buildCategoriesExitsCases(
+      userCategories.map((name) => ({ name })),
       existingCategories,
       existingExits
     );
 
-    // Return the complete node
     return {
       uuid: originalNode.uuid,
       actions: originalNode.actions || [],
-      router: router,
-      exits: exits
+      router: {
+        type: 'random',
+        categories
+      },
+      exits
     };
   },
   router: {
@@ -162,7 +104,5 @@ export const split_by_random: NodeConfig = {
   },
 
   // Localization support for categories
-  localizable: 'categories',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  localizable: 'categories'
 };

--- a/src/flow/nodes/split_by_resthook.ts
+++ b/src/flow/nodes/split_by_resthook.ts
@@ -2,12 +2,8 @@ import { ACTION_GROUPS, FormData, NodeConfig, FlowTypes } from '../types';
 import { CallResthook, Node } from '../../store/flow-definition';
 import { generateUUID, createSuccessFailureRouter } from '../../utils';
 import { html } from 'lit';
-import {
-  resultNameField,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
-} from './shared';
-import { renderClamped } from '../utils';
+import { resultNameField } from './shared';
+import { renderClamped, validateWith } from '../utils';
 
 export const split_by_resthook: NodeConfig = {
   type: 'split_by_resthook',
@@ -31,19 +27,11 @@ export const split_by_resthook: NodeConfig = {
     result_name: resultNameField
   },
   layout: ['resthook', 'result_name'],
-  validate: (formData: FormData) => {
-    const errors: { [key: string]: string } = {};
-
-    // validate resthook is provided
+  validate: validateWith((formData, errors) => {
     if (!formData.resthook || formData.resthook.length === 0) {
       errors.resthook = 'A resthook is required';
     }
-
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors
-    };
-  },
+  }),
   render: (node: Node) => {
     const callResthookAction = node.actions?.find(
       (action) => action.type === 'call_resthook'
@@ -130,7 +118,5 @@ export const split_by_resthook: NodeConfig = {
 
   // Localization support for categories
   localizable: 'categories',
-  nonTranslatableCategories: 'all',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  nonTranslatableCategories: 'all'
 };

--- a/src/flow/nodes/split_by_run_result.ts
+++ b/src/flow/nodes/split_by_run_result.ts
@@ -10,9 +10,7 @@ import {
   resultNameField,
   localizeRulesField,
   localizeCategoriesField,
-  nodeOptionsAccordion,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
+  nodeOptionsAccordion
 } from './shared';
 import {
   createRulesArrayConfig,
@@ -20,6 +18,7 @@ import {
   casesToFormRules
 } from './shared-rules';
 import { getStore } from '../../store/Store';
+import { validateWith } from '../utils';
 
 // delimit index options (first through 20th)
 const DELIMIT_INDEX_OPTIONS = [
@@ -125,19 +124,11 @@ export const split_by_run_result: NodeConfig = {
     'rules',
     nodeOptionsAccordion
   ],
-  validate: (formData: FormData) => {
-    const errors: { [key: string]: string } = {};
-
-    // Validate result is provided
+  validate: validateWith((formData, errors) => {
     if (!formData.result || formData.result.length === 0) {
       errors.result = 'A flow result is required';
     }
-
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors
-    };
-  },
+  }),
   toFormData: (node: Node, nodeUI?: any) => {
     // Get the result from the UI config operand (source of truth)
     // Normalize: toUIConfig saves { id, name, type } but the Select component
@@ -274,12 +265,12 @@ export const split_by_run_result: NodeConfig = {
       : 'split_by_run_result';
 
     config.localizeRules = !!formData.localizeRules;
-    config.localizeCategories = formData.result_name ? !!formData.localizeCategories : false;
+    config.localizeCategories = formData.result_name
+      ? !!formData.localizeCategories
+      : false;
     return config;
   },
 
   // Localization support for categories
-  localizable: 'categories',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  localizable: 'categories'
 };

--- a/src/flow/nodes/split_by_scheme.ts
+++ b/src/flow/nodes/split_by_scheme.ts
@@ -1,15 +1,13 @@
 import { SPLIT_GROUPS, FormData, NodeConfig, FlowTypes } from '../types';
-import { Node, Category, Exit, Case } from '../../store/flow-definition.d';
-import { generateUUID } from '../../utils';
-import { SCHEMES } from '../utils';
+import { Node, Case } from '../../store/flow-definition.d';
+import { SCHEMES, validateWith } from '../utils';
 import {
   resultNameField,
   nodeOptionsAccordionSimple,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
+  buildCategoriesExitsCases,
+  appendOtherCategory
 } from './shared';
 
-// Helper function to get scheme options for the select dropdown
 const getSchemeOptions = () => {
   return SCHEMES.map((scheme) => ({
     value: scheme.scheme,
@@ -17,95 +15,8 @@ const getSchemeOptions = () => {
   }));
 };
 
-// Helper function to create a switch router with scheme cases
-const createSchemeRouter = (
-  selectedSchemes: string[],
-  existingCategories: Category[] = [],
-  existingExits: Exit[] = [],
-  existingCases: Case[] = [],
-  resultName: string = ''
-) => {
-  const categories: Category[] = [];
-  const exits: Exit[] = [];
-  const cases: Case[] = [];
-
-  // Create categories, exits, and cases for each selected scheme
-  selectedSchemes.forEach((scheme) => {
-    const schemeObj = SCHEMES.find((s) => s.scheme === scheme);
-    const schemeName = schemeObj?.name || scheme;
-
-    // Try to find existing category by scheme name
-    const existingCategory = existingCategories.find(
-      (cat) => cat.name === schemeName
-    );
-    const existingExit = existingCategory
-      ? existingExits.find((exit) => exit.uuid === existingCategory.exit_uuid)
-      : null;
-    const existingCase = existingCases.find((c) => c.arguments?.[0] === scheme);
-
-    const exitUuid = existingExit?.uuid || generateUUID();
-    const categoryUuid = existingCategory?.uuid || generateUUID();
-    const caseUuid = existingCase?.uuid || generateUUID();
-
-    categories.push({
-      uuid: categoryUuid,
-      name: schemeName,
-      exit_uuid: exitUuid
-    });
-
-    exits.push({
-      uuid: exitUuid,
-      destination_uuid: existingExit?.destination_uuid || null
-    });
-
-    cases.push({
-      uuid: caseUuid,
-      type: 'has_only_phrase',
-      arguments: [scheme],
-      category_uuid: categoryUuid
-    });
-  });
-
-  // Add default "Other" category for schemes not in the selected list
-  const existingOtherCategory = existingCategories.find((cat) => {
-    const matchesSelected = selectedSchemes.some((scheme) => {
-      const schemeObj = SCHEMES.find((s) => s.scheme === scheme);
-      return schemeObj?.name === cat.name;
-    });
-    return cat.name === 'Other' && !matchesSelected;
-  });
-  const existingOtherExit = existingOtherCategory
-    ? existingExits.find(
-        (exit) => exit.uuid === existingOtherCategory.exit_uuid
-      )
-    : null;
-
-  const otherExitUuid = existingOtherExit?.uuid || generateUUID();
-  const otherCategoryUuid = existingOtherCategory?.uuid || generateUUID();
-
-  categories.push({
-    uuid: otherCategoryUuid,
-    name: 'Other',
-    exit_uuid: otherExitUuid
-  });
-
-  exits.push({
-    uuid: otherExitUuid,
-    destination_uuid: existingOtherExit?.destination_uuid || null
-  });
-
-  return {
-    router: {
-      type: 'switch' as const,
-      cases: cases,
-      categories: categories,
-      default_category_uuid: otherCategoryUuid,
-      operand: '@(urn_parts(contact.urn).scheme)',
-      result_name: resultName
-    },
-    exits: exits
-  };
-};
+const getSchemeName = (scheme: string) =>
+  SCHEMES.find((s) => s.scheme === scheme)?.name || scheme;
 
 export const split_by_scheme: NodeConfig = {
   type: 'split_by_scheme',
@@ -127,9 +38,7 @@ export const split_by_scheme: NodeConfig = {
     result_name: resultNameField
   },
   layout: ['schemes', nodeOptionsAccordionSimple],
-  validate: (formData: FormData) => {
-    const errors: { [key: string]: string } = {};
-
+  validate: validateWith((formData, errors) => {
     if (
       !formData.schemes ||
       !Array.isArray(formData.schemes) ||
@@ -137,14 +46,8 @@ export const split_by_scheme: NodeConfig = {
     ) {
       errors.schemes = 'At least one channel type is required';
     }
-
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors
-    };
-  },
+  }),
   toFormData: (node: Node) => {
-    // Extract schemes from the existing node structure
     const schemes: string[] = [];
 
     if (node.router?.cases) {
@@ -157,43 +60,57 @@ export const split_by_scheme: NodeConfig = {
 
     return {
       uuid: node.uuid,
-      schemes: schemes.map((scheme) => {
-        const schemeObj = SCHEMES.find((s) => s.scheme === scheme);
-        return {
-          value: scheme,
-          name: schemeObj?.name || scheme
-        };
-      }),
+      schemes: schemes.map((scheme) => ({
+        value: scheme,
+        name: getSchemeName(scheme)
+      })),
       result_name: node.router?.result_name || ''
     };
   },
   fromFormData: (formData: FormData, originalNode: Node): Node => {
-    // Get selected schemes (handle both array of objects and array of strings)
     const selectedSchemes = (formData.schemes || [])
       .filter((scheme: any) => scheme)
       .map((scheme: any) =>
         typeof scheme === 'string' ? scheme : scheme.value
       );
 
-    // Create router and exits using existing data when possible
     const existingCategories = originalNode.router?.categories || [];
     const existingExits = originalNode.exits || [];
     const existingCases = originalNode.router?.cases || [];
 
-    const { router, exits } = createSchemeRouter(
-      selectedSchemes,
+    const { categories, exits, cases } = buildCategoriesExitsCases(
+      selectedSchemes.map((scheme) => ({
+        name: getSchemeName(scheme),
+        case: {
+          type: 'has_only_phrase',
+          arguments: [scheme]
+        }
+      })),
       existingCategories,
       existingExits,
-      existingCases,
-      formData.result_name || ''
+      existingCases
     );
 
-    // Return the complete node
+    const defaultCategoryUuid = appendOtherCategory(
+      categories,
+      exits,
+      existingCategories,
+      existingExits,
+      selectedSchemes.map(getSchemeName)
+    );
+
     return {
       uuid: originalNode.uuid,
       actions: originalNode.actions || [],
-      router: router,
-      exits: exits
+      router: {
+        type: 'switch',
+        cases,
+        categories,
+        default_category_uuid: defaultCategoryUuid,
+        operand: '@(urn_parts(contact.urn).scheme)',
+        result_name: formData.result_name || ''
+      },
+      exits
     };
   },
   router: {
@@ -202,7 +119,5 @@ export const split_by_scheme: NodeConfig = {
   },
 
   // Localization support for categories
-  localizable: 'categories',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  localizable: 'categories'
 };

--- a/src/flow/nodes/split_by_subflow.ts
+++ b/src/flow/nodes/split_by_subflow.ts
@@ -4,10 +4,6 @@ import { generateUUID } from '../../utils';
 import { html } from 'lit';
 import { renderFlowLinks } from '../utils';
 import { shouldExcludeFlow } from '../flow-utils';
-import {
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
-} from './shared';
 
 export const split_by_subflow: NodeConfig = {
   type: 'split_by_subflow',
@@ -293,7 +289,5 @@ export const split_by_subflow: NodeConfig = {
 
   // Localization support for categories
   localizable: 'categories',
-  nonTranslatableCategories: 'all',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  nonTranslatableCategories: 'all'
 };

--- a/src/flow/nodes/split_by_ticket.ts
+++ b/src/flow/nodes/split_by_ticket.ts
@@ -2,10 +2,6 @@ import { ACTION_GROUPS, FormData, NodeConfig, FlowTypes } from '../types';
 import { Node, OpenTicket } from '../../store/flow-definition';
 import { generateUUID, createSuccessFailureRouter } from '../../utils';
 import { html } from 'lit';
-import {
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
-} from './shared';
 
 export const split_by_ticket: NodeConfig = {
   type: 'split_by_ticket',
@@ -147,7 +143,5 @@ export const split_by_ticket: NodeConfig = {
 
   // Localization support for categories
   localizable: 'categories',
-  nonTranslatableCategories: 'all',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  nonTranslatableCategories: 'all'
 };

--- a/src/flow/nodes/split_by_webhook.ts
+++ b/src/flow/nodes/split_by_webhook.ts
@@ -2,11 +2,7 @@ import { ACTION_GROUPS, FormData, NodeConfig, FlowTypes } from '../types';
 import { CallWebhook, Node } from '../../store/flow-definition';
 import { generateUUID, createSuccessFailureRouter } from '../../utils';
 import { html } from 'lit';
-import {
-  resultNameField,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
-} from './shared';
+import { resultNameField } from './shared';
 import { renderClamped, renderHighlightedText } from '../utils';
 
 // Default headers as {key, value} arrays (format used by key-value editor)
@@ -267,7 +263,5 @@ export const split_by_webhook: NodeConfig = {
 
   // Localization support for categories
   localizable: 'categories',
-  nonTranslatableCategories: 'all',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  nonTranslatableCategories: 'all'
 };

--- a/src/flow/nodes/wait_for_audio.ts
+++ b/src/flow/nodes/wait_for_audio.ts
@@ -1,10 +1,6 @@
 import { SPLIT_GROUPS, FormData, NodeConfig, FlowTypes } from '../types';
 import { Node, Category, Exit } from '../../store/flow-definition';
 import { generateUUID } from '../../utils';
-import {
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
-} from './shared';
 
 export const wait_for_audio: NodeConfig = {
   type: 'wait_for_audio',
@@ -84,7 +80,5 @@ export const wait_for_audio: NodeConfig = {
     };
   },
   localizable: 'categories',
-  nonTranslatableCategories: 'all',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  nonTranslatableCategories: 'all'
 };

--- a/src/flow/nodes/wait_for_dial.ts
+++ b/src/flow/nodes/wait_for_dial.ts
@@ -1,11 +1,7 @@
 import { SPLIT_GROUPS, FormData, NodeConfig, FlowTypes } from '../types';
 import { Node, Category, Exit } from '../../store/flow-definition';
 import { generateUUID } from '../../utils';
-import {
-  resultNameField,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
-} from './shared';
+import { resultNameField } from './shared';
 
 const DIAL_CATEGORIES = ['Answered', 'No Answer', 'Busy', 'Failed'];
 const DIAL_CASES = [
@@ -171,7 +167,5 @@ export const wait_for_dial: NodeConfig = {
     };
   },
   localizable: 'categories',
-  nonTranslatableCategories: 'all',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  nonTranslatableCategories: 'all'
 };

--- a/src/flow/nodes/wait_for_digits.ts
+++ b/src/flow/nodes/wait_for_digits.ts
@@ -10,9 +10,7 @@ import {
   resultNameField,
   localizeRulesField,
   localizeCategoriesField,
-  nodeOptionsAccordion,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
+  nodeOptionsAccordion
 } from './shared';
 import {
   createRulesArrayConfig,
@@ -62,7 +60,9 @@ export const wait_for_digits: NodeConfig = {
   toUIConfig: (formData: FormData) => {
     const config: Record<string, any> = {};
     config.localizeRules = !!formData.localizeRules;
-    config.localizeCategories = formData.result_name ? !!formData.localizeCategories : false;
+    config.localizeCategories = formData.result_name
+      ? !!formData.localizeCategories
+      : false;
     return config;
   },
   fromFormData: (formData: FormData, originalNode: Node): Node => {
@@ -100,7 +100,5 @@ export const wait_for_digits: NodeConfig = {
       exits
     };
   },
-  localizable: 'categories',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  localizable: 'categories'
 };

--- a/src/flow/nodes/wait_for_menu.ts
+++ b/src/flow/nodes/wait_for_menu.ts
@@ -5,9 +5,7 @@ import {
   resultNameField,
   localizeRulesField,
   localizeCategoriesField,
-  nodeOptionsAccordion,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
+  nodeOptionsAccordion
 } from './shared';
 
 // Menu digits in display order: 1-9 then 0
@@ -105,7 +103,9 @@ export const wait_for_menu: NodeConfig = {
   toUIConfig: (formData: FormData) => {
     const config: Record<string, any> = {};
     config.localizeRules = !!formData.localizeRules;
-    config.localizeCategories = formData.result_name ? !!formData.localizeCategories : false;
+    config.localizeCategories = formData.result_name
+      ? !!formData.localizeCategories
+      : false;
     return config;
   },
   fromFormData: (formData: FormData, originalNode: Node): Node => {
@@ -221,7 +221,5 @@ export const wait_for_menu: NodeConfig = {
       exits
     };
   },
-  localizable: 'categories',
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  localizable: 'categories'
 };

--- a/src/flow/nodes/wait_for_response.ts
+++ b/src/flow/nodes/wait_for_response.ts
@@ -10,15 +10,14 @@ import {
   resultNameField,
   localizeRulesField,
   localizeCategoriesField,
-  nodeOptionsAccordion,
-  categoriesToLocalizationFormData,
-  localizationFormDataToCategories
+  nodeOptionsAccordion
 } from './shared';
 import {
   createRulesArrayConfig,
   extractUserRules,
   casesToFormRules
 } from './shared-rules';
+import { validateWith } from '../utils';
 
 const TIMEOUT_OPTIONS = [
   { value: '60', name: '1 minute' },
@@ -127,17 +126,10 @@ export const wait_for_response: NodeConfig = {
       gap: '0.5rem'
     }
   ],
-  validate: (_formData: FormData) => {
-    const errors: { [key: string]: string } = {};
-
-    // No validation needed - allow multiple rules to use same category name
-    // Rules with the same category name will be merged to use the same exit
-
-    return {
-      valid: Object.keys(errors).length === 0,
-      errors
-    };
-  },
+  validate: validateWith(() => {
+    // No validation needed - allow multiple rules to use same category name.
+    // Rules with the same category name will be merged to use the same exit.
+  }),
   toFormData: (node: Node, nodeUI?: any) => {
     // Extract rules from router cases using shared function
     const rules = casesToFormRules(node);
@@ -165,7 +157,9 @@ export const wait_for_response: NodeConfig = {
   toUIConfig: (formData: FormData) => {
     const config: Record<string, any> = {};
     config.localizeRules = !!formData.localizeRules;
-    config.localizeCategories = formData.result_name ? !!formData.localizeCategories : false;
+    config.localizeCategories = formData.result_name
+      ? !!formData.localizeCategories
+      : false;
     return config;
   },
   fromFormData: (formData: FormData, originalNode: Node): Node => {
@@ -413,7 +407,5 @@ export const wait_for_response: NodeConfig = {
 
   // Localization support for categories
   localizable: 'categories',
-  nonTranslatableCategories: ['Timeout'],
-  toLocalizationFormData: categoriesToLocalizationFormData,
-  fromLocalizationFormData: localizationFormDataToCategories
+  nonTranslatableCategories: ['Timeout']
 };

--- a/src/flow/utils.ts
+++ b/src/flow/utils.ts
@@ -5,6 +5,106 @@ import { CustomEventType } from '../interfaces';
 import { tokenize, TokenType } from '../excellent/tokenizer';
 import { TOKEN_COLORS } from '../excellent/token-styles';
 import { messageParser, sessionParser } from '../excellent/helpers';
+import { FormData, ValidationResult, NodeConfig, ActionConfig } from './types';
+import {
+  categoriesToLocalizationFormData,
+  localizationFormDataToCategories
+} from './nodes/shared';
+
+/**
+ * Wraps a validation check into the standard `validate` signature. The check
+ * populates an `errors` object; the wrapper computes `valid` and returns the
+ * ValidationResult. Eliminates the `const errors = {}; ...; return {valid, errors}`
+ * boilerplate that appears in every node and action config.
+ */
+export function validateWith(
+  check: (formData: FormData, errors: { [key: string]: string }) => void
+): (formData: FormData) => ValidationResult {
+  return (formData: FormData) => {
+    const errors: { [key: string]: string } = {};
+    check(formData, errors);
+    return { valid: Object.keys(errors).length === 0, errors };
+  };
+}
+
+function makeTextToLocalizationFormData(fields: readonly string[]) {
+  return (
+    action: { uuid: string },
+    localization: Record<string, any>
+  ): FormData => {
+    const formData: FormData = { uuid: action.uuid };
+    fields.forEach((field) => {
+      const value = localization[field];
+      formData[field] = Array.isArray(value) ? value[0] || '' : '';
+    });
+    return formData;
+  };
+}
+
+function makeTextFromLocalizationFormData(fields: readonly string[]) {
+  return (
+    formData: FormData,
+    action: Record<string, any>
+  ): Record<string, any> => {
+    const localization: Record<string, any> = {};
+    fields.forEach((field) => {
+      const value = formData[field];
+      if (value && value.trim() !== '' && value !== action[field]) {
+        localization[field] = [value];
+      }
+    });
+    return localization;
+  };
+}
+
+type ToLocalizationFn = (
+  nodeOrAction: any,
+  localization: Record<string, any>
+) => FormData;
+
+type FromLocalizationFn = (
+  formData: FormData,
+  nodeOrAction: any
+) => Record<string, any>;
+
+/**
+ * Returns the `toLocalizationFormData` impl for a node or action config. Uses
+ * the explicit impl if the config provides one; otherwise infers from the
+ * `localizable` shape: `'categories'` → category helper, `string[]` → text
+ * factory. Returns undefined if the config isn't localizable.
+ */
+export function resolveToLocalizationFormData(
+  config: NodeConfig | ActionConfig
+): ToLocalizationFn | undefined {
+  if (config.toLocalizationFormData) {
+    return config.toLocalizationFormData as ToLocalizationFn;
+  }
+  if (config.localizable === 'categories') {
+    return categoriesToLocalizationFormData;
+  }
+  if (Array.isArray(config.localizable)) {
+    return makeTextToLocalizationFormData(config.localizable);
+  }
+  return undefined;
+}
+
+/**
+ * Mirror of resolveToLocalizationFormData for `fromLocalizationFormData`.
+ */
+export function resolveFromLocalizationFormData(
+  config: NodeConfig | ActionConfig
+): FromLocalizationFn | undefined {
+  if (config.fromLocalizationFormData) {
+    return config.fromLocalizationFormData as FromLocalizationFn;
+  }
+  if (config.localizable === 'categories') {
+    return localizationFormDataToCategories;
+  }
+  if (Array.isArray(config.localizable)) {
+    return makeTextFromLocalizationFormData(config.localizable);
+  }
+  return undefined;
+}
 
 const languageNames = new Intl.DisplayNames(['en'], { type: 'language' });
 

--- a/test/actions/play_audio.test.ts
+++ b/test/actions/play_audio.test.ts
@@ -2,6 +2,10 @@ import { expect } from '@open-wc/testing';
 import { play_audio } from '../../src/flow/actions/play_audio';
 import { PlayAudio } from '../../src/store/flow-definition';
 import { ActionTest } from '../ActionHelper';
+import {
+  resolveToLocalizationFormData,
+  resolveFromLocalizationFormData
+} from '../../src/flow/utils';
 
 /**
  * Test suite for the play_audio action configuration.
@@ -99,7 +103,7 @@ describe('play_audio action config', () => {
         audio_url: ['@results.voicemail_es']
       };
 
-      const formData = play_audio.toLocalizationFormData!(action, localization);
+      const formData = resolveToLocalizationFormData(play_audio)!(action, localization);
       expect(formData.audio_url).to.equal('@results.voicemail_es');
     });
 
@@ -110,7 +114,7 @@ describe('play_audio action config', () => {
         audio_url: '@results.voicemail'
       };
 
-      const formData = play_audio.toLocalizationFormData!(action, {});
+      const formData = resolveToLocalizationFormData(play_audio)!(action, {});
       expect(formData.audio_url).to.equal('');
     });
 
@@ -126,7 +130,7 @@ describe('play_audio action config', () => {
         audio_url: '@results.voicemail_es'
       };
 
-      const localization = play_audio.fromLocalizationFormData!(
+      const localization = resolveFromLocalizationFormData(play_audio)!(
         formData,
         action
       );
@@ -145,7 +149,7 @@ describe('play_audio action config', () => {
         audio_url: '@results.voicemail' // same as original
       };
 
-      const localization = play_audio.fromLocalizationFormData!(
+      const localization = resolveFromLocalizationFormData(play_audio)!(
         formData,
         action
       );

--- a/test/actions/say_msg.test.ts
+++ b/test/actions/say_msg.test.ts
@@ -2,6 +2,10 @@ import { expect } from '@open-wc/testing';
 import { say_msg } from '../../src/flow/actions/say_msg';
 import { SayMsg } from '../../src/store/flow-definition';
 import { ActionTest } from '../ActionHelper';
+import {
+  resolveToLocalizationFormData,
+  resolveFromLocalizationFormData
+} from '../../src/flow/utils';
 
 /**
  * Test suite for the say_msg action configuration.
@@ -136,7 +140,7 @@ describe('say_msg action config', () => {
         audio_url: ['https://example.com/es.mp3']
       };
 
-      const formData = say_msg.toLocalizationFormData!(action, localization);
+      const formData = resolveToLocalizationFormData(say_msg)!(action, localization);
       expect(formData.text).to.equal('Hola');
       expect(formData.audio_url).to.equal('https://example.com/es.mp3');
     });
@@ -148,7 +152,7 @@ describe('say_msg action config', () => {
         text: 'Hello'
       } as SayMsg;
 
-      const formData = say_msg.toLocalizationFormData!(action, {});
+      const formData = resolveToLocalizationFormData(say_msg)!(action, {});
       expect(formData.text).to.equal('');
       expect(formData.audio_url).to.equal('');
     });
@@ -167,7 +171,7 @@ describe('say_msg action config', () => {
         audio_url: 'https://example.com/es.mp3'
       };
 
-      const localization = say_msg.fromLocalizationFormData!(formData, action);
+      const localization = resolveFromLocalizationFormData(say_msg)!(formData, action);
       expect(localization.text).to.deep.equal(['Hola']);
       expect(localization.audio_url).to.deep.equal([
         'https://example.com/es.mp3'
@@ -188,7 +192,7 @@ describe('say_msg action config', () => {
         audio_url: 'https://example.com/en.mp3' // same as original
       };
 
-      const localization = say_msg.fromLocalizationFormData!(formData, action);
+      const localization = resolveFromLocalizationFormData(say_msg)!(formData, action);
       expect(localization.text).to.be.undefined;
       expect(localization.audio_url).to.be.undefined;
     });


### PR DESCRIPTION
## Summary

Extracts three layers of duplication that had accumulated across router nodes and action configs:

- **Router construction helpers** (`buildCategoriesExitsCases`, `appendOtherCategory`) shared by `split_by_groups`, `split_by_random`, `split_by_scheme` — preserves UUID continuity across edits.
- **`validateWith` wrapper** that eliminates the `const errors = {}; ...; return { valid, errors }` boilerplate in every node and action validator (16 files).
- **`resolveToLocalizationFormData` / `resolveFromLocalizationFormData`** that infer localization impls from the `localizable` shape — 18 node configs and 3 text-only action configs no longer declare the pair explicitly. Custom impls in `send_msg` and `send_broadcast` still take precedence.

Net: 525 insertions, 763 deletions across 26 files.

## Test plan

- [x] `pnpm build` (TypeScript compiles clean)
- [x] `pnpm test:fast` — 1678 passed, 0 failed