### PR TITLE
Use RapidPro language names for ISO 639-3 codes not covered by Intl

### DIFF
--- a/src/flow/utils.ts
+++ b/src/flow/utils.ts
@@ -113,10 +113,9 @@ export function getLanguageDisplayName(code: string): string {
 
   // Prefer names from the RapidPro languages endpoint, which supplies
   // ISO 639-3 codes (e.g. prd, pst) that Intl.DisplayNames doesn't cover.
-  const storeNames = zustand.getState().languageNames;
-  const storeName = storeNames?.[code];
+  const storeName = zustand.getState().languageNames?.[code];
   if (storeName) {
-    return typeof storeName === 'string' ? storeName : storeName.name || code;
+    return storeName;
   }
 
   try {

--- a/src/flow/utils.ts
+++ b/src/flow/utils.ts
@@ -1,6 +1,6 @@
 import { html, TemplateResult } from 'lit-html';
 import { Action, NamedObject, FlowPosition } from '../store/flow-definition';
-import { FlowIssue } from '../store/AppState';
+import { FlowIssue, zustand } from '../store/AppState';
 import { CustomEventType } from '../interfaces';
 import { tokenize, TokenType } from '../excellent/tokenizer';
 import { TOKEN_COLORS } from '../excellent/token-styles';
@@ -106,12 +106,21 @@ export function resolveFromLocalizationFormData(
   return undefined;
 }
 
-const languageNames = new Intl.DisplayNames(['en'], { type: 'language' });
+const intlLanguageNames = new Intl.DisplayNames(['en'], { type: 'language' });
 
 export function getLanguageDisplayName(code: string): string {
   if (code === 'und') return 'Unknown';
+
+  // Prefer names from the RapidPro languages endpoint, which supplies
+  // ISO 639-3 codes (e.g. prd, pst) that Intl.DisplayNames doesn't cover.
+  const storeNames = zustand.getState().languageNames;
+  const storeName = storeNames?.[code];
+  if (storeName) {
+    return typeof storeName === 'string' ? storeName : storeName.name || code;
+  }
+
   try {
-    return languageNames.of(code) || code;
+    return intlLanguageNames.of(code) || code;
   } catch {
     return code;
   }

--- a/src/store/AppState.ts
+++ b/src/store/AppState.ts
@@ -192,7 +192,7 @@ export interface AppState {
   issuesByAction: Map<string, FlowIssue[]>;
 
   languageCode: string;
-  languageNames: { [code: string]: Language };
+  languageNames: { [code: string]: string };
   workspace: Workspace;
   isTranslating: boolean;
   viewingRevision: boolean;

--- a/test/temba-flow-utils.test.ts
+++ b/test/temba-flow-utils.test.ts
@@ -50,7 +50,7 @@ describe('shouldExcludeFlow', () => {
 
 describe('getLanguageDisplayName', () => {
   afterEach(() => {
-    zustand.setState({ ...zustand.getState(), languageNames: {} });
+    zustand.setState({ languageNames: {} });
   });
 
   it('returns "Unknown" for the "und" code', () => {
@@ -69,21 +69,14 @@ describe('getLanguageDisplayName', () => {
 
   it('uses names from the store for ISO 639-3 codes Intl does not cover', () => {
     zustand.setState({
-      ...zustand.getState(),
-      languageNames: {
-        prd: 'Parsi-Dari' as any,
-        pst: 'Central Pashto' as any
-      }
+      languageNames: { prd: 'Parsi-Dari', pst: 'Central Pashto' }
     });
     expect(getLanguageDisplayName('prd')).to.equal('Parsi-Dari');
     expect(getLanguageDisplayName('pst')).to.equal('Central Pashto');
   });
 
   it('prefers store names over Intl lookups', () => {
-    zustand.setState({
-      ...zustand.getState(),
-      languageNames: { eng: 'Anglais' as any }
-    });
+    zustand.setState({ languageNames: { eng: 'Anglais' } });
     expect(getLanguageDisplayName('eng')).to.equal('Anglais');
   });
 });

--- a/test/temba-flow-utils.test.ts
+++ b/test/temba-flow-utils.test.ts
@@ -49,6 +49,10 @@ describe('shouldExcludeFlow', () => {
 });
 
 describe('getLanguageDisplayName', () => {
+  afterEach(() => {
+    zustand.setState({ ...zustand.getState(), languageNames: {} });
+  });
+
   it('returns "Unknown" for the "und" code', () => {
     expect(getLanguageDisplayName('und')).to.equal('Unknown');
   });
@@ -61,5 +65,25 @@ describe('getLanguageDisplayName', () => {
     expect(getLanguageDisplayName('xx-invalid-code')).to.equal(
       'xx-invalid-code'
     );
+  });
+
+  it('uses names from the store for ISO 639-3 codes Intl does not cover', () => {
+    zustand.setState({
+      ...zustand.getState(),
+      languageNames: {
+        prd: 'Parsi-Dari' as any,
+        pst: 'Central Pashto' as any
+      }
+    });
+    expect(getLanguageDisplayName('prd')).to.equal('Parsi-Dari');
+    expect(getLanguageDisplayName('pst')).to.equal('Central Pashto');
+  });
+
+  it('prefers store names over Intl lookups', () => {
+    zustand.setState({
+      ...zustand.getState(),
+      languageNames: { eng: 'Anglais' as any }
+    });
+    expect(getLanguageDisplayName('eng')).to.equal('Anglais');
   });
 });


### PR DESCRIPTION
## Summary

RapidPro uses ISO 639-3 codes for languages, including ones like `prd` (Parsi-Dari) and `pst` (Central Pashto) that aren't covered by the browser's `Intl.DisplayNames` API, causing the language selector to show the raw code. `getLanguageDisplayName` now consults the authoritative names already fetched from the RapidPro `languagesEndpoint` (stored in `AppState.languageNames`) before falling back to `Intl.DisplayNames`, so these codes display with their proper names.

## Test plan

- [ ] Load a flow in a workspace with ISO 639-3 languages (e.g. `prd`, `pst`) and confirm the language selector shows names instead of codes
- [ ] Confirm common codes (e.g. `eng`, `fra`) still resolve correctly