### PR TITLE
Make canvas context menu shortcuts declarative per flow type

### DIFF
--- a/src/flow/CanvasMenu.ts
+++ b/src/flow/CanvasMenu.ts
@@ -6,11 +6,11 @@ import { ContextMenuShortcut } from './types';
 
 /**
  * Event detail for canvas menu selection. `action` is either one of the
- * built-in menu actions or the `type` of a configured shortcut (e.g.
- * 'send_msg', 'say_msg', 'set_contact_field').
+ * built-in menu actions ('sticky', 'other', 'reflow') or the `type` of a
+ * configured shortcut (e.g. 'send_msg', 'say_msg', 'set_contact_field').
  */
 export interface CanvasMenuSelection {
-  action: 'sticky' | 'other' | 'reflow' | string;
+  action: string;
   position: { x: number; y: number };
 }
 

--- a/src/flow/CanvasMenu.ts
+++ b/src/flow/CanvasMenu.ts
@@ -2,12 +2,15 @@ import { css, html, PropertyValueMap, TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { RapidElement } from '../RapidElement';
 import { CustomEventType } from '../interfaces';
+import { ContextMenuShortcut } from './types';
 
 /**
- * Event detail for canvas menu selection
+ * Event detail for canvas menu selection. `action` is either one of the
+ * built-in menu actions or the `type` of a configured shortcut (e.g.
+ * 'send_msg', 'say_msg', 'set_contact_field').
  */
 export interface CanvasMenuSelection {
-  action: 'sticky' | 'other' | 'send_msg' | 'wait_for_response' | 'reflow';
+  action: 'sticky' | 'other' | 'reflow' | string;
   position: { x: number; y: number };
 }
 
@@ -78,8 +81,8 @@ export class CanvasMenu extends RapidElement {
   @property({ type: Boolean })
   public showStickyNote = true;
 
-  @property({ type: Boolean })
-  public showWaitForResponse = true;
+  @property({ type: Array })
+  public shortcuts: ContextMenuShortcut[] = [];
 
   @property({ type: Boolean })
   public showReflow = false;
@@ -131,14 +134,14 @@ export class CanvasMenu extends RapidElement {
     clickPosition: { x: number; y: number },
     showStickyNote: boolean = true,
     showReflow: boolean = false,
-    showWaitForResponse: boolean = true
+    shortcuts: ContextMenuShortcut[] = []
   ) {
     this.x = x;
     this.y = y;
     this.clickPosition = clickPosition;
     this.showStickyNote = showStickyNote;
     this.showReflow = showReflow;
-    this.showWaitForResponse = showWaitForResponse;
+    this.shortcuts = shortcuts;
     this.open = true;
 
     // Adjust position after menu renders to ensure it fits on screen
@@ -202,25 +205,17 @@ export class CanvasMenu extends RapidElement {
 
     return html`
       <div class="menu" style="left: ${this.x}px; top: ${this.y}px;">
-        <div
-          class="menu-item"
-          @click=${() => this.handleMenuItemClick('send_msg')}
-        >
-          <temba-icon name="send" size="1.25"></temba-icon>
-          <div class="menu-item-title">Send Message</div>
-        </div>
-
-        ${this.showWaitForResponse
-          ? html`
-              <div
-                class="menu-item"
-                @click=${() => this.handleMenuItemClick('wait_for_response')}
-              >
-                <temba-icon name="message" size="1.25"></temba-icon>
-                <div class="menu-item-title">Wait for Response</div>
-              </div>
-            `
-          : ''}
+        ${this.shortcuts.map(
+          (shortcut) => html`
+            <div
+              class="menu-item"
+              @click=${() => this.handleMenuItemClick(shortcut.type)}
+            >
+              <temba-icon name="${shortcut.icon}" size="1.25"></temba-icon>
+              <div class="menu-item-title">${shortcut.name}</div>
+            </div>
+          `
+        )}
 
         <div
           class="menu-item"

--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -34,7 +34,11 @@ import { PRIMARY_LANGUAGE_OPTION_VALUE } from './EditorToolbar';
 import { calculateLayeredLayout, placeStickyNotes } from './reflow';
 import type { RevisionsWindow } from './RevisionsWindow';
 
-import { ACTION_GROUP_METADATA } from './types';
+import {
+  ACTION_GROUP_METADATA,
+  CONTEXT_MENU_SHORTCUTS,
+  FlowType
+} from './types';
 
 import {
   Plumber,
@@ -1360,7 +1364,7 @@ export class Editor extends RapidElement {
             },
             false, // Don't show sticky note option for connection drops
             false,
-            this.flowType === 'message'
+            CONTEXT_MENU_SHORTCUTS[this.flowType as FlowType] ?? []
           );
         }
       }
@@ -2193,7 +2197,8 @@ export class Editor extends RapidElement {
     search.definition = this.definition;
     search.languageCode = this.languageCode || '';
     search.scope = this.showMessageTable ? 'table' : 'flow';
-    search.includeCategories = this.isTranslating && this.hasAnyNodeWithLocalizeCategories();
+    search.includeCategories =
+      this.isTranslating && this.hasAnyNodeWithLocalizeCategories();
     search.show();
   }
 
@@ -2858,7 +2863,7 @@ export class Editor extends RapidElement {
         },
         true,
         hasNodes,
-        this.flowType === 'message'
+        CONTEXT_MENU_SHORTCUTS[this.flowType as FlowType] ?? []
       );
     }
   }
@@ -2887,7 +2892,7 @@ export class Editor extends RapidElement {
         { x: nodeLeft, y: nodeTop },
         false,
         false,
-        this.flowType === 'message'
+        CONTEXT_MENU_SHORTCUTS[this.flowType as FlowType] ?? []
       );
     }
   }
@@ -2920,19 +2925,6 @@ export class Editor extends RapidElement {
       this.connectionSourceX = null;
       this.connectionSourceY = null;
       this.dragFromNodeId = null;
-    } else if (
-      selection.action === 'send_msg' ||
-      selection.action === 'wait_for_response'
-    ) {
-      // Go directly to the node editor (skip node type selector)
-      this.handleNodeTypeSelection(
-        new CustomEvent(CustomEventType.Selection, {
-          detail: {
-            nodeType: selection.action,
-            position: selection.position
-          } as NodeTypeSelection
-        })
-      );
     } else if (selection.action === 'other') {
       // Show unified node type selector
       const selector = this.querySelector(
@@ -2943,6 +2935,17 @@ export class Editor extends RapidElement {
       }
       // Note: we don't clear pendingCanvasConnection or placeholder here,
       // they will be used in handleNodeTypeSelection
+    } else {
+      // Configured shortcut — go directly to the node editor with the
+      // action/node type carried in selection.action.
+      this.handleNodeTypeSelection(
+        new CustomEvent(CustomEventType.Selection, {
+          detail: {
+            nodeType: selection.action,
+            position: selection.position
+          } as NodeTypeSelection
+        })
+      );
     }
   }
 
@@ -3855,9 +3858,7 @@ export class Editor extends RapidElement {
 
     this.focusNode(issue.node_uuid);
 
-    const node = this.definition.nodes.find(
-      (n) => n.uuid === issue.node_uuid
-    );
+    const node = this.definition.nodes.find((n) => n.uuid === issue.node_uuid);
     if (!node) return;
 
     if (issue.action_uuid) {
@@ -3962,7 +3963,8 @@ export class Editor extends RapidElement {
         ?zoom-fitted=${this.zoomManager.isZoomFitted}
         ?revisions-active=${!this.revisionsWindowHidden}
         ?is-saving=${this.isSaving}
-        ?search-disabled=${this.getRevisionsWindow()?.isViewingRevision ?? false}
+        ?search-disabled=${this.getRevisionsWindow()?.isViewingRevision ??
+        false}
         .languageOptions=${languageOptions}
         current-language-name=${currentLanguage.name}
         ?is-base-language=${isBaseSelected}
@@ -4219,9 +4221,7 @@ export class Editor extends RapidElement {
                     : ''}
                 <div
                   id="grid"
-                  class="${this.viewingRevision
-                    ? 'viewing-revision'
-                    : ''}"
+                  class="${this.viewingRevision ? 'viewing-revision' : ''}"
                   style="min-width:${100 / this.zoom}%;min-height:${100 /
                   this.zoom}%;width:${this.canvasSize.width}px; height:${this
                     .canvasSize.height}px;transform:scale(${this.zoom})"
@@ -4229,11 +4229,9 @@ export class Editor extends RapidElement {
                   <div
                     id="canvas"
                     class="${getClasses({
-                      'viewing-revision':
-                        this.viewingRevision,
+                      'viewing-revision': this.viewingRevision,
                       'read-only-connections':
-                        this.viewingRevision ||
-                        this.isTranslating
+                        this.viewingRevision || this.isTranslating
                     })}"
                   >
                     ${this.definition && !hasCorruptedUI
@@ -4354,7 +4352,8 @@ export class Editor extends RapidElement {
         : ''}
       <temba-flow-search
         .scope=${this.showMessageTable ? 'table' : 'flow'}
-        .includeCategories=${this.isTranslating && this.hasAnyNodeWithLocalizeCategories()}
+        .includeCategories=${this.isTranslating &&
+        this.hasAnyNodeWithLocalizeCategories()}
         @temba-search-result-selected=${this.handleSearchResultSelected}
       ></temba-flow-search>
       ${!this.showMessageTable && this.flowIssues?.length

--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -37,7 +37,8 @@ import type { RevisionsWindow } from './RevisionsWindow';
 import {
   ACTION_GROUP_METADATA,
   CONTEXT_MENU_SHORTCUTS,
-  FlowType
+  FlowType,
+  FlowTypes
 } from './types';
 
 import {
@@ -205,7 +206,7 @@ export class Editor extends RapidElement {
   public version: string;
 
   @property({ type: String })
-  public flowType: string = 'message';
+  public flowType: FlowType = FlowTypes.MESSAGE;
 
   @property({ type: Array })
   public features: string[] = [];
@@ -1364,7 +1365,7 @@ export class Editor extends RapidElement {
             },
             false, // Don't show sticky note option for connection drops
             false,
-            CONTEXT_MENU_SHORTCUTS[this.flowType as FlowType] ?? []
+            CONTEXT_MENU_SHORTCUTS[this.flowType]
           );
         }
       }
@@ -1541,17 +1542,17 @@ export class Editor extends RapidElement {
    * FlowDefinition uses: 'messaging', 'messaging_background', 'messaging_offline', 'voice'
    * Editor uses: 'message', 'voice', 'background'
    */
-  private getFlowTypeFromDefinition(definitionType: string): string {
+  private getFlowTypeFromDefinition(definitionType: string): FlowType {
     if (definitionType === 'voice') {
-      return 'voice';
+      return FlowTypes.VOICE;
     } else if (
       definitionType === 'messaging_background' ||
       definitionType === 'messaging_offline'
     ) {
-      return 'background';
+      return FlowTypes.BACKGROUND;
     } else {
       // 'messaging' or any other messaging type defaults to 'message'
-      return 'message';
+      return FlowTypes.MESSAGE;
     }
   }
 
@@ -2863,7 +2864,7 @@ export class Editor extends RapidElement {
         },
         true,
         hasNodes,
-        CONTEXT_MENU_SHORTCUTS[this.flowType as FlowType] ?? []
+        CONTEXT_MENU_SHORTCUTS[this.flowType]
       );
     }
   }
@@ -2892,7 +2893,7 @@ export class Editor extends RapidElement {
         { x: nodeLeft, y: nodeTop },
         false,
         false,
-        CONTEXT_MENU_SHORTCUTS[this.flowType as FlowType] ?? []
+        CONTEXT_MENU_SHORTCUTS[this.flowType]
       );
     }
   }

--- a/src/flow/types.ts
+++ b/src/flow/types.ts
@@ -18,6 +18,33 @@ export const FlowTypes = {
 export type FlowType = (typeof FlowTypes)[keyof typeof FlowTypes];
 
 /**
+ * Shortcut entry shown in the canvas context menu. The `type` is the
+ * action or node type to open the editor with when selected.
+ */
+export interface ContextMenuShortcut {
+  type: string;
+  name: string;
+  icon: string;
+}
+
+/**
+ * Per-flow-type context menu shortcuts.
+ */
+export const CONTEXT_MENU_SHORTCUTS: Record<FlowType, ContextMenuShortcut[]> = {
+  [FlowTypes.MESSAGE]: [
+    { type: 'send_msg', name: 'Send Message', icon: 'send' },
+    { type: 'wait_for_response', name: 'Wait for Response', icon: 'message' }
+  ],
+  [FlowTypes.VOICE]: [
+    { type: 'say_msg', name: 'Say Message', icon: 'send' },
+    { type: 'wait_for_menu', name: 'Wait for Menu', icon: 'dots-grid' }
+  ],
+  [FlowTypes.BACKGROUND]: [
+    { type: 'set_contact_field', name: 'Update Contact', icon: 'contact' }
+  ]
+};
+
+/**
  * Features - defines the features available in the account
  */
 export const Features = {

--- a/test/temba-canvas-menu.test.ts
+++ b/test/temba-canvas-menu.test.ts
@@ -1,8 +1,13 @@
 import { expect, assert } from '@open-wc/testing';
 import { CanvasMenu } from '../src/flow/CanvasMenu';
+import { CONTEXT_MENU_SHORTCUTS, FlowTypes } from '../src/flow/types';
 import { assertScreenshot, getClip, getComponent } from './utils.test';
 
 describe('temba-canvas-menu', () => {
+  const messageShortcuts = CONTEXT_MENU_SHORTCUTS[FlowTypes.MESSAGE];
+  const voiceShortcuts = CONTEXT_MENU_SHORTCUTS[FlowTypes.VOICE];
+  const backgroundShortcuts = CONTEXT_MENU_SHORTCUTS[FlowTypes.BACKGROUND];
+
   const createCanvasMenu = async () => {
     const component = (await getComponent(
       'temba-canvas-menu',
@@ -33,8 +38,8 @@ describe('temba-canvas-menu', () => {
   it('shows menu when opened', async () => {
     const menu = await createCanvasMenu();
 
-    // open the menu
-    menu.show(100, 100, { x: 50, y: 50 });
+    // open the menu with messaging shortcuts
+    menu.show(100, 100, { x: 50, y: 50 }, true, false, messageShortcuts);
     await menu.updateComplete;
 
     expect(menu.open).to.be.true;
@@ -48,15 +53,14 @@ describe('temba-canvas-menu', () => {
     await assertScreenshot('canvas-menu/open', getClip(menu));
   });
 
-  it('has four menu items', async () => {
+  it('shows messaging shortcuts for messaging flows', async () => {
     const menu = await createCanvasMenu();
-    menu.show(100, 100, { x: 50, y: 50 });
+    menu.show(100, 100, { x: 50, y: 50 }, true, false, messageShortcuts);
     await menu.updateComplete;
 
     const menuItems = menu.shadowRoot?.querySelectorAll('.menu-item');
     expect(menuItems?.length).to.equal(4);
 
-    // check menu item titles
     const titles = Array.from(menuItems || []).map(
       (item) => item.querySelector('.menu-item-title')?.textContent
     );
@@ -68,9 +72,40 @@ describe('temba-canvas-menu', () => {
     ]);
   });
 
+  it('shows voice shortcuts for voice flows', async () => {
+    const menu = await createCanvasMenu();
+    menu.show(100, 100, { x: 50, y: 50 }, true, false, voiceShortcuts);
+    await menu.updateComplete;
+
+    const titles = Array.from(
+      menu.shadowRoot?.querySelectorAll('.menu-item-title') || []
+    ).map((item) => item.textContent);
+    expect(titles).to.deep.equal([
+      'Say Message',
+      'Wait for Menu',
+      'Add Other',
+      'Add Sticky Note'
+    ]);
+  });
+
+  it('shows background shortcuts for background flows', async () => {
+    const menu = await createCanvasMenu();
+    menu.show(100, 100, { x: 50, y: 50 }, true, false, backgroundShortcuts);
+    await menu.updateComplete;
+
+    const titles = Array.from(
+      menu.shadowRoot?.querySelectorAll('.menu-item-title') || []
+    ).map((item) => item.textContent);
+    expect(titles).to.deep.equal([
+      'Update Contact',
+      'Add Other',
+      'Add Sticky Note'
+    ]);
+  });
+
   it('closes when close() is called', async () => {
     const menu = await createCanvasMenu();
-    menu.show(100, 100, { x: 50, y: 50 });
+    menu.show(100, 100, { x: 50, y: 50 }, true, false, messageShortcuts);
     await menu.updateComplete;
 
     expect(menu.open).to.be.true;
@@ -83,7 +118,7 @@ describe('temba-canvas-menu', () => {
 
   it('fires selection event when menu item is clicked', async () => {
     const menu = await createCanvasMenu();
-    menu.show(100, 100, { x: 50, y: 50 });
+    menu.show(100, 100, { x: 50, y: 50 }, true, false, messageShortcuts);
     await menu.updateComplete;
 
     let selectionFired = false;
@@ -108,9 +143,31 @@ describe('temba-canvas-menu', () => {
     expect(menu.open).to.be.false;
   });
 
+  it('fires shortcut selection carrying the shortcut type', async () => {
+    const menu = await createCanvasMenu();
+    menu.show(100, 100, { x: 50, y: 50 }, true, false, voiceShortcuts);
+    await menu.updateComplete;
+
+    let selectionDetail: any = null;
+    menu.addEventListener('temba-selection', (event: any) => {
+      selectionDetail = event.detail;
+    });
+
+    const firstShortcut = menu.shadowRoot?.querySelectorAll(
+      '.menu-item'
+    )?.[0] as HTMLElement;
+    firstShortcut.click();
+    await menu.updateComplete;
+
+    expect(selectionDetail).to.deep.equal({
+      action: 'say_msg',
+      position: { x: 50, y: 50 }
+    });
+  });
+
   it('shows reflow option when showReflow is true', async () => {
     const menu = await createCanvasMenu();
-    menu.show(100, 100, { x: 50, y: 50 }, true, true);
+    menu.show(100, 100, { x: 50, y: 50 }, true, true, messageShortcuts);
     await menu.updateComplete;
 
     const menuItems = menu.shadowRoot?.querySelectorAll('.menu-item');
@@ -130,7 +187,7 @@ describe('temba-canvas-menu', () => {
 
   it('fires reflow selection event when reflow is clicked', async () => {
     const menu = await createCanvasMenu();
-    menu.show(100, 100, { x: 50, y: 50 }, true, true);
+    menu.show(100, 100, { x: 50, y: 50 }, true, true, messageShortcuts);
     await menu.updateComplete;
 
     let selectionDetail = null;
@@ -152,7 +209,7 @@ describe('temba-canvas-menu', () => {
 
   it('hides reflow option by default', async () => {
     const menu = await createCanvasMenu();
-    menu.show(100, 100, { x: 50, y: 50 });
+    menu.show(100, 100, { x: 50, y: 50 }, true, false, messageShortcuts);
     await menu.updateComplete;
 
     const menuItems = menu.shadowRoot?.querySelectorAll('.menu-item');
@@ -173,10 +230,14 @@ describe('temba-canvas-menu', () => {
     const margin = 10; // matches the margin in CanvasMenu
 
     // position that would go off the right and bottom edges
-    menu.show(viewportWidth - 50, viewportHeight - 50, {
-      x: 100,
-      y: 100
-    });
+    menu.show(
+      viewportWidth - 50,
+      viewportHeight - 50,
+      { x: 100, y: 100 },
+      true,
+      false,
+      messageShortcuts
+    );
     await menu.updateComplete;
 
     // wait for position adjustment


### PR DESCRIPTION
## Summary

- Canvas context menu shortcuts are now declared in `CONTEXT_MENU_SHORTCUTS` (src/flow/types.ts), keyed by `FlowType`.
- Voice flows show **Say Message** and **Wait for Menu**; background flows show **Update Contact**; messaging flows keep **Send Message** and **Wait for Response**.
- `CanvasMenu` now takes a `shortcuts` array and renders entries generically, so adding a shortcut for a flow type is a one-line config change.
- Editor routes any non-builtin shortcut action through `handleNodeTypeSelection`, so new shortcut types work without further wiring.

## Test plan

- [x] Open a messaging flow and verify the context menu shows Send Message / Wait for Response
- [x] Open a voice (IVR) flow and verify the context menu shows Say Message / Wait for Menu (with keypad icon)
- [x] Open a background flow and verify the context menu shows Update Contact
- [x] Selecting each shortcut opens the correct node editor