### PR TITLE
Hide language selector dropdown for empty flows

### DIFF
--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -3934,25 +3934,28 @@ export class Editor extends RapidElement {
     const percent = Math.round(
       (progress.localized / Math.max(progress.total, 1)) * 100
     );
-    const languageOptions = [
-      {
-        name: baseLanguageName,
-        value: PRIMARY_LANGUAGE_OPTION_VALUE
-      },
-      ...languages.map((lang) => {
-        const localizationProgress = this.getLocalizationProgress(lang.code);
-        const localizationPercent = Math.round(
-          (localizationProgress.localized /
-            Math.max(localizationProgress.total, 1)) *
-            100
-        );
-        return {
-          name: lang.name,
-          value: lang.code,
-          percent: localizationPercent
-        };
-      })
-    ];
+    const isEmptyFlow = !this.definition || this.definition.nodes.length === 0;
+    const languageOptions = isEmptyFlow
+      ? []
+      : [
+          {
+            name: baseLanguageName,
+            value: PRIMARY_LANGUAGE_OPTION_VALUE
+          },
+          ...languages.map((lang) => {
+            const localizationProgress = this.getLocalizationProgress(lang.code);
+            const localizationPercent = Math.round(
+              (localizationProgress.localized /
+                Math.max(localizationProgress.total, 1)) *
+                100
+            );
+            return {
+              name: lang.name,
+              value: lang.code,
+              percent: localizationPercent
+            };
+          })
+        ];
 
     return html`
       <temba-editor-toolbar

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -185,6 +185,44 @@ describe('Localization Editing', () => {
     expect(languageBtn).to.exist;
   });
 
+  it('should hide language controls when flow has no nodes', async () => {
+    editor?.remove();
+
+    setupWorkspace();
+
+    const emptyFlowDefinition: FlowDefinition = {
+      uuid: 'empty-flow',
+      name: 'Empty Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {},
+      nodes: [],
+      _ui: {
+        nodes: {},
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: emptyFlowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 0, languages: 0 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    await editor.updateComplete;
+
+    const toolbar = await getToolbar(editor);
+    const languageBtn = toolbar.shadowRoot.querySelector('#language-btn');
+    expect(languageBtn).to.be.null;
+  });
+
   it('should show language options with non-base languages', async () => {
     const toolbar = await getToolbar(editor);
     // Open language dropdown


### PR DESCRIPTION
## Summary
- When a flow has no nodes, the language selector dropdown in the editor toolbar is now hidden. Previously it could appear for brand-new/empty flows with multiple workspace languages configured, even though there was nothing to translate.
- Implemented by passing an empty `languageOptions` array to `<temba-editor-toolbar>` when the flow is empty; the toolbar already hides the control when fewer than two options are present.

## Test plan
- [x] Open an empty flow in a workspace with multiple languages — language pill should not appear
- [x] Open a non-empty flow — language pill appears and functions as before