### PR TITLE
Apply code formatting

### DIFF
--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -862,7 +862,12 @@ export class Chat extends RapidElement {
 
         // show notification if new messages are appended and user is scrolled away from bottom
         // but not during search (searchHighlight is set)
-        if (append && isScrolledAway && newMessages.length > 0 && !this.searchHighlight) {
+        if (
+          append &&
+          isScrolledAway &&
+          newMessages.length > 0 &&
+          !this.searchHighlight
+        ) {
           this.showNewMessageNotification = true;
         }
 
@@ -1123,10 +1128,7 @@ export class Chat extends RapidElement {
     }, 150);
   }
 
-  private highlightText(
-    text: string,
-    search: string
-  ): TemplateResult | string {
+  private highlightText(text: string, search: string): TemplateResult | string {
     if (!search || !text) {
       return text;
     }
@@ -1245,9 +1247,7 @@ export class Chat extends RapidElement {
               const latestClass = index === msgIds.length - 1 ? 'latest' : '';
               const eventClass = msg._rendered ? 'is-event' : '';
               const matchClass =
-                this.highlightMessageUuid === msg.uuid
-                  ? 'search-match'
-                  : '';
+                this.highlightMessageUuid === msg.uuid ? 'search-match' : '';
               return html`<div
                 class="row message ${statusClass} ${unsendableClass} ${deletedClass} ${latestClass} ${eventClass} ${matchClass}"
                 data-uuid=${msg.uuid || nothing}

--- a/src/display/FloatingTab.ts
+++ b/src/display/FloatingTab.ts
@@ -28,8 +28,8 @@ export class FloatingTab extends RapidElement {
         border-bottom-left-radius: 8px;
         cursor: pointer;
         box-shadow: -2px 2px 8px rgba(0, 0, 0, 0.2);
-        transition:
-          transform calc(var(--transition-duration, 300ms) * 0.7) ease-in-out;
+        transition: transform calc(var(--transition-duration, 300ms) * 0.7)
+          ease-in-out;
         user-select: none;
       }
 

--- a/src/display/Options.ts
+++ b/src/display/Options.ts
@@ -170,12 +170,18 @@ export class Options extends RapidElement {
       }
 
       .option:hover {
-        background: var(--temba-options-option-hover-bg, var(--option-hover-bg));
+        background: var(
+          --temba-options-option-hover-bg,
+          var(--option-hover-bg)
+        );
         color: var(--temba-options-option-hover-text, var(--option-hover-text));
       }
 
       .option.focused {
-        background: var(--temba-options-option-focus-bg, var(--color-selection));
+        background: var(
+          --temba-options-option-focus-bg,
+          var(--color-selection)
+        );
         color: var(--temba-options-option-focus-text, var(--color-text-dark));
       }
 

--- a/src/flow/CanvasNode.ts
+++ b/src/flow/CanvasNode.ts
@@ -1622,9 +1622,7 @@ export class CanvasNode extends RapidElement {
 
     // IMPORTANT: Add the action to this node FIRST, before removing from source
     // This ensures we don't lose the action if the source node gets deleted
-    const droppedAction = isCopy
-      ? { ...action, uuid: generateUUID() }
-      : action;
+    const droppedAction = isCopy ? { ...action, uuid: generateUUID() } : action;
     const newActions = [...this.node.actions];
     newActions.splice(dropIndex, 0, droppedAction);
 
@@ -1638,11 +1636,13 @@ export class CanvasNode extends RapidElement {
         for (const langCode of Object.keys(localization)) {
           const entry = localization[langCode]?.[action.uuid];
           if (entry) {
-            store.getState().updateLocalization(
-              langCode,
-              droppedAction.uuid,
-              JSON.parse(JSON.stringify(entry))
-            );
+            store
+              .getState()
+              .updateLocalization(
+                langCode,
+                droppedAction.uuid,
+                JSON.parse(JSON.stringify(entry))
+              );
           }
         }
       }
@@ -1915,9 +1915,10 @@ export class CanvasNode extends RapidElement {
     const nodeConfig = NODE_CONFIG[this.ui?.type];
     const supportsLocalization = nodeConfig?.localizable === 'categories';
     const translatableCategoryUuids = new Set(
-      getTranslatableCategoriesForNode(this.ui?.type, node.router.categories).map(
-        (category) => category.uuid
-      )
+      getTranslatableCategoriesForNode(
+        this.ui?.type,
+        node.router.categories
+      ).map((category) => category.uuid)
     );
 
     return html`<div class="categories">
@@ -2010,7 +2011,10 @@ export class CanvasNode extends RapidElement {
     // currently hidden by the categories toggle.
     const hasTranslatableCategories =
       nodeConfig?.localizable === 'categories' &&
-      hasTranslatableCategoriesForNode(this.ui.type, this.node.router?.categories);
+      hasTranslatableCategoriesForNode(
+        this.ui.type,
+        this.node.router?.categories
+      );
     const hasTranslatableActions = (this.node.actions || []).some((action) => {
       const actionConfig = ACTION_CONFIG[action.type];
       return !!actionConfig?.localizable?.length;

--- a/src/flow/DragManager.ts
+++ b/src/flow/DragManager.ts
@@ -138,7 +138,11 @@ export class DragManager {
     const position = this.getPosition(uuid, type);
     if (!position) return;
 
-    if (!this.editor.selectedItems.has(uuid) && !event.ctrlKey && !event.metaKey) {
+    if (
+      !this.editor.selectedItems.has(uuid) &&
+      !event.ctrlKey &&
+      !event.metaKey
+    ) {
       this.editor.selectedItems.clear();
     } else if (!this.editor.selectedItems.has(uuid)) {
       this.editor.selectedItems.add(uuid);
@@ -215,7 +219,9 @@ export class DragManager {
   private handleGlobalMouseDown(event: MouseEvent): void {
     if (isRightClick(event)) return;
 
-    const canvasRect = this.editor.querySelector('#grid')?.getBoundingClientRect();
+    const canvasRect = this.editor
+      .querySelector('#grid')
+      ?.getBoundingClientRect();
     if (!canvasRect) return;
 
     const isWithinCanvas =
@@ -258,7 +264,9 @@ export class DragManager {
       this.canvasMouseDown = true;
       this.dragStartPos = { x: event.clientX, y: event.clientY };
 
-      const canvasRect = this.editor.querySelector('#canvas')?.getBoundingClientRect();
+      const canvasRect = this.editor
+        .querySelector('#canvas')
+        ?.getBoundingClientRect();
       if (canvasRect) {
         this.editor.selectedItems.clear();
 
@@ -348,7 +356,9 @@ export class DragManager {
   private updateSelectionBox(event: MouseEvent): void {
     if (!this.editor.selectionBox || !this.canvasMouseDown) return;
 
-    const canvasRect = this.editor.querySelector('#canvas')?.getBoundingClientRect();
+    const canvasRect = this.editor
+      .querySelector('#canvas')
+      ?.getBoundingClientRect();
     if (!canvasRect) return;
 
     const relativeX = (event.clientX - canvasRect.left) / this.editor.zoom;
@@ -368,9 +378,18 @@ export class DragManager {
 
     const newSelection = new Set<string>();
 
-    const boxLeft = Math.min(this.editor.selectionBox.startX, this.editor.selectionBox.endX);
-    const boxTop = Math.min(this.editor.selectionBox.startY, this.editor.selectionBox.endY);
-    const boxRight = Math.max(this.editor.selectionBox.startX, this.editor.selectionBox.endX);
+    const boxLeft = Math.min(
+      this.editor.selectionBox.startX,
+      this.editor.selectionBox.endX
+    );
+    const boxTop = Math.min(
+      this.editor.selectionBox.startY,
+      this.editor.selectionBox.endY
+    );
+    const boxRight = Math.max(
+      this.editor.selectionBox.startX,
+      this.editor.selectionBox.endX
+    );
     const boxBottom = Math.max(
       this.editor.selectionBox.startY,
       this.editor.selectionBox.endY
@@ -384,8 +403,9 @@ export class DragManager {
       if (nodeElement) {
         const position = this.editor.definition._ui?.nodes[node.uuid]?.position;
         if (position) {
-          const canvasRect =
-            this.editor.querySelector('#canvas')?.getBoundingClientRect();
+          const canvasRect = this.editor
+            .querySelector('#canvas')
+            ?.getBoundingClientRect();
 
           if (canvasRect) {
             const nodeLeft = position.left;
@@ -441,10 +461,20 @@ export class DragManager {
   public renderSelectionBox(): TemplateResult | string {
     if (!this.editor.selectionBox || !this.editor.isSelecting) return '';
 
-    const left = Math.min(this.editor.selectionBox.startX, this.editor.selectionBox.endX);
-    const top = Math.min(this.editor.selectionBox.startY, this.editor.selectionBox.endY);
-    const width = Math.abs(this.editor.selectionBox.endX - this.editor.selectionBox.startX);
-    const height = Math.abs(this.editor.selectionBox.endY - this.editor.selectionBox.startY);
+    const left = Math.min(
+      this.editor.selectionBox.startX,
+      this.editor.selectionBox.endX
+    );
+    const top = Math.min(
+      this.editor.selectionBox.startY,
+      this.editor.selectionBox.endY
+    );
+    const width = Math.abs(
+      this.editor.selectionBox.endX - this.editor.selectionBox.startX
+    );
+    const height = Math.abs(
+      this.editor.selectionBox.endY - this.editor.selectionBox.startY
+    );
 
     return html`<div
       class="selection-box"
@@ -484,7 +514,9 @@ export class DragManager {
     this.canvasMouseDown = true;
     this.dragStartPos = { x: touch.clientX, y: touch.clientY };
 
-    const canvasRect = this.editor.querySelector('#canvas')?.getBoundingClientRect();
+    const canvasRect = this.editor
+      .querySelector('#canvas')
+      ?.getBoundingClientRect();
     if (canvasRect) {
       this.editor.selectedItems.clear();
 
@@ -529,7 +561,8 @@ export class DragManager {
 
       if (targetNode) {
         this.editor.targetId = targetNode.getAttribute('uuid');
-        this.editor.isValidTarget = this.editor.targetId !== this.editor.dragFromNodeId;
+        this.editor.isValidTarget =
+          this.editor.targetId !== this.editor.dragFromNodeId;
 
         if (this.editor.isValidTarget) {
           targetNode.classList.add('connection-target-valid');
@@ -545,7 +578,8 @@ export class DragManager {
         const canvas = this.editor.querySelector('#canvas');
         if (canvas) {
           const canvasRect = canvas.getBoundingClientRect();
-          const relativeX = (event.clientX - canvasRect.left) / this.editor.zoom;
+          const relativeX =
+            (event.clientX - canvasRect.left) / this.editor.zoom;
           const relativeY = (event.clientY - canvasRect.top) / this.editor.zoom;
 
           const placeholderWidth = 200;
@@ -630,9 +664,10 @@ export class DragManager {
     this.currentDragIsCopy = true;
 
     for (const uuid of itemsToCopy) {
-      const element = this.editor.querySelector(`[uuid="${uuid}"]`) as HTMLElement;
-      const type =
-        element?.tagName === 'TEMBA-FLOW-NODE' ? 'node' : 'sticky';
+      const element = this.editor.querySelector(
+        `[uuid="${uuid}"]`
+      ) as HTMLElement;
+      const type = element?.tagName === 'TEMBA-FLOW-NODE' ? 'node' : 'sticky';
       const position = this.getPosition(uuid, type);
       if (element && position) {
         element.style.left = `${position.left}px`;
@@ -641,7 +676,9 @@ export class DragManager {
     }
     this.editor.plumber.revalidate(itemsToCopy);
     for (const uuid of itemsToCopy) {
-      const element = this.editor.querySelector(`[uuid="${uuid}"]`) as HTMLElement;
+      const element = this.editor.querySelector(
+        `[uuid="${uuid}"]`
+      ) as HTMLElement;
       if (element) {
         void element.offsetHeight;
         element.classList.remove('dragging');
@@ -724,7 +761,9 @@ export class DragManager {
         : [this.editor.currentDragItem.uuid];
 
     itemsToMove.forEach((uuid) => {
-      const element = this.editor.querySelector(`[uuid="${uuid}"]`) as HTMLElement;
+      const element = this.editor.querySelector(
+        `[uuid="${uuid}"]`
+      ) as HTMLElement;
       if (element) {
         const type = element.tagName === 'TEMBA-FLOW-NODE' ? 'node' : 'sticky';
         const position = this.getPosition(uuid, type);
@@ -814,9 +853,11 @@ export class DragManager {
 
         if (scrollDx > 0 || scrollDy > 0) {
           const neededWidth =
-            (editorEl.scrollLeft + editorEl.clientWidth + scrollDx) / this.editor.zoom;
+            (editorEl.scrollLeft + editorEl.clientWidth + scrollDx) /
+            this.editor.zoom;
           const neededHeight =
-            (editorEl.scrollTop + editorEl.clientHeight + scrollDy) / this.editor.zoom;
+            (editorEl.scrollTop + editorEl.clientHeight + scrollDy) /
+            this.editor.zoom;
           getStore()?.getState()?.expandCanvas(neededWidth, neededHeight);
         }
 
@@ -884,7 +925,9 @@ export class DragManager {
       const newPositions: { [uuid: string]: FlowPosition } = {};
 
       itemsToMove.forEach((uuid) => {
-        const type = this.editor.definition.nodes.find((node) => node.uuid === uuid)
+        const type = this.editor.definition.nodes.find(
+          (node) => node.uuid === uuid
+        )
           ? 'node'
           : 'sticky';
         const position = this.getPosition(uuid, type);
@@ -899,7 +942,9 @@ export class DragManager {
           const newPosition = { left: snappedLeft, top: snappedTop };
           newPositions[uuid] = newPosition;
 
-          const element = this.editor.querySelector(`[uuid="${uuid}"]`) as HTMLElement;
+          const element = this.editor.querySelector(
+            `[uuid="${uuid}"]`
+          ) as HTMLElement;
           if (element) {
             element.classList.remove('dragging', 'drag-copy');
             element.style.left = `${snappedLeft}px`;
@@ -983,7 +1028,9 @@ export class DragManager {
       event.preventDefault();
       this.editor.isSelecting = true;
 
-      const canvasRect = this.editor.querySelector('#canvas')?.getBoundingClientRect();
+      const canvasRect = this.editor
+        .querySelector('#canvas')
+        ?.getBoundingClientRect();
       if (canvasRect && this.editor.selectionBox) {
         this.editor.selectionBox = {
           ...this.editor.selectionBox,
@@ -1001,7 +1048,10 @@ export class DragManager {
     if (this.editor.plumber.connectionDragging) {
       event.preventDefault();
 
-      const targetNode = this.editor.findTargetNodeAt(touch.clientX, touch.clientY);
+      const targetNode = this.editor.findTargetNodeAt(
+        touch.clientX,
+        touch.clientY
+      );
 
       document.querySelectorAll('temba-flow-node').forEach((node) => {
         node.classList.remove(
@@ -1012,7 +1062,8 @@ export class DragManager {
 
       if (targetNode) {
         this.editor.targetId = targetNode.getAttribute('uuid');
-        this.editor.isValidTarget = this.editor.targetId !== this.editor.dragFromNodeId;
+        this.editor.isValidTarget =
+          this.editor.targetId !== this.editor.dragFromNodeId;
 
         if (this.editor.isValidTarget) {
           targetNode.classList.add('connection-target-valid');
@@ -1028,7 +1079,8 @@ export class DragManager {
         const canvas = this.editor.querySelector('#canvas');
         if (canvas) {
           const canvasRect = canvas.getBoundingClientRect();
-          const relativeX = (touch.clientX - canvasRect.left) / this.editor.zoom;
+          const relativeX =
+            (touch.clientX - canvasRect.left) / this.editor.zoom;
           const relativeY = (touch.clientY - canvasRect.top) / this.editor.zoom;
 
           const placeholderWidth = 200;
@@ -1123,10 +1175,14 @@ export class DragManager {
     // --- Connection dragging ---
     if (this.editor.plumber.connectionDragging) {
       if (touch) {
-        const targetNode = this.editor.findTargetNodeAt(touch.clientX, touch.clientY);
+        const targetNode = this.editor.findTargetNodeAt(
+          touch.clientX,
+          touch.clientY
+        );
         if (targetNode) {
           this.editor.targetId = targetNode.getAttribute('uuid');
-          this.editor.isValidTarget = this.editor.targetId !== this.editor.dragFromNodeId;
+          this.editor.isValidTarget =
+            this.editor.targetId !== this.editor.dragFromNodeId;
         }
       }
       return;
@@ -1154,7 +1210,9 @@ export class DragManager {
       const newPositions: { [uuid: string]: FlowPosition } = {};
 
       itemsToMove.forEach((uuid) => {
-        const type = this.editor.definition.nodes.find((node) => node.uuid === uuid)
+        const type = this.editor.definition.nodes.find(
+          (node) => node.uuid === uuid
+        )
           ? 'node'
           : 'sticky';
         const position = this.getPosition(uuid, type);
@@ -1167,7 +1225,9 @@ export class DragManager {
 
           newPositions[uuid] = { left: snappedLeft, top: snappedTop };
 
-          const element = this.editor.querySelector(`[uuid="${uuid}"]`) as HTMLElement;
+          const element = this.editor.querySelector(
+            `[uuid="${uuid}"]`
+          ) as HTMLElement;
           if (element) {
             element.classList.remove('dragging');
             element.style.left = `${snappedLeft}px`;

--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -3945,7 +3945,9 @@ export class Editor extends RapidElement {
             value: PRIMARY_LANGUAGE_OPTION_VALUE
           },
           ...languages.map((lang) => {
-            const localizationProgress = this.getLocalizationProgress(lang.code);
+            const localizationProgress = this.getLocalizationProgress(
+              lang.code
+            );
             const localizationPercent = Math.round(
               (localizationProgress.localized /
                 Math.max(localizationProgress.total, 1)) *

--- a/src/flow/EditorToolbar.ts
+++ b/src/flow/EditorToolbar.ts
@@ -311,10 +311,7 @@ export class EditorToolbar extends RapidElement {
     `;
   }
 
-  private renderShortcutLabel(
-    label: string,
-    shortcut: string
-  ): TemplateResult {
+  private renderShortcutLabel(label: string, shortcut: string): TemplateResult {
     return html`<span style="display:inline-flex; align-items:center; gap:8px;">
       <span>${label}</span>
       <kbd>${shortcut}</kbd>
@@ -348,7 +345,9 @@ export class EditorToolbar extends RapidElement {
 
     return html`
       <div
-        style="display:flex; align-items:center; justify-content:space-between; gap:8px; padding:6px 10px; ${optionBg ? `background:${optionBg};` : ''} ${optionRadius}"
+        style="display:flex; align-items:center; justify-content:space-between; gap:8px; padding:6px 10px; ${optionBg
+          ? `background:${optionBg};`
+          : ''} ${optionRadius}"
         @mouseenter=${isComplete
           ? (e: MouseEvent) => {
               (e.currentTarget as HTMLElement).style.background = optionHoverBg;
@@ -372,9 +371,7 @@ export class EditorToolbar extends RapidElement {
 
   public render(): TemplateResult {
     const showLanguageControls = this.languageOptions.length > 1;
-    const searchTargetLabel = this.messageView
-      ? 'Search table'
-      : 'Search flow';
+    const searchTargetLabel = this.messageView ? 'Search table' : 'Search flow';
 
     return html`
       <div class="editor-toolbar">
@@ -384,7 +381,8 @@ export class EditorToolbar extends RapidElement {
             html`
               <button
                 class="toolbar-btn ${!this.messageView ? 'active' : ''}"
-                @click=${() => this.fireToolbarAction('view-change', { view: 'flow' })}
+                @click=${() =>
+                  this.fireToolbarAction('view-change', { view: 'flow' })}
                 aria-label="Flow View"
               >
                 <temba-icon name="flow" size="1"></temba-icon>
@@ -396,7 +394,8 @@ export class EditorToolbar extends RapidElement {
             html`
               <button
                 class="toolbar-btn ${this.messageView ? 'active' : ''}"
-                @click=${() => this.fireToolbarAction('view-change', { view: 'table' })}
+                @click=${() =>
+                  this.fireToolbarAction('view-change', { view: 'table' })}
                 aria-label="Table View"
               >
                 <temba-icon name=${Icon.quick_replies} size="1"></temba-icon>
@@ -412,7 +411,11 @@ export class EditorToolbar extends RapidElement {
                       'Change language',
                       html`
                         <button
-                          class="language-pill ${this.isBaseLanguage ? 'primary' : this.languagePercent === 100 ? 'complete' : ''}"
+                          class="language-pill ${this.isBaseLanguage
+                            ? 'primary'
+                            : this.languagePercent === 100
+                              ? 'complete'
+                              : ''}"
                           id="language-btn"
                           @click=${this.handleLanguageIconClick}
                           aria-label="Change language"
@@ -434,7 +437,9 @@ export class EditorToolbar extends RapidElement {
                       `
                     )}
                     <temba-options
-                      .anchorTo=${this.shadowRoot?.querySelector('#language-btn') as HTMLElement}
+                      .anchorTo=${this.shadowRoot?.querySelector(
+                        '#language-btn'
+                      ) as HTMLElement}
                       .options=${this.languageOptions}
                       .renderOption=${this.renderLanguageOption}
                       ?visible=${this.showLanguageOptions}
@@ -462,10 +467,7 @@ export class EditorToolbar extends RapidElement {
                       ?disabled=${!this.zoomInitialized || this.zoomFitted}
                       aria-label="Zoom to fit"
                     >
-                      <temba-icon
-                        name=${Icon.zoom_fit}
-                        size="1"
-                      ></temba-icon>
+                      <temba-icon name=${Icon.zoom_fit} size="1"></temba-icon>
                     </button>
                   `
                 )}
@@ -511,10 +513,7 @@ export class EditorToolbar extends RapidElement {
                       ?disabled=${!this.zoomInitialized || this.zoom >= 1.0}
                       aria-label="Zoom to 100%"
                     >
-                      <temba-icon
-                        name=${Icon.zoom_in}
-                        size="1"
-                      ></temba-icon>
+                      <temba-icon name=${Icon.zoom_in} size="1"></temba-icon>
                     </button>
                   `
                 )}

--- a/src/flow/FlowSearch.ts
+++ b/src/flow/FlowSearch.ts
@@ -265,9 +265,7 @@ function getNodeSearchTexts(
   if (node.router?.categories) {
     for (const cat of node.router.categories) {
       if (cat.name && cat.name !== 'Other' && cat.name !== 'All Responses') {
-        texts.push(
-          localizeCategoryName(cat.uuid, cat.name, langLocalization)
-        );
+        texts.push(localizeCategoryName(cat.uuid, cat.name, langLocalization));
       }
     }
   }
@@ -748,7 +746,8 @@ export class FlowSearch extends LitElement {
           const actionConfig = ACTION_CONFIG[action.type];
           if (
             action.type !== 'send_msg' &&
-            (!actionConfig?.localizable || actionConfig.localizable.length === 0)
+            (!actionConfig?.localizable ||
+              actionConfig.localizable.length === 0)
           ) {
             continue;
           }
@@ -907,7 +906,10 @@ export class FlowSearch extends LitElement {
                       >
                         <div
                           class="result-type-badge"
-                          style="background:${result.color};border-color:${result.borderColor || result.color}${result.textColor ? `;color:${result.textColor}` : ''}"
+                          style="background:${result.color};border-color:${result.borderColor ||
+                          result.color}${result.textColor
+                            ? `;color:${result.textColor}`
+                            : ''}"
                         >
                           ${result.typeName}
                         </div>
@@ -925,8 +927,8 @@ export class FlowSearch extends LitElement {
               `
             : html`<div class="no-results">No matches found</div>`
           : html`<div class="hint">
-              <kbd>↑</kbd> <kbd>↓</kbd> to navigate &nbsp;
-              <kbd>Enter</kbd> to open &nbsp; <kbd>Esc</kbd> to close
+              <kbd>↑</kbd> <kbd>↓</kbd> to navigate &nbsp; <kbd>Enter</kbd> to
+              open &nbsp; <kbd>Esc</kbd> to close
             </div>`}
       </div>
     `;

--- a/src/flow/MessageTable.ts
+++ b/src/flow/MessageTable.ts
@@ -87,7 +87,9 @@ export class MessageTable extends RapidElement {
         padding: 2px 16px 2px 26px;
       }
 
-      .message-table tr.localization-paired-row:not(.localization-paired-last) td {
+      .message-table
+        tr.localization-paired-row:not(.localization-paired-last)
+        td {
         border-bottom: none;
       }
 
@@ -278,11 +280,13 @@ export class MessageTable extends RapidElement {
         transition: background 0.15s;
       }
 
-      .translation-cell.category-translation-cell:hover .category-translation-item {
+      .translation-cell.category-translation-cell:hover
+        .category-translation-item {
         background: #f5f8ff;
       }
 
-      .translation-cell.category-translation-cell:hover .category-translation-item.missing {
+      .translation-cell.category-translation-cell:hover
+        .category-translation-item.missing {
         color: #9bb8df;
       }
 
@@ -399,14 +403,24 @@ export class MessageTable extends RapidElement {
       const nodeType = nodeUI?.type;
 
       // Collect rules that have localized values or are flagged for localization
-      const langLocalization = this.definition?.localization?.[this.languageCode] || {};
-      let rules: Array<{ uuid: string; type: string; arguments: string[] }> = [];
+      const langLocalization =
+        this.definition?.localization?.[this.languageCode] || {};
+      let rules: Array<{ uuid: string; type: string; arguments: string[] }> =
+        [];
       if (node.router?.cases?.length) {
         const hasLocalizeRules = nodeUI?.config?.localizeRules;
         rules = node.router.cases
           .filter((c) => c.arguments?.length > 0 && c.arguments.some((a) => a))
-          .filter((c) => hasLocalizeRules || langLocalization[c.uuid]?.arguments?.some((a: string) => a))
-          .map((c) => ({ uuid: c.uuid, type: c.type, arguments: [...c.arguments] }));
+          .filter(
+            (c) =>
+              hasLocalizeRules ||
+              langLocalization[c.uuid]?.arguments?.some((a: string) => a)
+          )
+          .map((c) => ({
+            uuid: c.uuid,
+            type: c.type,
+            arguments: [...c.arguments]
+          }));
       }
 
       // Collect categories that have localized values or are flagged for localization
@@ -424,8 +438,8 @@ export class MessageTable extends RapidElement {
         if (hasLocalizeCategories) {
           categories = translatableCategories;
         } else {
-          categories = translatableCategories.filter(
-            (cat) => langLocalization[cat.uuid]?.name?.some((n: string) => n)
+          categories = translatableCategories.filter((cat) =>
+            langLocalization[cat.uuid]?.name?.some((n: string) => n)
           );
         }
       }
@@ -492,9 +506,7 @@ export class MessageTable extends RapidElement {
     }
 
     return localization.quick_replies
-      .map((reply: unknown) =>
-        typeof reply === 'string' ? reply.trim() : ''
-      )
+      .map((reply: unknown) => (typeof reply === 'string' ? reply.trim() : ''))
       .filter((reply: string) => reply.length > 0);
   }
 
@@ -568,7 +580,10 @@ export class MessageTable extends RapidElement {
     // Count string-type localizable fields (exclude arrays like attachments, quick_replies)
     const textFields = config.localizable.filter((key) => {
       const fieldConfig = config.form?.[key];
-      return fieldConfig && (fieldConfig.type === 'text' || fieldConfig.type === 'textarea');
+      return (
+        fieldConfig &&
+        (fieldConfig.type === 'text' || fieldConfig.type === 'textarea')
+      );
     });
     return textFields.length > 1;
   }
@@ -587,11 +602,15 @@ export class MessageTable extends RapidElement {
     return config.localizable
       .filter((key) => {
         const fieldConfig = config.form?.[key];
-        return fieldConfig && (fieldConfig.type === 'text' || fieldConfig.type === 'textarea');
+        return (
+          fieldConfig &&
+          (fieldConfig.type === 'text' || fieldConfig.type === 'textarea')
+        );
       })
       .map((key) => {
         const fieldConfig = config.form![key];
-        const label = typeof fieldConfig.label === 'string' ? fieldConfig.label : key;
+        const label =
+          typeof fieldConfig.label === 'string' ? fieldConfig.label : key;
         return {
           key,
           label,
@@ -609,7 +628,8 @@ export class MessageTable extends RapidElement {
         if (colonIdx < 0) return html``;
         const contentType = att.substring(0, colonIdx);
         const baseType = contentType.split('/')[0];
-        const iconName = MessageTable.ATTACHMENT_ICONS[baseType] || Icon.attachment;
+        const iconName =
+          MessageTable.ATTACHMENT_ICONS[baseType] || Icon.attachment;
         return html`<div class="attachment-icon">
           <temba-icon name="${iconName}"></temba-icon>
         </div>`;
@@ -628,10 +648,17 @@ export class MessageTable extends RapidElement {
     if (config?.form) {
       for (const key of localizable) {
         const fc = config.form[key];
-        if (fc && (fc.type === 'text' || fc.type === 'textarea' || fc.type === 'message-editor')) {
+        if (
+          fc &&
+          (fc.type === 'text' ||
+            fc.type === 'textarea' ||
+            fc.type === 'message-editor')
+        ) {
           const text = action[key] || '';
           if (text) {
-            parts.push(renderHighlightedText(this.stripLeadingLineBreaks(text), true));
+            parts.push(
+              renderHighlightedText(this.stripLeadingLineBreaks(text), true)
+            );
           }
         }
       }
@@ -640,9 +667,15 @@ export class MessageTable extends RapidElement {
     // Quick replies (send_msg)
     const quickReplies: string[] = action.quick_replies || [];
     if (quickReplies.length > 0) {
-      parts.push(html`<div class="quick-replies ${parts.length === 0 ? 'standalone' : ''}">${quickReplies.map(
-        (reply) => html`<div class="quick-reply">${reply}</div>`
-      )}</div>`);
+      parts.push(
+        html`<div
+          class="quick-replies ${parts.length === 0 ? 'standalone' : ''}"
+        >
+          ${quickReplies.map(
+            (reply) => html`<div class="quick-reply">${reply}</div>`
+          )}
+        </div>`
+      );
     }
 
     // Attachments
@@ -669,10 +702,20 @@ export class MessageTable extends RapidElement {
     if (config?.form) {
       for (const key of localizable) {
         const fc = config.form[key];
-        if (fc && (fc.type === 'text' || fc.type === 'textarea' || fc.type === 'message-editor')) {
+        if (
+          fc &&
+          (fc.type === 'text' ||
+            fc.type === 'textarea' ||
+            fc.type === 'message-editor')
+        ) {
           const translatedText = this.getTranslatedField(action.uuid, key);
           if (typeof translatedText === 'string') {
-            parts.push(renderHighlightedText(this.stripLeadingLineBreaks(translatedText), true));
+            parts.push(
+              renderHighlightedText(
+                this.stripLeadingLineBreaks(translatedText),
+                true
+              )
+            );
           }
         }
       }
@@ -681,13 +724,22 @@ export class MessageTable extends RapidElement {
     // Translated quick replies
     const translatedQuickReplies = this.getTranslatedQuickReplies(action.uuid);
     if (translatedQuickReplies.length > 0) {
-      parts.push(html`<div class="quick-replies ${parts.length === 0 ? 'standalone' : ''}">${translatedQuickReplies.map(
-        (reply) => html`<div class="quick-reply">${reply}</div>`
-      )}</div>`);
+      parts.push(
+        html`<div
+          class="quick-replies ${parts.length === 0 ? 'standalone' : ''}"
+        >
+          ${translatedQuickReplies.map(
+            (reply) => html`<div class="quick-reply">${reply}</div>`
+          )}
+        </div>`
+      );
     }
 
     // Translated attachments
-    const translatedAttachments = this.getTranslatedArrayField(action.uuid, 'attachments');
+    const translatedAttachments = this.getTranslatedArrayField(
+      action.uuid,
+      'attachments'
+    );
     if (translatedAttachments.length > 0) {
       parts.push(this.renderAttachments(translatedAttachments));
     }
@@ -739,9 +791,7 @@ export class MessageTable extends RapidElement {
     });
   }
 
-  private getGroupTranslations(
-    entry: LocalizationGroupEntry
-  ): Array<{
+  private getGroupTranslations(entry: LocalizationGroupEntry): Array<{
     original: string;
     translated: string | null;
     isRule: boolean;
@@ -795,7 +845,10 @@ export class MessageTable extends RapidElement {
   }
 
   private renderPairedRows(
-    items: Array<{ original: TemplateResult; translated: TemplateResult | null }>,
+    items: Array<{
+      original: TemplateResult;
+      translated: TemplateResult | null;
+    }>,
     entry: TableEntry,
     handleBaseClick: () => void,
     handleTranslationClick: () => void,
@@ -805,11 +858,17 @@ export class MessageTable extends RapidElement {
       ${items.map(
         (item, idx) => html`
           <tr
-            class="category-row localization-paired-row ${idx === 0 ? 'localization-paired-first' : ''} ${idx === items.length - 1 ? 'localization-paired-last' : ''}"
+            class="category-row localization-paired-row ${idx === 0
+              ? 'localization-paired-first'
+              : ''} ${idx === items.length - 1
+              ? 'localization-paired-last'
+              : ''}"
             style=${`--node-rail-color: ${this.getEntryRailColor(entry)};`}
             data-node-uuid=${entry.node.uuid}
             data-entry-kind=${entry.kind}
-            data-action-uuid=${entry.kind === 'message' ? entry.action.uuid : ''}
+            data-action-uuid=${entry.kind === 'message'
+              ? entry.action.uuid
+              : ''}
           >
             <td>
               <div
@@ -830,9 +889,16 @@ export class MessageTable extends RapidElement {
                     title="Click to edit translation"
                   >
                     <div
-                      class="category-item category-translation-item ${item.translated !== null ? '' : 'missing'}"
+                      class="category-item category-translation-item ${item.translated !==
+                      null
+                        ? ''
+                        : 'missing'}"
                     >
-                      <span>${item.translated !== null ? item.translated : 'No translation'}</span>
+                      <span
+                        >${item.translated !== null
+                          ? item.translated
+                          : 'No translation'}</span
+                      >
                     </div>
                   </div>
                 </td>`
@@ -880,32 +946,55 @@ export class MessageTable extends RapidElement {
               const groupTranslations = this.getGroupTranslations(entry);
               const items = groupTranslations.map((item) => ({
                 original: html`${item.isRule && item.operatorName
-                  ? html`<span class="rule-operator">${item.operatorName}</span> `
+                  ? html`<span class="rule-operator"
+                      >${item.operatorName}</span
+                    > `
                   : ''}${renderHighlightedText(item.original, true)}`,
-                translated: item.translated !== null
-                  ? html`${item.isRule && item.operatorName
-                      ? html`<span class="rule-operator">${item.operatorName}</span> `
-                      : ''}${renderHighlightedText(item.translated, true)}`
-                  : null
+                translated:
+                  item.translated !== null
+                    ? html`${item.isRule && item.operatorName
+                        ? html`<span class="rule-operator"
+                            >${item.operatorName}</span
+                          > `
+                        : ''}${renderHighlightedText(item.translated, true)}`
+                    : null
               }));
-              return this.renderPairedRows(items, entry, handleBaseClick, handleTranslationClickFn, showTranslation);
+              return this.renderPairedRows(
+                items,
+                entry,
+                handleBaseClick,
+                handleTranslationClickFn,
+                showTranslation
+              );
             }
 
             // Multi-field actions (e.g. send_email with subject + body) - paired rows
-            if (
-              entry.kind === 'message' &&
-              this.usesPairedRows(entry.action)
-            ) {
+            if (entry.kind === 'message' && this.usesPairedRows(entry.action)) {
               const fields = this.getPairedFields(entry.action);
               const items = fields.map((f) => ({
                 original: html`${f.original
-                  ? renderHighlightedText(this.stripLeadingLineBreaks(f.original), true)
-                  : html`<span style="color: #bbb; font-style: italic;">Empty</span>`}`,
-                translated: f.translated !== null
-                  ? html`${renderHighlightedText(this.stripLeadingLineBreaks(f.translated), true)}`
-                  : null
+                  ? renderHighlightedText(
+                      this.stripLeadingLineBreaks(f.original),
+                      true
+                    )
+                  : html`<span style="color: #bbb; font-style: italic;"
+                      >Empty</span
+                    >`}`,
+                translated:
+                  f.translated !== null
+                    ? html`${renderHighlightedText(
+                        this.stripLeadingLineBreaks(f.translated),
+                        true
+                      )}`
+                    : null
               }));
-              return this.renderPairedRows(items, entry, handleBaseClick, handleTranslationClickFn, showTranslation);
+              return this.renderPairedRows(
+                items,
+                entry,
+                handleBaseClick,
+                handleTranslationClickFn,
+                showTranslation
+              );
             }
 
             // Single-row entries (send_msg, send_broadcast, etc.)
@@ -913,9 +1002,9 @@ export class MessageTable extends RapidElement {
               entry.kind === 'message' &&
               showTranslation &&
               this.hasAnyTranslation(entry);
-            const translationCellClass = `translation-cell ${hasTranslation
-              ? 'has-translation'
-              : 'missing-translation'}`;
+            const translationCellClass = `translation-cell ${
+              hasTranslation ? 'has-translation' : 'missing-translation'
+            }`;
 
             return html`
               <tr
@@ -936,23 +1025,41 @@ export class MessageTable extends RapidElement {
                       ? this.renderOriginalContent(entry)
                       : isGroupEntry
                         ? html`
-                          <div class="category-stack category-stack-original">
-                            ${entry.rules.map(
-                              (c) => html`
-                                <div class="category-item category-original-item">
-                                  <span><span class="rule-operator">${getOperatorConfig(c.type)?.name || c.type}</span> ${renderHighlightedText(c.arguments.join(', '), true)}</span>
-                                </div>
-                              `
-                            )}
-                            ${entry.categories.map(
-                              (category) => html`
-                                <div class="category-item category-original-item">
-                                  <span>${renderHighlightedText(category.name, true)}</span>
-                                </div>
-                              `
-                            )}
-                          </div>
-                        `
+                            <div class="category-stack category-stack-original">
+                              ${entry.rules.map(
+                                (c) => html`
+                                  <div
+                                    class="category-item category-original-item"
+                                  >
+                                    <span
+                                      ><span class="rule-operator"
+                                        >${getOperatorConfig(c.type)?.name ||
+                                        c.type}</span
+                                      >
+                                      ${renderHighlightedText(
+                                        c.arguments.join(', '),
+                                        true
+                                      )}</span
+                                    >
+                                  </div>
+                                `
+                              )}
+                              ${entry.categories.map(
+                                (category) => html`
+                                  <div
+                                    class="category-item category-original-item"
+                                  >
+                                    <span
+                                      >${renderHighlightedText(
+                                        category.name,
+                                        true
+                                      )}</span
+                                    >
+                                  </div>
+                                `
+                              )}
+                            </div>
+                          `
                         : ''}
                   </div>
                 </td>
@@ -964,8 +1071,8 @@ export class MessageTable extends RapidElement {
                         title="Click to edit translation"
                       >
                         ${entry.kind === 'message'
-                            ? this.renderTranslatedContent(entry)
-                            : 'No translation'}
+                          ? this.renderTranslatedContent(entry)
+                          : 'No translation'}
                       </div>
                     </td>`
                   : ''}

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -213,8 +213,7 @@ export class RevisionsWindow extends RapidElement {
 
   private cancelRevisionView() {
     const store = getStore().getState();
-    const preservedLanguageCode =
-      this.browseLanguageCode || store.languageCode;
+    const preservedLanguageCode = this.browseLanguageCode || store.languageCode;
 
     if (this.preRevertState) {
       const currentInfo = store.flowInfo;
@@ -246,8 +245,7 @@ export class RevisionsWindow extends RapidElement {
     if (!this.viewingRevision || !this.preRevertState) return;
 
     const store = getStore().getState();
-    const preservedLanguageCode =
-      this.browseLanguageCode || store.languageCode;
+    const preservedLanguageCode = this.browseLanguageCode || store.languageCode;
 
     const definitionToSave = {
       ...store.flowDefinition,

--- a/src/flow/ZoomManager.ts
+++ b/src/flow/ZoomManager.ts
@@ -524,8 +524,7 @@ export class ZoomManager {
     const dx = canvasX - this.loupeCursorCanvas.x;
     const dy = canvasY - this.loupeCursorCanvas.y;
     const moved =
-      Math.abs(dx) > visibleRadius * 0.5 ||
-      Math.abs(dy) > visibleRadius * 0.5;
+      Math.abs(dx) > visibleRadius * 0.5 || Math.abs(dy) > visibleRadius * 0.5;
 
     if (
       !this.loupeClone ||

--- a/src/flow/actions/send_broadcast.ts
+++ b/src/flow/actions/send_broadcast.ts
@@ -220,8 +220,7 @@ export const send_broadcast: ActionConfig = {
 
     if (attachments.length > 0) {
       if (
-        JSON.stringify(attachments) !==
-        JSON.stringify(action.attachments || [])
+        JSON.stringify(attachments) !== JSON.stringify(action.attachments || [])
       ) {
         localization.attachments = attachments;
       }

--- a/src/flow/actions/send_msg.ts
+++ b/src/flow/actions/send_msg.ts
@@ -172,7 +172,11 @@ export const send_msg: ActionConfig = {
 
           if (!contentType.includes('/')) {
             runtimeAttachments.push({
-              type: { name: ATTACHMENT_TYPE_NAMES[contentType] || titleCase(contentType), value: contentType },
+              type: {
+                name:
+                  ATTACHMENT_TYPE_NAMES[contentType] || titleCase(contentType),
+                value: contentType
+              },
               expression: value
             });
           } else {
@@ -319,7 +323,11 @@ export const send_msg: ActionConfig = {
 
           if (!contentType.includes('/')) {
             runtimeAttachments.push({
-              type: { name: ATTACHMENT_TYPE_NAMES[contentType] || titleCase(contentType), value: contentType },
+              type: {
+                name:
+                  ATTACHMENT_TYPE_NAMES[contentType] || titleCase(contentType),
+                value: contentType
+              },
               expression: value
             });
           } else {

--- a/src/flow/actions/start_session.ts
+++ b/src/flow/actions/start_session.ts
@@ -236,8 +236,7 @@ export const start_session: ActionConfig = {
       const recipients = formData.recipients || [];
       action.contacts = recipients
         .filter(
-          (r: any) =>
-            r.type === 'contact' || (!r.type && !r.expression && r.id)
+          (r: any) => r.type === 'contact' || (!r.type && !r.expression && r.id)
         )
         .map((c: any) => ({ uuid: c.id, name: c.name }));
       action.groups = recipients

--- a/src/form/Compose.ts
+++ b/src/form/Compose.ts
@@ -41,7 +41,10 @@ export class Compose extends FieldElement {
 
       .container:focus-within {
         border-color: var(--color-focus);
-        box-shadow: var(--widget-box-shadow-focused, 0 0 0 3px rgba(0, 123, 255, 0.25));
+        box-shadow: var(
+          --widget-box-shadow-focused,
+          0 0 0 3px rgba(0, 123, 255, 0.25)
+        );
       }
 
       .editor-wrapper {
@@ -115,14 +118,15 @@ export class Compose extends FieldElement {
         color: #888;
         background: rgba(0, 0, 0, 0.04);
         border-radius: 8px;
-        transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+        transition:
+          background-color 0.2s ease-in-out,
+          color 0.2s ease-in-out;
       }
 
       .shortcut-icon:hover {
         color: var(--color-text-dark);
         background: rgba(0, 0, 0, 0.08);
       }
-
     `;
   }
 
@@ -347,7 +351,10 @@ export class Compose extends FieldElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.removeEventListener('keydown', this.handleHostKeyDown as EventListener);
+    this.removeEventListener(
+      'keydown',
+      this.handleHostKeyDown as EventListener
+    );
   }
 
   private handleShortcutIconClick() {

--- a/src/form/MessageEditor.ts
+++ b/src/form/MessageEditor.ts
@@ -59,7 +59,7 @@ export class MessageEditor extends FieldElement {
         position: relative;
       }
 
-      ::slotted([slot="icons"]) {
+      ::slotted([slot='icons']) {
         position: absolute;
         bottom: 4px;
         left: 36px;
@@ -69,7 +69,7 @@ export class MessageEditor extends FieldElement {
         z-index: 1;
       }
 
-      .has-attachments ::slotted([slot="icons"]) {
+      .has-attachments ::slotted([slot='icons']) {
         left: 4px;
       }
 
@@ -155,7 +155,9 @@ export class MessageEditor extends FieldElement {
         padding: 6px;
         border-radius: 8px;
         background: rgba(0, 0, 0, 0.04);
-        transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+        transition:
+          background-color 0.2s ease-in-out,
+          color 0.2s ease-in-out;
       }
 
       .attachment-icon:hover {

--- a/src/form/RichEditor.ts
+++ b/src/form/RichEditor.ts
@@ -678,7 +678,9 @@ export class RichEditor extends FieldElement {
       <div class="comp-container">
         <div id="anchor" style=${styleMap(anchorStyles)}></div>
         <div
-          class="input-container ${this.flavor !== 'default' ? this.flavor : ''}"
+          class="input-container ${this.flavor !== 'default'
+            ? this.flavor
+            : ''}"
           style=${this.minHeight
             ? `--textarea-min-height: ${this.minHeight}px`
             : ''}

--- a/src/form/TemplateEditor.ts
+++ b/src/form/TemplateEditor.ts
@@ -491,7 +491,11 @@ export class TemplateEditor extends FieldElement {
         >
         </temba-select>
         ${this.templateWarning && this.selectedTemplate
-          ? html`<temba-alert level="warning" style="margin-bottom: 0.5em; display: block;">${this.templateWarning}</temba-alert>`
+          ? html`<temba-alert
+              level="warning"
+              style="margin-bottom: 0.5em; display: block;"
+              >${this.templateWarning}</temba-alert
+            >`
           : null}
         ${content ? html` <div class="template">${content}</div>` : null}
       </div>

--- a/src/form/select/Select.ts
+++ b/src/form/select/Select.ts
@@ -866,9 +866,7 @@ export class Select<T extends SelectOption> extends FieldElement {
   }
 
   private updateEnterHintPosition() {
-    const hint = this.shadowRoot.querySelector(
-      '.enter-hint'
-    ) as HTMLElement;
+    const hint = this.shadowRoot.querySelector('.enter-hint') as HTMLElement;
     if (!hint) {
       this.removeHintRepositionListeners();
       return;
@@ -2346,7 +2344,9 @@ export class Select<T extends SelectOption> extends FieldElement {
               : null
           }</slot>
           ${
-            !this.tags && !this.emails && !(this.clearable && this.values.length > 0 && !this.isMultiMode)
+            !this.tags &&
+            !this.emails &&
+            !(this.clearable && this.values.length > 0 && !this.isMultiMode)
               ? html`<div
                   class="right-side arrow"
                   style="display:block;margin-right:5px"
@@ -2412,11 +2412,13 @@ export class Select<T extends SelectOption> extends FieldElement {
           : null
       }
     </temba-options>
-    ${showEnterHint
-      ? html`<div class="enter-hint">
-          <span style="position:relative;top:3px">↵</span> ${msg('to add')}
-        </div>`
-      : null}
+    ${
+      showEnterHint
+        ? html`<div class="enter-hint">
+            <span style="position:relative;top:3px">↵</span> ${msg('to add')}
+          </div>`
+        : null
+    }
     `;
   }
 

--- a/src/layout/AccordionSection.ts
+++ b/src/layout/AccordionSection.ts
@@ -194,9 +194,15 @@ export class AccordionSection extends LitElement {
         @mouseenter=${this.handleMouseEnter}
         @mouseleave=${this.handleMouseLeave}
       >
-        <div class="accordion-title">${this.icon
-            ? html`<temba-icon name=${this.icon} size="1" style="margin-right:6px;color:#999;"></temba-icon>`
-            : ''}${this.label}</div>
+        <div class="accordion-title">
+          ${this.icon
+            ? html`<temba-icon
+                name=${this.icon}
+                size="1"
+                style="margin-right:6px;color:#999;"
+              ></temba-icon>`
+            : ''}${this.label}
+        </div>
         ${this.hasError
           ? html`<temba-icon
               name="alert_warning"

--- a/src/layout/Modax.ts
+++ b/src/layout/Modax.ts
@@ -312,9 +312,7 @@ export class Modax extends RapidElement {
         } else {
           // apply or clear header colors from response
           const headerBg = response.headers.get('X-Temba-Header-Bg');
-          const headerText = response.headers.get(
-            'X-Temba-Header-Text'
-          );
+          const headerText = response.headers.get('X-Temba-Header-Text');
           if (headerBg) {
             this.style.setProperty('--header-bg', headerBg);
           } else {

--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -68,8 +68,6 @@ export class ContactChat extends ContactStoreElement {
         --compose-padding: 3px;
         --compose-curvature: none;
         border-top: 1px inset rgba(0, 0, 0, 0.05);
-
-
       }
 
       .chat-wrapper {
@@ -612,9 +610,7 @@ export class ContactChat extends ContactStoreElement {
         this.refreshId = null;
       }
       window.setTimeout(() => {
-        const input = this.shadowRoot.querySelector(
-          '.search-input'
-        ) as any;
+        const input = this.shadowRoot.querySelector('.search-input') as any;
         if (input) {
           input.focus();
         }
@@ -1125,7 +1121,13 @@ export class ContactChat extends ContactStoreElement {
   private fetchingNewer = false;
 
   private fetchNewerMessages() {
-    if (!this.searchMode || !this.afterUUID || !this.chat || this.fetchingNewer || this.blockFetchingNewer) {
+    if (
+      !this.searchMode ||
+      !this.afterUUID ||
+      !this.chat ||
+      this.fetchingNewer ||
+      this.blockFetchingNewer
+    ) {
       return;
     }
 
@@ -1141,28 +1143,30 @@ export class ContactChat extends ContactStoreElement {
       this.currentTicket?.uuid,
       null,
       this.afterUUID
-    ).then((page: ContactHistoryPage) => {
-      if (!this.chat) {
+    )
+      .then((page: ContactHistoryPage) => {
+        if (!this.chat) {
+          this.fetchingNewer = false;
+          return;
+        }
+
+        const messages = this.createMessages(page);
+        messages.reverse();
+
+        if (messages.length === 0) {
+          this.blockFetchingNewer = true;
+          this.fetchingNewer = false;
+          return;
+        }
+
+        // maintainScroll=true keeps the user's visual position stable
+        // so they must actively scroll down to trigger the next fetch
+        // fetchingNewer is reset in fetchComplete after scroll settles
+        this.chat.addMessages(messages, null, true, true);
+      })
+      .catch(() => {
         this.fetchingNewer = false;
-        return;
-      }
-
-      const messages = this.createMessages(page);
-      messages.reverse();
-
-      if (messages.length === 0) {
-        this.blockFetchingNewer = true;
-        this.fetchingNewer = false;
-        return;
-      }
-
-      // maintainScroll=true keeps the user's visual position stable
-      // so they must actively scroll down to trigger the next fetch
-      // fetchingNewer is reset in fetchComplete after scroll settles
-      this.chat.addMessages(messages, null, true, true);
-    }).catch(() => {
-      this.fetchingNewer = false;
-    });
+      });
   }
 
   private getTembaCompose(): TemplateResult {
@@ -1330,7 +1334,11 @@ export class ContactChat extends ContactStoreElement {
       ${this.currentContact
         ? html`<div class="chat-container">
               ${this.showSearch && this.searchMode
-                ? html`<div class="search-overlay ${this.searchClosing ? 'closing' : ''}">
+                ? html`<div
+                    class="search-overlay ${this.searchClosing
+                      ? 'closing'
+                      : ''}"
+                  >
                     <div class="search-input-wrapper">
                       <temba-textinput
                         class="search-input"
@@ -1350,10 +1358,7 @@ export class ContactChat extends ContactStoreElement {
                         this.searchLoading}
                         title="Search (Enter)"
                       >
-                        <temba-icon
-                          name="search"
-                          size="0.8"
-                        ></temba-icon>
+                        <temba-icon name="search" size="0.8"></temba-icon>
                       </button>
                     </div>
                     ${this.searchLoading
@@ -1362,22 +1367,25 @@ export class ContactChat extends ContactStoreElement {
                         ></span>`
                       : this.searchResults.length > 0
                         ? html`<span class="search-counter"
-                            >${this.searchIndex + 1} /
-                            ${this.searchResults.length}</span
-                          ><button
-                            class="search-btn ${this.searchFocused && this.searchQuery.trim() === this.lastSearchedQuery ? 'enter-target' : ''}"
-                            @click=${this.handleSearchNext}
-                            title="Older match (Enter)"
-                          >
-                            &#x25B2;
-                          </button>
-                          <button
-                            class="search-btn"
-                            @click=${this.handleSearchPrev}
-                            title="Newer match (Shift+Enter)"
-                          >
-                            &#x25BC;
-                          </button>`
+                              >${this.searchIndex + 1} /
+                              ${this.searchResults.length}</span
+                            ><button
+                              class="search-btn ${this.searchFocused &&
+                              this.searchQuery.trim() === this.lastSearchedQuery
+                                ? 'enter-target'
+                                : ''}"
+                              @click=${this.handleSearchNext}
+                              title="Older match (Enter)"
+                            >
+                              &#x25B2;
+                            </button>
+                            <button
+                              class="search-btn"
+                              @click=${this.handleSearchPrev}
+                              title="Newer match (Shift+Enter)"
+                            >
+                              &#x25BC;
+                            </button>`
                         : null}
                     <button
                       class="search-btn"

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -1947,13 +1947,19 @@ export class Simulator extends RapidElement {
       totalElapsedMs === null
         ? 'n/a'
         : this.formatWebhookDuration(totalElapsedMs);
-    const renderWebhookLogContent = (log: WebhookLog, singleAttempt = false) => {
+    const renderWebhookLogContent = (
+      log: WebhookLog,
+      singleAttempt = false
+    ) => {
       const request = this.formatWebhookValue(log.request) || 'No request body';
-      const response = this.formatWebhookValue(log.response) || 'No response body';
+      const response =
+        this.formatWebhookValue(log.response) || 'No response body';
 
       return html`
         <div
-          class="webhook-log-content ${singleAttempt ? 'webhook-single-log' : ''}"
+          class="webhook-log-content ${singleAttempt
+            ? 'webhook-single-log'
+            : ''}"
         >
           <div class="webhook-log-section">
             <h4>Request</h4>

--- a/test/actions/play_audio.test.ts
+++ b/test/actions/play_audio.test.ts
@@ -103,7 +103,10 @@ describe('play_audio action config', () => {
         audio_url: ['@results.voicemail_es']
       };
 
-      const formData = resolveToLocalizationFormData(play_audio)!(action, localization);
+      const formData = resolveToLocalizationFormData(play_audio)!(
+        action,
+        localization
+      );
       expect(formData.audio_url).to.equal('@results.voicemail_es');
     });
 

--- a/test/actions/say_msg.test.ts
+++ b/test/actions/say_msg.test.ts
@@ -140,7 +140,10 @@ describe('say_msg action config', () => {
         audio_url: ['https://example.com/es.mp3']
       };
 
-      const formData = resolveToLocalizationFormData(say_msg)!(action, localization);
+      const formData = resolveToLocalizationFormData(say_msg)!(
+        action,
+        localization
+      );
       expect(formData.text).to.equal('Hola');
       expect(formData.audio_url).to.equal('https://example.com/es.mp3');
     });
@@ -171,7 +174,10 @@ describe('say_msg action config', () => {
         audio_url: 'https://example.com/es.mp3'
       };
 
-      const localization = resolveFromLocalizationFormData(say_msg)!(formData, action);
+      const localization = resolveFromLocalizationFormData(say_msg)!(
+        formData,
+        action
+      );
       expect(localization.text).to.deep.equal(['Hola']);
       expect(localization.audio_url).to.deep.equal([
         'https://example.com/es.mp3'
@@ -192,7 +198,10 @@ describe('say_msg action config', () => {
         audio_url: 'https://example.com/en.mp3' // same as original
       };
 
-      const localization = resolveFromLocalizationFormData(say_msg)!(formData, action);
+      const localization = resolveFromLocalizationFormData(say_msg)!(
+        formData,
+        action
+      );
       expect(localization.text).to.be.undefined;
       expect(localization.audio_url).to.be.undefined;
     });

--- a/test/actions/start_session.test.ts
+++ b/test/actions/start_session.test.ts
@@ -209,9 +209,7 @@ describe('start_session action config', () => {
         uuid: 'test-uuid',
         flow: [{ uuid: 'flow-1', name: 'Test Flow' }],
         startType: [{ value: 'manual', name: 'Select recipients manually' }],
-        recipients: [
-          { id: 'contact-1', name: 'Alice', type: 'contact' }
-        ]
+        recipients: [{ id: 'contact-1', name: 'Alice', type: 'contact' }]
       };
 
       const action = start_session.fromFormData(formData) as StartSession;

--- a/test/nodes/split_by_expression.test.ts
+++ b/test/nodes/split_by_expression.test.ts
@@ -261,7 +261,8 @@ describe('split_by_expression node config', () => {
     });
 
     it('should preserve expression operands with spaces for has_number_between', () => {
-      const minExpression = '@(extract(webhook.json.queryData[0], "minLength"))';
+      const minExpression =
+        '@(extract(webhook.json.queryData[0], "minLength"))';
       const formData = {
         uuid: 'test-node-uuid',
         operand: '@fields.value',

--- a/test/temba-compose.test.ts
+++ b/test/temba-compose.test.ts
@@ -201,9 +201,7 @@ describe('temba-compose broadcast edit', () => {
         variables: []
       }
     };
-    const languages = JSON.stringify([
-      { iso: 'eng', name: 'English' }
-    ]);
+    const languages = JSON.stringify([{ iso: 'eng', name: 'English' }]);
 
     const compose: Compose = await getCompose({
       counter: true,

--- a/test/temba-contact-chat.test.ts
+++ b/test/temba-contact-chat.test.ts
@@ -309,9 +309,7 @@ describe('temba-contact-chat', () => {
     await assertScreenshot('contacts/chat-search-open', getClip(chat));
 
     // type "primus" into the search input
-    const textInput = chat.shadowRoot.querySelector(
-      '.search-input'
-    ) as any;
+    const textInput = chat.shadowRoot.querySelector('.search-input') as any;
     expect(textInput).to.exist;
     textInput.value = 'primus';
     textInput.dispatchEvent(new Event('input', { bubbles: true }));
@@ -367,9 +365,7 @@ describe('temba-contact-chat', () => {
     await chat.updateComplete;
 
     // type a query with no matches
-    const textInput = chat.shadowRoot.querySelector(
-      '.search-input'
-    ) as any;
+    const textInput = chat.shadowRoot.querySelector('.search-input') as any;
     textInput.value = 'xyznotfound';
     textInput.dispatchEvent(new Event('input', { bubbles: true }));
     await chat.updateComplete;

--- a/test/temba-expression-highlight.test.ts
+++ b/test/temba-expression-highlight.test.ts
@@ -18,14 +18,9 @@ describe('temba-expression-highlight', () => {
   });
 
   it('highlights identifier expressions', async () => {
-    const el = await createHighlight(
-      'Hi there @contact.name, welcome!'
-    );
+    const el = await createHighlight('Hi there @contact.name, welcome!');
     assert.instanceOf(el, ExpressionHighlight);
-    await assertScreenshot(
-      'expression-highlight/identifier',
-      getClip(el)
-    );
+    await assertScreenshot('expression-highlight/identifier', getClip(el));
   });
 
   it('highlights parenthesized expressions', async () => {
@@ -33,10 +28,7 @@ describe('temba-expression-highlight', () => {
       'Hi @(contact.first_name)! You have @(results.count) items.'
     );
     assert.instanceOf(el, ExpressionHighlight);
-    await assertScreenshot(
-      'expression-highlight/parenthesized',
-      getClip(el)
-    );
+    await assertScreenshot('expression-highlight/parenthesized', getClip(el));
   });
 
   it('highlights function calls', async () => {
@@ -44,18 +36,12 @@ describe('temba-expression-highlight', () => {
       'Today is @(format_date(now(), "YYYY-MM-DD"))'
     );
     assert.instanceOf(el, ExpressionHighlight);
-    await assertScreenshot(
-      'expression-highlight/function',
-      getClip(el)
-    );
+    await assertScreenshot('expression-highlight/function', getClip(el));
   });
 
   it('renders plain text without expressions', async () => {
     const el = await createHighlight('Just plain text here');
     assert.instanceOf(el, ExpressionHighlight);
-    await assertScreenshot(
-      'expression-highlight/plain',
-      getClip(el)
-    );
+    await assertScreenshot('expression-highlight/plain', getClip(el));
   });
 });

--- a/test/temba-field-config.test.ts
+++ b/test/temba-field-config.test.ts
@@ -30,7 +30,10 @@ if (!customElements.get('temba-rich-edit')) {
       Object.defineProperty(this.editableDiv, 'selectionEnd', {
         get: () => this.caretEnd
       });
-      (this.editableDiv as any).setSelectionRange = (start: number, end: number) => {
+      (this.editableDiv as any).setSelectionRange = (
+        start: number,
+        end: number
+      ) => {
         this.caretStart = start;
         this.caretEnd = end;
       };

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -126,12 +126,11 @@ describe('Editor Revisions', () => {
     await revisionsWindow.updateComplete;
 
     // Check revisions window color - now inside the component's shadow DOM
-    const floatingWindow =
-      revisionsWindow.shadowRoot?.querySelector('temba-floating-window');
-    expect(floatingWindow).to.exist;
-    expect(floatingWindow.getAttribute('color')).to.equal(
-      'rgb(142, 94, 167)'
+    const floatingWindow = revisionsWindow.shadowRoot?.querySelector(
+      'temba-floating-window'
     );
+    expect(floatingWindow).to.exist;
+    expect(floatingWindow.getAttribute('color')).to.equal('rgb(142, 94, 167)');
 
     // Check selected item styles - inside the component's shadow DOM
     const selectedItem = revisionsWindow.shadowRoot?.querySelector(

--- a/test/temba-flow-self-routing.test.ts
+++ b/test/temba-flow-self-routing.test.ts
@@ -155,7 +155,11 @@ describe('Flow Editor Self-Routing Prevention', () => {
         } as any);
 
       // Set up editor state
-      (editor as any).plumber = { connectionDragging: true, setContainer: stub(), repaintEverything: stub() };
+      (editor as any).plumber = {
+        connectionDragging: true,
+        setContainer: stub(),
+        repaintEverything: stub()
+      };
       (editor as any).definition = mockDefinition;
       (editor as any).sourceId = 'exit-1a';
       (editor as any).sourceNodeId = 'node-1';

--- a/test/temba-message-editor.test.ts
+++ b/test/temba-message-editor.test.ts
@@ -261,9 +261,7 @@ describe('temba-message-editor', () => {
       'temba-message-editor'
     )) as MessageEditor;
 
-    const richEdit = editor.shadowRoot.querySelector(
-      'temba-rich-edit'
-    ) as any;
+    const richEdit = editor.shadowRoot.querySelector('temba-rich-edit') as any;
     expect(richEdit).to.not.be.null;
     const editableDiv = richEdit.shadowRoot.querySelector(
       '.highlight-editor'

--- a/test/temba-modax.test.ts
+++ b/test/temba-modax.test.ts
@@ -3,12 +3,7 @@ import { useFakeTimers } from 'sinon';
 import { Button } from '../src/display/Button';
 import { Modax } from '../src/layout/Modax';
 import { CustomEventType } from '../src/interfaces';
-import {
-  assertScreenshot,
-  getClip,
-  mockGET,
-  mockPOST
-} from './utils.test';
+import { assertScreenshot, getClip, mockGET, mockPOST } from './utils.test';
 
 let clock: any;
 
@@ -180,57 +175,37 @@ describe('temba-modax', () => {
   });
 
   it('applies header colors from response headers', async () => {
-    mockGET(
-      /\/test-assets\/modax\/hello\.html/,
-      '<div>Colored Header</div>',
-      {
-        'X-Temba-Header-Bg': '#8e5ea7',
-        'X-Temba-Header-Text': '#fff'
-      }
-    );
+    mockGET(/\/test-assets\/modax\/hello\.html/, '<div>Colored Header</div>', {
+      'X-Temba-Header-Bg': '#8e5ea7',
+      'X-Temba-Header-Text': '#fff'
+    });
 
     const modax: Modax = await fixture(
       getModaxHTML('/test-assets/modax/hello.html')
     );
 
     await open(modax);
-    expect(modax.style.getPropertyValue('--header-bg')).to.equal(
-      '#8e5ea7'
-    );
-    expect(
-      modax.style.getPropertyValue('--header-text')
-    ).to.equal('#fff');
+    expect(modax.style.getPropertyValue('--header-bg')).to.equal('#8e5ea7');
+    expect(modax.style.getPropertyValue('--header-text')).to.equal('#fff');
   });
 
   it('clears header colors when headers are absent', async () => {
     // First load with custom headers
-    mockGET(
-      /\/colored-header\.html/,
-      '<div>Colored</div>',
-      {
-        'X-Temba-Header-Bg': '#8e5ea7',
-        'X-Temba-Header-Text': '#fff'
-      }
-    );
+    mockGET(/\/colored-header\.html/, '<div>Colored</div>', {
+      'X-Temba-Header-Bg': '#8e5ea7',
+      'X-Temba-Header-Text': '#fff'
+    });
 
-    const modax: Modax = await fixture(
-      getModaxHTML('/colored-header.html')
-    );
+    const modax: Modax = await fixture(getModaxHTML('/colored-header.html'));
 
     await open(modax);
-    expect(modax.style.getPropertyValue('--header-bg')).to.equal(
-      '#8e5ea7'
-    );
+    expect(modax.style.getPropertyValue('--header-bg')).to.equal('#8e5ea7');
 
     // Close and reopen with a different endpoint (no headers)
     await clickPrimary(modax);
     modax.endpoint = '/test-assets/modax/form.html';
     await open(modax);
-    expect(modax.style.getPropertyValue('--header-bg')).to.equal(
-      ''
-    );
-    expect(
-      modax.style.getPropertyValue('--header-text')
-    ).to.equal('');
+    expect(modax.style.getPropertyValue('--header-bg')).to.equal('');
+    expect(modax.style.getPropertyValue('--header-text')).to.equal('');
   });
 });

--- a/test/temba-node-editor.test.ts
+++ b/test/temba-node-editor.test.ts
@@ -539,14 +539,11 @@ describe('temba-node-editor', () => {
 
     // Check that bubble counts are displayed in accordion sections
     // Bubbles are now inside temba-accordion-section shadow DOMs
-    const sections = el.shadowRoot.querySelectorAll(
-      'temba-accordion-section'
-    );
+    const sections = el.shadowRoot.querySelectorAll('temba-accordion-section');
     const bubbles: Element[] = [];
     sections.forEach((section) => {
-      const sectionBubbles = section.shadowRoot.querySelectorAll(
-        '.count-bubble'
-      );
+      const sectionBubbles =
+        section.shadowRoot.querySelectorAll('.count-bubble');
       sectionBubbles.forEach((b) => bubbles.push(b));
     });
 
@@ -554,9 +551,7 @@ describe('temba-node-editor', () => {
     expect(bubbles.length).to.be.greaterThan(0);
 
     // Check specific bubble values (trim to handle whitespace in rendered text)
-    const bubbleTexts = bubbles.map((bubble) =>
-      bubble.textContent?.trim()
-    );
+    const bubbleTexts = bubbles.map((bubble) => bubble.textContent?.trim());
 
     // Runtime attachments section should show bubble when collapsed and has values
     expect(bubbleTexts).to.include('2'); // 2 runtime attachments
@@ -582,9 +577,7 @@ describe('temba-node-editor', () => {
 
     // Check that arrows are displayed instead of bubbles
     // Elements are now inside temba-accordion-section shadow DOMs
-    const sections = el.shadowRoot.querySelectorAll(
-      'temba-accordion-section'
-    );
+    const sections = el.shadowRoot.querySelectorAll('temba-accordion-section');
     const bubbles: Element[] = [];
     const arrows: Element[] = [];
     sections.forEach((section) => {

--- a/test/temba-rich-edit.test.ts
+++ b/test/temba-rich-edit.test.ts
@@ -4,10 +4,7 @@ import { fixture, html, expect } from '@open-wc/testing';
 describe('temba-rich-edit', () => {
   it('emits input when selecting a completion option', async () => {
     const editor = (await fixture(html`
-      <temba-rich-edit
-        value="@con"
-        session
-      ></temba-rich-edit>
+      <temba-rich-edit value="@con" session></temba-rich-edit>
     `)) as any;
 
     await editor.updateComplete;
@@ -49,10 +46,7 @@ describe('temba-rich-edit', () => {
 
   it('emits input when selecting completion via keyboard', async () => {
     const editor = (await fixture(html`
-      <temba-rich-edit
-        value="@con"
-        session
-      ></temba-rich-edit>
+      <temba-rich-edit value="@con" session></temba-rich-edit>
     `)) as any;
 
     await editor.updateComplete;
@@ -85,10 +79,7 @@ describe('temba-rich-edit', () => {
 
   it('undoes completion back to pre-completion value', async () => {
     const editor = (await fixture(html`
-      <temba-rich-edit
-        value="@co"
-        session
-      ></temba-rich-edit>
+      <temba-rich-edit value="@co" session></temba-rich-edit>
     `)) as any;
 
     await editor.updateComplete;

--- a/test/temba-user.test.ts
+++ b/test/temba-user.test.ts
@@ -8,9 +8,7 @@ const createUser = async (markup: string): Promise<TembaUser> => {
 
 describe('temba-user', () => {
   it('renders with initials from name', async () => {
-    const user = await createUser(
-      '<temba-user name="Jane Doe"></temba-user>'
-    );
+    const user = await createUser('<temba-user name="Jane Doe"></temba-user>');
     assert.instanceOf(user, TembaUser);
     assert.equal(user.initials, 'JD');
     assert.notEqual(user.bgcolor, '#e6e6e6');
@@ -18,9 +16,7 @@ describe('temba-user', () => {
   });
 
   it('resets initials and bgcolor when name is cleared', async () => {
-    const user = await createUser(
-      '<temba-user name="Jane Doe"></temba-user>'
-    );
+    const user = await createUser('<temba-user name="Jane Doe"></temba-user>');
     user.name = '';
     await user.updateComplete;
     assert.equal(user.initials, '');
@@ -53,9 +49,7 @@ describe('temba-user', () => {
   });
 
   it('omits name element when showName is false', async () => {
-    const user = await createUser(
-      '<temba-user name="Jane Doe"></temba-user>'
-    );
+    const user = await createUser('<temba-user name="Jane Doe"></temba-user>');
     await user.updateComplete;
     assert.isNull(user.shadowRoot.querySelector('.name'));
   });


### PR DESCRIPTION
Runs `pnpm format` (eslint `--fix` + prettier) across the codebase to catch up on drift. Pure whitespace and line-wrap changes; no logic edits.