### PR TITLE
Use distinct icon for Say Message canvas shortcut

### DIFF
--- a/src/flow/types.ts
+++ b/src/flow/types.ts
@@ -36,7 +36,7 @@ export const CONTEXT_MENU_SHORTCUTS: Record<FlowType, ContextMenuShortcut[]> = {
     { type: 'wait_for_response', name: 'Wait for Response', icon: 'message' }
   ],
   [FlowTypes.VOICE]: [
-    { type: 'say_msg', name: 'Say Message', icon: 'send' },
+    { type: 'say_msg', name: 'Say Message', icon: 'recording' },
     { type: 'wait_for_menu', name: 'Wait for Menu', icon: 'dots-grid' }
   ],
   [FlowTypes.BACKGROUND]: [


### PR DESCRIPTION
## Summary

The canvas context-menu shortcut for **Say Message** in voice flows previously used the same `send` icon as **Send Message** in message flows, making them visually indistinguishable and semantically a poor fit for a TTS action. This change swaps it to the `recording` (microphone) icon, which is both distinct and more representative of speaking/voice output.

## Test plan

- [x] `pnpm test:fast --files test/temba-canvas-menu.test.ts` passes
- [ ] Visually confirm the Say Message shortcut shows a microphone icon in a voice flow canvas menu