### PR TITLE
Visualize translation status in Compose language selector

### DIFF
--- a/demo/components/compose/example.html
+++ b/demo/components/compose/example.html
@@ -67,6 +67,42 @@
     </div>
 
     <div class="example">
+      <h3>Compose with Multiple Languages</h3>
+      <p>
+        A compose component showing translation status for each language
+        (Original, translated, untranslated)
+      </p>
+      <temba-compose
+        id="multilang-compose"
+        placeholder="Write a message..."
+        attachments
+        quickReplies
+      >
+      </temba-compose>
+      <script>
+        const el = document.getElementById('multilang-compose');
+        el.languages = [
+          { iso: 'eng', name: 'English' },
+          { iso: 'spa', name: 'Spanish' },
+          { iso: 'fra', name: 'French' },
+          { iso: 'deu', name: 'German' }
+        ];
+        el.value = JSON.stringify({
+          eng: {
+            text: 'Hello there!',
+            attachments: [],
+            quick_replies: ['Yes', 'No']
+          },
+          spa: {
+            text: '¡Hola!',
+            attachments: [],
+            quick_replies: []
+          }
+        });
+      </script>
+    </div>
+
+    <div class="example">
       <h3>Full Featured Compose</h3>
       <p>A compose component with attachments, quick replies, counter, and completion</p>
       <temba-compose

--- a/src/form/Compose.ts
+++ b/src/form/Compose.ts
@@ -281,7 +281,9 @@ export class Compose extends FieldElement {
   }
 
   private getSortedLanguages(): Language[] {
-    return [...this.languages].sort((a, b) => {
+    if (this.languages.length === 0) return [];
+    const [base, ...rest] = this.languages;
+    const sorted = [...rest].sort((a, b) => {
       const aTranslated = this.hasTranslation(a.iso);
       const bTranslated = this.hasTranslation(b.iso);
       if (aTranslated !== bTranslated) {
@@ -289,6 +291,7 @@ export class Compose extends FieldElement {
       }
       return 0;
     });
+    return [base, ...sorted];
   }
 
   private renderLanguageOption = (option: Language): TemplateResult => {
@@ -476,11 +479,15 @@ export class Compose extends FieldElement {
       if (editor) {
         const richEdit = editor.getRichEditor();
         if (richEdit) {
-          richEdit.value = this.initialText;
+          const targetText = this.initialText;
+          const targetLanguage = this.currentLanguage;
+          richEdit.value = targetText;
           const editable = richEdit.inputElement;
           if (editable) {
             window.setTimeout(() => {
-              setCaretOffset(editable, this.initialText.length);
+              if (this.currentLanguage === targetLanguage) {
+                setCaretOffset(editable, targetText.length);
+              }
             }, 0);
           }
         }
@@ -497,12 +504,6 @@ export class Compose extends FieldElement {
       changes.has('variables')
     ) {
       this.fireCustomEvent(CustomEventType.ContentChanged, this.langValues);
-      const langSelect = this.shadowRoot.querySelector(
-        'temba-select.language'
-      ) as Select<any>;
-      if (langSelect) {
-        langSelect.requestUpdate();
-      }
     }
   }
 

--- a/src/form/Compose.ts
+++ b/src/form/Compose.ts
@@ -2,12 +2,12 @@ import { TemplateResult, html, css, PropertyValues, nothing } from 'lit';
 import { FieldElement } from './FieldElement';
 import { property } from 'lit/decorators.js';
 import { Attachment, CustomEventType, Language, Shortcut } from '../interfaces';
+import { Icon } from '../Icons';
 import { DEFAULT_MEDIA_ENDPOINT } from '../utils';
 import { Select } from './select/Select';
 import { MessageEditor } from './MessageEditor';
 import { ShortcutList } from '../list/ShortcutList';
 import { setCaretOffset } from '../excellent/caret-utils';
-import { Icon } from '../Icons';
 
 export interface ComposeValue {
   text: string;
@@ -270,6 +270,62 @@ export class Compose extends FieldElement {
     );
   }
 
+  private hasTranslation(iso: string): boolean {
+    const entry = this.langValues?.[iso];
+    if (!entry) return false;
+    return !!(
+      (entry.text && entry.text.trim().length > 0) ||
+      (entry.attachments && entry.attachments.length > 0) ||
+      (entry.quick_replies && entry.quick_replies.length > 0)
+    );
+  }
+
+  private getSortedLanguages(): Language[] {
+    return [...this.languages].sort((a, b) => {
+      const aTranslated = this.hasTranslation(a.iso);
+      const bTranslated = this.hasTranslation(b.iso);
+      if (aTranslated !== bTranslated) {
+        return aTranslated ? -1 : 1;
+      }
+      return 0;
+    });
+  }
+
+  private renderLanguageOption = (option: Language): TemplateResult => {
+    const isBase =
+      this.languages.length > 0 && option.iso === this.languages[0].iso;
+
+    const badgeBase =
+      'display:inline-flex; align-items:center; border-radius:999px; font-size:10px; font-weight:700; line-height:1;';
+
+    let badge: TemplateResult;
+    if (isBase) {
+      badge = html`<span
+        style="${badgeBase} background:rgba(47, 63, 82, 0.12); color:#2f3f52; padding:3px 7px;"
+        >Original</span
+      >`;
+    } else if (this.hasTranslation(option.iso)) {
+      badge = html`<span
+        style="${badgeBase} background:rgba(26, 127, 55, 0.15); color:#1a7f37; padding:3px 7px;"
+        >Translated</span
+      >`;
+    } else {
+      badge = html`<span
+        style="${badgeBase} background:transparent; color:#8a94a1; border:1px solid #c2c8d0; padding:2px 6px;"
+        >Missing</span
+      >`;
+    }
+
+    return html`
+      <div
+        style="display:flex; align-items:center; justify-content:space-between; gap:8px; flex:1; padding:2px 8px;"
+      >
+        <span>${option.name}</span>
+        ${badge}
+      </div>
+    `;
+  };
+
   public willUpdate(changed: PropertyValues): void {
     super.willUpdate(changed);
 
@@ -421,6 +477,12 @@ export class Compose extends FieldElement {
         const richEdit = editor.getRichEditor();
         if (richEdit) {
           richEdit.value = this.initialText;
+          const editable = richEdit.inputElement;
+          if (editable) {
+            window.setTimeout(() => {
+              setCaretOffset(editable, this.initialText.length);
+            }, 0);
+          }
         }
       }
     }
@@ -435,6 +497,12 @@ export class Compose extends FieldElement {
       changes.has('variables')
     ) {
       this.fireCustomEvent(CustomEventType.ContentChanged, this.langValues);
+      const langSelect = this.shadowRoot.querySelector(
+        'temba-select.language'
+      ) as Select<any>;
+      if (langSelect) {
+        langSelect.requestUpdate();
+      }
     }
   }
 
@@ -657,7 +725,8 @@ export class Compose extends FieldElement {
               @change=${this.handleLanguageChange}
               class="language"
               name="language"
-              .staticOptions=${this.languages}
+              .staticOptions=${this.getSortedLanguages()}
+              .renderOption=${this.renderLanguageOption}
               valueKey="iso"
             >
             </temba-select>`

--- a/src/form/select/Select.ts
+++ b/src/form/select/Select.ts
@@ -2272,7 +2272,7 @@ export class Select<T extends SelectOption> extends FieldElement {
                             --icon-color: var(--color-text-dark);
                             ${this.isMultiMode
                 ? 'vertical-align: middle; background: #fff; border: 1px solid rgba(100,100,100,0.3); user-select: none; border-radius: 2px; align-items: center; flex-direction: row; flex-wrap: nowrap; margin: 2px 2px;'
-                : ''}
+                : 'flex: 1; min-width: 0;'}
                             ${index === this.selectedIndex
                 ? 'background: rgba(100,100,100,0.3);'
                 : ''}

--- a/test/temba-compose.test.ts
+++ b/test/temba-compose.test.ts
@@ -266,3 +266,112 @@ describe('temba-compose broadcast edit', () => {
     expect(editor).to.not.be.null;
   });
 });
+
+describe('temba-compose language visualization', () => {
+  const getLangSelect = async (compose: Compose) => {
+    const select = compose.shadowRoot.querySelector(
+      'temba-select.language'
+    ) as any;
+    if (select) {
+      await select.updateComplete;
+    }
+    return select;
+  };
+
+  it('pins base language first and sorts translated before missing', async () => {
+    const langValue = {
+      eng: { text: 'Hello', attachments: [], quick_replies: [] },
+      fra: { text: 'Bonjour', attachments: [], quick_replies: [] }
+    };
+    const compose: Compose = await getCompose({
+      languages: JSON.stringify([
+        { iso: 'eng', name: 'English' },
+        { iso: 'spa', name: 'Spanish' },
+        { iso: 'fra', name: 'French' },
+        { iso: 'deu', name: 'German' }
+      ]),
+      value: JSON.stringify(langValue)
+    });
+
+    const select = await getLangSelect(compose);
+    const options = select.staticOptions;
+    expect(options.map((o: any) => o.iso)).to.deep.equal([
+      'eng',
+      'fra',
+      'spa',
+      'deu'
+    ]);
+  });
+
+  it('keeps base language first even when it has no content', async () => {
+    const langValue = {
+      fra: { text: 'Bonjour', attachments: [], quick_replies: [] }
+    };
+    const compose: Compose = await getCompose({
+      languages: JSON.stringify([
+        { iso: 'eng', name: 'English' },
+        { iso: 'fra', name: 'French' }
+      ]),
+      value: JSON.stringify(langValue)
+    });
+
+    const select = await getLangSelect(compose);
+    expect(select.staticOptions.map((o: any) => o.iso)).to.deep.equal([
+      'eng',
+      'fra'
+    ]);
+  });
+
+  it('renders Original badge for the base language in the selected display', async () => {
+    const compose: Compose = await getCompose({
+      languages: JSON.stringify([
+        { iso: 'eng', name: 'English' },
+        { iso: 'spa', name: 'Spanish' }
+      ]),
+      value: JSON.stringify({
+        eng: { text: 'Hello', attachments: [], quick_replies: [] }
+      })
+    });
+
+    const select = await getLangSelect(compose);
+    expect(select.shadowRoot.querySelector('.selected').textContent).to.include(
+      'Original'
+    );
+  });
+
+  it('reorders options when content is added to a previously missing language', async () => {
+    const compose: Compose = await getCompose({
+      languages: JSON.stringify([
+        { iso: 'eng', name: 'English' },
+        { iso: 'spa', name: 'Spanish' },
+        { iso: 'deu', name: 'German' }
+      ]),
+      value: JSON.stringify({
+        eng: { text: 'Hello', attachments: [], quick_replies: [] }
+      })
+    });
+
+    let select = await getLangSelect(compose);
+    expect(select.staticOptions.map((o: any) => o.iso)).to.deep.equal([
+      'eng',
+      'spa',
+      'deu'
+    ]);
+
+    // Simulate the user adding a translation for German
+    compose.langValues = {
+      ...compose.langValues,
+      deu: { text: 'Hallo', attachments: [], quick_replies: [] }
+    };
+    compose.currentLanguage = 'deu';
+    compose.currentText = 'Hallo';
+    await compose.updateComplete;
+
+    select = await getLangSelect(compose);
+    expect(select.staticOptions.map((o: any) => o.iso)).to.deep.equal([
+      'eng',
+      'deu',
+      'spa'
+    ]);
+  });
+});

--- a/test/temba-select.test.ts
+++ b/test/temba-select.test.ts
@@ -259,6 +259,21 @@ describe('temba-select', () => {
       // but our cursor should be on the first match
       assert.equal(select.cursorIndex, 0);
     });
+
+    it('single-mode selected-item flexes to fill its container', async () => {
+      // Needed so custom renderOption content can right-align trailing
+      // elements (e.g. status badges) in the closed/selected state.
+      const select = await createSelect(
+        clock,
+        getSelectHTML(colors, { value: '1' })
+      );
+      const selectedItem = select.shadowRoot.querySelector(
+        '.selected-item'
+      ) as HTMLElement;
+      expect(selectedItem).to.not.be.null;
+      const computed = window.getComputedStyle(selectedItem);
+      expect(computed.flexGrow).to.equal('1');
+    });
   });
 
   describe('multiple selection', () => {


### PR DESCRIPTION
## Summary

- Adds pill badges to each language option in the Compose widget's language selector: **Original** for the base language, **Translated** for languages with content, **Missing** for ones without.
- Options are sorted translated-first so incomplete translations fall to the bottom; the selected language display now stays in sync as content changes.
- Focusing a language places the caret at the end of its existing text instead of the start.
- Single-select `.selected-item` now flexes to fill its container so custom renderers can right-align trailing content (badges) the same way they do in the dropdown list.

## Test plan

- [ ] Open the "Compose with Multiple Languages" demo example and verify the Original/Translated/Missing badges appear and sort correctly.
- [ ] Type in a non-base language and confirm the closed selector badge switches from Missing to Translated.
- [ ] Switch languages and verify the caret lands at the end of the existing text.