### PR TITLE
Fix field error styling on temba-compose

### DIFF
--- a/src/form/Compose.ts
+++ b/src/form/Compose.ts
@@ -21,6 +21,7 @@ export interface ComposeValue {
 export class Compose extends FieldElement {
   static get styles() {
     return css`
+      ${super.styles}
       :host {
         border-top-right-radius: var(--curvature);
         border-top-left-radius: var(--curvature);


### PR DESCRIPTION
`Compose` defined its own `static get styles()` without including `${super.styles}`, so it was missing the base `FieldElement` styles — including `.alert-error`, `.has-error`, and `.help-text`. Form field errors on `temba-compose` rendered as plain unstyled text below the widget instead of the red popup-on-hover used by other fields.

Adds `${super.styles}` to match the pattern used by `TextInput`, `Select`, `Checkbox`, and other `FieldElement` subclasses.