### PR TITLE
Re-enable auto translate using new bulk LLM endpoint

### DIFF
--- a/src/display/Button.ts
+++ b/src/display/Button.ts
@@ -53,16 +53,20 @@ export class Button extends LitElement {
         background: rgba(0, 0, 0, 0.05);
       }
 
-      .button-container:focus {
-        outline: none;
-        margin: 0;
+      .button-mask:active {
+        background: rgba(0, 0, 0, 0.12);
       }
 
       .button-container:focus {
+        outline: none;
+      }
+
+      /* Only show the focus ring for keyboard navigation, never on click. */
+      .button-container:focus-visible {
         box-shadow: var(--widget-box-shadow-focused);
       }
 
-      .button-container.secondary-button:focus .button-mask {
+      .button-container.secondary-button:focus-visible .button-mask {
         background: transparent;
       }
 
@@ -103,7 +107,8 @@ export class Button extends LitElement {
         border: 1px solid transparent;
       }
 
-      .button-container.secondary-button.active-button:focus .button-mask {
+      .button-container.secondary-button.active-button:focus-visible
+        .button-mask {
         background: transparent;
         box-shadow: none;
       }

--- a/src/flow/AutoTranslate.ts
+++ b/src/flow/AutoTranslate.ts
@@ -6,6 +6,7 @@ import { getStore } from '../store/Store';
 import { zustand } from '../store/AppState';
 import { FlowDefinition } from '../store/flow-definition';
 import { TranslationEntry, buildTranslationBundles } from './flow-translations';
+import { getLanguageDisplayName } from './utils';
 
 interface TranslationModel {
   uuid: string;
@@ -528,10 +529,11 @@ export class AutoTranslate extends RapidElement {
     }
 
     const selected = this.selectedModel ? [this.selectedModel] : [];
+    const languageName = getLanguageDisplayName(this.languageCode);
     return html`
       <p>
-        Untranslated text will be sent to the selected AI model and the
-        responses saved automatically.
+        All remaining text for <strong>${languageName}</strong> will be
+        translated automatically. Remember, AI models can make mistakes so it is important to review all of your translations to verify they are correct.
       </p>
       ${this.models.length > 1
         ? html`<temba-select

--- a/src/flow/AutoTranslate.ts
+++ b/src/flow/AutoTranslate.ts
@@ -1,0 +1,611 @@
+import { html, TemplateResult } from 'lit-html';
+import { css, PropertyValues } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import { RapidElement } from '../RapidElement';
+import { getStore } from '../store/Store';
+import { zustand } from '../store/AppState';
+import { FlowDefinition } from '../store/flow-definition';
+import { TranslationEntry, buildTranslationBundles } from './flow-translations';
+
+interface TranslationModel {
+  uuid: string;
+  name: string;
+}
+
+const MODELS_ENDPOINT = '/api/internal/llms.json';
+const ADD_MODEL_URL = '/ai/';
+
+// Max size of the serialized JSON payload per translate request. Keeps the
+// LLM's output comfortably below its token limit. Measured against the full
+// payload (uuids, keys, JSON structural chars, and source strings).
+const TRANSLATION_BATCH_CHAR_LIMIT = 10000;
+
+export class AutoTranslate extends RapidElement {
+  static get styles() {
+    return css`
+      :host {
+        display: contents;
+      }
+
+      .auto-translate-body {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 20px;
+        font-size: 14px;
+        color: #374151;
+      }
+
+      .auto-translate-body p {
+        margin: 0;
+      }
+
+      .auto-translate-loading {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+        color: #6b7280;
+      }
+
+      .auto-translate-empty {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        font-size: 13px;
+      }
+
+      .auto-translate-empty a {
+        color: var(--color-link);
+        text-decoration: none;
+      }
+
+      .auto-translate-empty a:hover {
+        text-decoration: underline;
+      }
+
+      .auto-translate-single-model {
+        font-size: 13px;
+      }
+
+      .auto-translate-status {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        /* align with the progress bar in the body (body has 20px padding,
+           dialog-footer has 10px) */
+        padding-left: 10px;
+        font-size: 12px;
+        color: #6b7280;
+      }
+
+      .auto-translate-status-spinner {
+        --icon-color: #6b7280;
+      }
+
+      .auto-translate-error-block {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding: 12px 14px;
+        background: #fef2f2;
+        border: 1px solid #fecaca;
+        border-radius: 6px;
+        overflow: hidden;
+        font-size: 13px;
+        color: #7f1d1d;
+      }
+
+      .auto-translate-error-block p {
+        margin: 0;
+      }
+
+      .auto-translate-error-help {
+        color: inherit;
+      }
+
+      .auto-translate-error-toggle {
+        align-self: flex-start;
+        margin-top: 2px;
+        padding: 0;
+        background: none;
+        border: none;
+        color: inherit;
+        font: inherit;
+        font-size: 12px;
+        text-decoration: underline;
+        cursor: pointer;
+      }
+
+      .auto-translate-error-details {
+        margin: 6px -14px -12px;
+        padding: 10px 14px;
+        background: #fff;
+        border-top: 1px solid #fecaca;
+        font-size: 12px;
+        color: inherit;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+    `;
+  }
+
+  @property({ attribute: false })
+  definition: FlowDefinition | null = null;
+
+  @property({ type: String, attribute: 'language-code' })
+  languageCode = '';
+
+  @property({ type: Boolean })
+  disabled = false;
+
+  // Reactive flag the host can read to show "translating" state in UI
+  // adjacent to this component (e.g. the toolbar button).
+  @property({ type: Boolean, reflect: true })
+  running = false;
+
+  @state()
+  dialogOpen = false;
+
+  @state()
+  models: TranslationModel[] = [];
+
+  @state()
+  modelsLoading = false;
+
+  @state()
+  selectedModel: TranslationModel | null = null;
+
+  @state()
+  progress: { done: number; total: number } = { done: 0, total: 0 };
+
+  @state()
+  error: string | null = null;
+
+  @state()
+  errorExpanded = false;
+
+  @state()
+  interrupt = false;
+
+  /**
+   * Public entry point. If a translation is in flight, sets the interrupt
+   * flag; otherwise opens the model picker.
+   */
+  public async start(): Promise<void> {
+    if (this.disabled) {
+      return;
+    }
+
+    if (this.running) {
+      this.interrupt = true;
+      return;
+    }
+
+    this.error = null;
+    this.errorExpanded = false;
+    this.selectedModel = null;
+    this.dialogOpen = true;
+    await this.loadModels();
+
+    if (this.models.length === 1) {
+      this.selectedModel = this.models[0];
+    }
+  }
+
+  private async loadModels(): Promise<void> {
+    this.modelsLoading = true;
+    try {
+      const store = getStore();
+      const results = store
+        ? await store.getResults(MODELS_ENDPOINT, { force: true })
+        : [];
+      this.models = (results || []).map((r: any) => ({
+        uuid: r.uuid,
+        name: r.name
+      }));
+    } catch (err) {
+      console.error('Failed to load AI models', err);
+      this.models = [];
+      this.error = 'Unable to load AI models.';
+    } finally {
+      this.modelsLoading = false;
+    }
+  }
+
+  private handleModelChange(event: Event): void {
+    const select = event.target as any;
+    const next = select?.values?.[0];
+    this.selectedModel = next ? { uuid: next.uuid, name: next.name } : null;
+  }
+
+  private confirmTranslate(): void {
+    if (!this.selectedModel) {
+      return;
+    }
+    this.dialogOpen = false;
+    this.runAutoTranslation().catch((err) => {
+      console.error('Auto translation failed', err);
+      this.error = 'Auto translation failed. Please try again.';
+      this.running = false;
+    });
+  }
+
+  private cancelDialog(): void {
+    this.dialogOpen = false;
+  }
+
+  private dismissError(): void {
+    this.error = null;
+    this.errorExpanded = false;
+    this.progress = { done: 0, total: 0 };
+  }
+
+  /**
+   * Builds batches of translation requests from all untranslated entries,
+   * grouping so each request's serialized payload stays under
+   * TRANSLATION_BATCH_CHAR_LIMIT.
+   */
+  private buildTranslationBatches(): {
+    keyToEntries: Map<string, TranslationEntry[]>;
+    batches: { items: Record<string, string[]> }[];
+  } {
+    const keyToEntries = new Map<string, TranslationEntry[]>();
+    const batches: { items: Record<string, string[]> }[] = [];
+
+    if (!this.definition) {
+      return { keyToEntries, batches };
+    }
+
+    const bundles = buildTranslationBundles(this.definition, this.languageCode);
+    const pending: { key: string; entry: TranslationEntry }[] = [];
+
+    for (const bundle of bundles) {
+      for (const entry of bundle.translations) {
+        if (entry.to && entry.to.trim().length > 0) {
+          continue;
+        }
+        if (!entry.from || entry.from.trim().length === 0) {
+          continue;
+        }
+        const key = `${entry.uuid}:${entry.attribute}`;
+        pending.push({ key, entry });
+        const list = keyToEntries.get(key) || [];
+        list.push(entry);
+        keyToEntries.set(key, list);
+      }
+    }
+
+    const source = this.definition.language;
+    const target = this.languageCode;
+    const measurePayload = (items: Record<string, string[]>): number =>
+      JSON.stringify({ source, target, items }).length;
+
+    let current: Record<string, string[]> = {};
+
+    for (const { key, entry } of pending) {
+      const prevList = current[key];
+      const nextList = prevList ? [...prevList, entry.from] : [entry.from];
+      const tentative = { ...current, [key]: nextList };
+
+      const tentativeSize = measurePayload(tentative);
+      const batchHasItems = Object.keys(current).length > 0;
+
+      if (tentativeSize > TRANSLATION_BATCH_CHAR_LIMIT && batchHasItems) {
+        // a single oversized entry still ships on its own
+        batches.push({ items: current });
+        current = { [key]: [entry.from] };
+      } else {
+        current = tentative;
+      }
+    }
+
+    if (Object.keys(current).length > 0) {
+      batches.push({ items: current });
+    }
+
+    return { keyToEntries, batches };
+  }
+
+  /**
+   * Drives the batch loop. Public so tests can invoke directly with a
+   * pre-set selectedModel.
+   */
+  public async runAutoTranslation(): Promise<void> {
+    if (
+      !this.definition ||
+      !this.selectedModel ||
+      this.languageCode === this.definition.language
+    ) {
+      return;
+    }
+
+    const { keyToEntries, batches } = this.buildTranslationBatches();
+    if (batches.length === 0) {
+      return;
+    }
+
+    this.running = true;
+    this.interrupt = false;
+    this.progress = { done: 0, total: batches.length };
+
+    const source = this.definition.language;
+    const target = this.languageCode;
+    const url = `/llm/translate/${this.selectedModel.uuid}/`;
+    const store = getStore();
+    if (!store) {
+      this.running = false;
+      return;
+    }
+
+    for (let i = 0; i < batches.length; i++) {
+      if (this.interrupt) {
+        break;
+      }
+
+      try {
+        const response = await store.postJSON(url, {
+          source,
+          target,
+          items: batches[i].items
+        });
+
+        if (response.status >= 200 && response.status < 300) {
+          const returned: Record<string, string[]> = response.json?.items || {};
+          this.applyBatchTranslations(returned, keyToEntries);
+        } else {
+          this.error =
+            response.json?.error ||
+            `Translate request failed (${response.status}).`;
+          break;
+        }
+      } catch (err) {
+        console.error('Translate request failed', err);
+        this.error = 'Translate request failed.';
+        break;
+      }
+
+      this.progress = { done: i + 1, total: batches.length };
+    }
+
+    this.running = false;
+    this.interrupt = false;
+  }
+
+  private applyBatchTranslations(
+    returned: Record<string, string[]>,
+    keyToEntries: Map<string, TranslationEntry[]>
+  ): void {
+    const store = getStore();
+    if (!store || !this.definition) {
+      return;
+    }
+
+    // group updates by uuid so multiple attributes merge into one write
+    const updatesByUuid = new Map<string, Record<string, any>>();
+
+    for (const [key, values] of Object.entries(returned)) {
+      const entries = keyToEntries.get(key);
+      if (!entries || entries.length === 0) {
+        continue;
+      }
+      const [firstEntry] = entries;
+      const uuid = firstEntry.uuid;
+      const attribute = firstEntry.attribute;
+
+      keyToEntries.delete(key);
+
+      if (!values || values.length === 0) {
+        continue;
+      }
+
+      const existing =
+        this.definition.localization?.[this.languageCode]?.[uuid] || {};
+      const merged = updatesByUuid.get(uuid) || { ...existing };
+      merged[attribute] = values;
+      updatesByUuid.set(uuid, merged);
+    }
+
+    for (const [uuid, merged] of updatesByUuid.entries()) {
+      store.getState().updateLocalization(this.languageCode, uuid, merged);
+      zustand.getState().markAutoTranslated(
+        this.languageCode,
+        uuid,
+        Object.keys(merged).filter(
+          (k) => merged[k] && (merged[k] as any[]).length > 0
+        )
+      );
+    }
+  }
+
+  protected updated(changed: PropertyValues): void {
+    if (changed.has('running')) {
+      // emit a state-change event so the host can update adjacent UI
+      // (e.g. toolbar button) without polling
+      this.dispatchEvent(
+        new CustomEvent('temba-auto-translate-changed', {
+          detail: { running: this.running },
+          bubbles: true,
+          composed: true
+        })
+      );
+    }
+  }
+
+  private handleDialogButton(event: CustomEvent): void {
+    const name = event.detail?.button?.name;
+    if (this.error) {
+      // only the Dismiss button shows in the error state
+      this.dismissError();
+      return;
+    }
+    if (this.running) {
+      // only the Stop button shows while running
+      if (!this.interrupt) {
+        this.interrupt = true;
+      }
+      return;
+    }
+    if (name === 'Translate') {
+      this.confirmTranslate();
+    } else {
+      this.cancelDialog();
+    }
+  }
+
+  public render(): TemplateResult | string {
+    const showPicker = this.dialogOpen;
+    const showProgress = this.running || !!this.error;
+    const open = showPicker || showProgress;
+
+    if (!open) {
+      return '';
+    }
+
+    let header: string;
+    let body: TemplateResult;
+    let gutter: TemplateResult | string = '';
+    let primary = '';
+    let cancel = '';
+    let disabled = false;
+
+    if (this.error) {
+      header = 'Problem with AI Model';
+      body = this.renderErrorBody();
+      cancel = 'Dismiss';
+    } else if (this.running) {
+      header = 'Auto Translation';
+      body = this.renderRunningBody();
+      gutter = this.renderRunningGutter();
+      // Stop is the primary so the dialog does NOT auto-close on click;
+      // we close it ourselves once the in-flight batch returns
+      primary = 'Stop';
+      disabled = this.interrupt;
+    } else {
+      header = 'Auto Translation';
+      const noModels = !this.modelsLoading && this.models.length === 0;
+      body = this.renderPickerBody();
+      cancel = noModels ? 'Close' : 'Cancel';
+      primary = noModels ? '' : 'Translate';
+      disabled = this.modelsLoading || noModels || !this.selectedModel;
+    }
+
+    return html`
+      <temba-dialog
+        header=${header}
+        .open=${open}
+        size="small"
+        primaryButtonName=${primary}
+        cancelButtonName=${cancel}
+        ?disabled=${disabled}
+        variant="flat"
+        @temba-button-clicked=${this.handleDialogButton}
+      >
+        <div class="auto-translate-body">${body}</div>
+        ${gutter ? html`<div slot="gutter">${gutter}</div>` : ''}
+      </temba-dialog>
+    `;
+  }
+
+  private renderPickerBody(): TemplateResult {
+    if (this.modelsLoading) {
+      return html`<div class="auto-translate-loading">
+        <temba-loading units="3" size="8"></temba-loading>
+      </div>`;
+    }
+
+    if (this.models.length === 0) {
+      return html`
+        <div class="auto-translate-empty">
+          <p>You need to add an AI model before you can auto translate.</p>
+          <p>
+            <a href="${ADD_MODEL_URL}" target="_blank" rel="noopener"
+              >Manage AI models</a
+            >
+          </p>
+        </div>
+      `;
+    }
+
+    const selected = this.selectedModel ? [this.selectedModel] : [];
+    return html`
+      <p>
+        Untranslated text will be sent to the selected AI model and the
+        responses saved automatically.
+      </p>
+      ${this.models.length > 1
+        ? html`<temba-select
+            class="auto-translate-model-select"
+            endpoint="${MODELS_ENDPOINT}"
+            valueKey="uuid"
+            .values=${selected}
+            ?searchable=${true}
+            placeholder="Select an AI model"
+            @change=${this.handleModelChange}
+          ></temba-select>`
+        : html`<div class="auto-translate-single-model">
+            Using <strong>${this.models[0]?.name}</strong>
+          </div>`}
+    `;
+  }
+
+  private renderRunningBody(): TemplateResult {
+    const { done, total } = this.progress;
+    const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+
+    return html`
+      <temba-progress
+        .total=${total}
+        .current=${done}
+        .pct=${pct}
+        showPercentage
+      ></temba-progress>
+    `;
+  }
+
+  private renderRunningGutter(): TemplateResult {
+    const { done, total } = this.progress;
+    // current batch is 1-indexed: while batch 0 is in flight, done is still
+    // 0, so we display "1 of N"
+    const currentBatch = Math.min(done + 1, total);
+    const statusText = this.interrupt
+      ? 'Stopping...'
+      : total > 1
+        ? `Translating ${currentBatch} of ${total}`
+        : 'Translating';
+
+    return html`
+      <div class="auto-translate-status">
+        <temba-icon
+          class="auto-translate-status-spinner"
+          name="progress_spinner"
+          size="0.9"
+          spin
+        ></temba-icon>
+        <span>${statusText}</span>
+      </div>
+    `;
+  }
+
+  private renderErrorBody(): TemplateResult {
+    return html`
+      <div class="auto-translate-error-block">
+        <p class="auto-translate-error-help">
+          Any translations already applied have been kept. You can try again,
+          or check the AI model's settings if the problem persists.
+        </p>
+        ${this.errorExpanded
+          ? html`<pre class="auto-translate-error-details">
+${this.error}</pre
+            >`
+          : html`<button
+              class="auto-translate-error-toggle"
+              type="button"
+              @click=${() => (this.errorExpanded = true)}
+            >
+              Show details
+            </button>`}
+      </div>
+    `;
+  }
+}

--- a/src/flow/AutoTranslate.ts
+++ b/src/flow/AutoTranslate.ts
@@ -169,6 +169,11 @@ export class AutoTranslate extends RapidElement {
   @state()
   interrupt = false;
 
+  // Tracks whether the dialog has ever opened so we can keep it mounted
+  // afterwards (so it sees its own close transition) without paying
+  // for an empty hidden dialog before that.
+  private everOpened = false;
+
   /**
    * Public entry point. If a translation is in flight, sets the interrupt
    * flag; otherwise opens the model picker.
@@ -400,8 +405,13 @@ export class AutoTranslate extends RapidElement {
         continue;
       }
 
+      // read from the live store rather than this.definition, which can
+      // lag behind across batches and cause earlier attributes to be
+      // overwritten when multiple attrs on the same uuid land in
+      // different batches
+      const liveDefinition = zustand.getState().flowDefinition;
       const existing =
-        this.definition.localization?.[this.languageCode]?.[uuid] || {};
+        liveDefinition?.localization?.[this.languageCode]?.[uuid] || {};
       const merged = updatesByUuid.get(uuid) || { ...existing };
       merged[attribute] = values;
       updatesByUuid.set(uuid, merged);
@@ -459,12 +469,17 @@ export class AutoTranslate extends RapidElement {
     const showProgress = this.running || !!this.error;
     const open = showPicker || showProgress;
 
-    if (!open) {
+    // Skip rendering until the dialog has been opened at least once so we
+    // don't pay for an empty hidden dialog on every editor instance.
+    if (!open && !this.everOpened) {
       return '';
     }
+    if (open) {
+      this.everOpened = true;
+    }
 
-    let header: string;
-    let body: TemplateResult;
+    let header = 'Auto Translation';
+    let body: TemplateResult = html``;
     let gutter: TemplateResult | string = '';
     let primary = '';
     let cancel = '';
@@ -475,15 +490,13 @@ export class AutoTranslate extends RapidElement {
       body = this.renderErrorBody();
       cancel = 'Dismiss';
     } else if (this.running) {
-      header = 'Auto Translation';
       body = this.renderRunningBody();
       gutter = this.renderRunningGutter();
       // Stop is the primary so the dialog does NOT auto-close on click;
       // we close it ourselves once the in-flight batch returns
       primary = 'Stop';
       disabled = this.interrupt;
-    } else {
-      header = 'Auto Translation';
+    } else if (showPicker) {
       const noModels = !this.modelsLoading && this.models.length === 0;
       body = this.renderPickerBody();
       cancel = noModels ? 'Close' : 'Cancel';
@@ -491,6 +504,10 @@ export class AutoTranslate extends RapidElement {
       disabled = this.modelsLoading || noModels || !this.selectedModel;
     }
 
+    // We always render the dialog (after first open) so it sees the
+    // open: true -> false transition and runs its body scroll/unlock
+    // cleanup; otherwise body styles can stay stuck after auto-translate
+    // completes.
     return html`
       <temba-dialog
         header=${header}

--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -29,14 +29,18 @@ import {
   snapToGrid
 } from './utils';
 import { ACTION_CONFIG, NODE_CONFIG } from './config';
-import { getTranslatableCategoriesForNode } from './categoryLocalization';
 import { PRIMARY_LANGUAGE_OPTION_VALUE } from './EditorToolbar';
+import {
+  buildTranslationBundles,
+  getTranslationCounts
+} from './flow-translations';
 import { calculateLayeredLayout, placeStickyNotes } from './reflow';
 import type { RevisionsWindow } from './RevisionsWindow';
 
 import {
   ACTION_GROUP_METADATA,
   CONTEXT_MENU_SHORTCUTS,
+  Features,
   FlowType,
   FlowTypes
 } from './types';
@@ -85,22 +89,6 @@ export interface SelectionBox {
   endY: number;
 }
 
-type TranslationType = 'property' | 'category';
-
-interface TranslationEntry {
-  uuid: string;
-  type: TranslationType;
-  attribute: string;
-  from: string;
-  to: string | null;
-}
-
-interface TranslationBundle {
-  nodeUuid: string;
-  actionUuid?: string;
-  translations: TranslationEntry[];
-}
-
 export type ToolbarAction =
   | { action: 'view-change'; view: 'flow' | 'table' }
   | { action: 'zoom-in' }
@@ -109,7 +97,8 @@ export type ToolbarAction =
   | { action: 'zoom-to-full' }
   | { action: 'revisions' }
   | { action: 'search' }
-  | { action: 'language-change'; isPrimary?: boolean; languageCode?: string };
+  | { action: 'language-change'; isPrimary?: boolean; languageCode?: string }
+  | { action: 'auto-translate' };
 const EMPTY_FLOW_ISSUES: FlowIssue[] = [];
 
 // How long the pending-changes auto-save countdown runs (in ms).
@@ -211,6 +200,10 @@ export class Editor extends RapidElement {
   @property({ type: Array })
   public features: string[] = [];
 
+  private get autoTranslateEnabled(): boolean {
+    return this.features?.includes(Features.AUTO_TRANSLATE) ?? false;
+  }
+
   private activityTimer: number | null = null;
   private activityInterval = 100; // Start with 100ms interval for fast initial load
 
@@ -302,6 +295,9 @@ export class Editor extends RapidElement {
 
   @state()
   public zoom = 1.0;
+
+  @state()
+  private autoTranslating = false;
 
   // Non-reactive flag set in willUpdate to suppress the debouncedSave
   // call in updated() when the dirtyDate change comes from a reflow/copy
@@ -895,54 +891,6 @@ export class Editor extends RapidElement {
         font-weight: 600;
         cursor: pointer;
         transition: opacity 0.2s ease;
-      }
-
-      .auto-translate-button {
-        background: var(--color-primary-dark);
-        border: none;
-        color: #fff;
-        padding: 10px 12px;
-        border-radius: var(--curvature);
-        font-size: 12px;
-        font-weight: 600;
-        cursor: pointer;
-        transition: opacity 0.2s ease;
-      }
-
-      .auto-translate-button[disabled] {
-        opacity: 0.5;
-        cursor: not-allowed;
-      }
-
-      .auto-translate-error {
-        font-size: 12px;
-        color: #b91c1c;
-      }
-
-      .auto-translate-dialog-content {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-        font-size: 14px;
-        color: #374151;
-      }
-
-      .auto-translate-dialog-content p {
-        margin: 0;
-      }
-
-      .auto-translate-loading {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        font-size: 13px;
-        color: #6b7280;
-      }
-
-      .auto-translate-empty {
-        font-size: 13px;
-        color: #6b7280;
       }
 
       .localization-empty {
@@ -1799,239 +1747,8 @@ export class Editor extends RapidElement {
     total: number;
     localized: number;
   } {
-    if (
-      !this.definition ||
-      !languageCode ||
-      languageCode === this.definition.language
-    ) {
-      return { total: 0, localized: 0 };
-    }
-
-    const bundles = this.buildTranslationBundles(languageCode);
-    return this.getTranslationCounts(bundles);
-  }
-
-  private getLanguageLocalization(languageCode: string): Record<string, any> {
-    if (!this.definition?.localization) {
-      return {};
-    }
-    return this.definition.localization[languageCode] || {};
-  }
-
-  private buildTranslationBundles(
-    languageCode: string = this.languageCode
-  ): TranslationBundle[] {
-    if (
-      !this.definition ||
-      !languageCode ||
-      languageCode === this.definition.language
-    ) {
-      return [];
-    }
-
-    const languageLocalization = this.getLanguageLocalization(languageCode);
-    const bundles: TranslationBundle[] = [];
-
-    this.definition.nodes.forEach((node) => {
-      node.actions?.forEach((action) => {
-        const config = ACTION_CONFIG[action.type];
-        if (!config?.localizable || config.localizable.length === 0) {
-          return;
-        }
-
-        // For send_msg actions, only count 'text' for progress tracking
-        // (quick_replies and attachments are still localizable but don't count toward progress)
-        const localizableKeys =
-          action.type === 'send_msg'
-            ? config.localizable.filter((key) => key === 'text')
-            : config.localizable;
-
-        const translations = this.findTranslations(
-          'property',
-          action.uuid,
-          localizableKeys,
-          action,
-          languageLocalization
-        );
-
-        if (translations.length > 0) {
-          bundles.push({
-            nodeUuid: node.uuid,
-            actionUuid: action.uuid,
-            translations
-          });
-        }
-      });
-
-      const nodeUI = this.definition._ui?.nodes?.[node.uuid];
-      const nodeType = nodeUI?.type;
-      if (!nodeType) {
-        return;
-      }
-
-      // Include rule (case argument) translations when localizeRules is set
-      if (nodeUI?.config?.localizeRules && node.router?.cases?.length) {
-        const ruleTranslations = node.router.cases
-          .filter((c) => c.arguments?.length > 0 && c.arguments.some((a) => a))
-          .flatMap((c) =>
-            this.findTranslations(
-              'property',
-              c.uuid,
-              ['arguments'],
-              c,
-              languageLocalization
-            )
-          );
-
-        if (ruleTranslations.length > 0) {
-          bundles.push({
-            nodeUuid: node.uuid,
-            translations: ruleTranslations
-          });
-        }
-      }
-
-      const nodeConfig = NODE_CONFIG[nodeType];
-      if (
-        nodeUI?.config?.localizeCategories &&
-        nodeConfig?.localizable === 'categories' &&
-        node.router?.categories?.length
-      ) {
-        const translatableCategories = getTranslatableCategoriesForNode(
-          nodeType,
-          node.router.categories
-        );
-        const categoryTranslations = translatableCategories.flatMap(
-          (category) =>
-            this.findTranslations(
-              'category',
-              category.uuid,
-              ['name'],
-              category,
-              languageLocalization
-            )
-        );
-
-        if (categoryTranslations.length > 0) {
-          bundles.push({
-            nodeUuid: node.uuid,
-            translations: categoryTranslations
-          });
-        }
-      }
-    });
-
-    return bundles;
-  }
-
-  private findTranslations(
-    type: TranslationType,
-    uuid: string,
-    localizeableKeys: string[],
-    source: any,
-    localization: Record<string, any>
-  ): TranslationEntry[] {
-    const translations: TranslationEntry[] = [];
-
-    localizeableKeys.forEach((attribute) => {
-      if (attribute === 'quick_replies') {
-        return;
-      }
-
-      const pathSegments = attribute.split('.');
-      let from: any = source;
-      let to: any = [];
-
-      while (pathSegments.length > 0 && from) {
-        if (from.uuid) {
-          to = localization[from.uuid];
-        }
-
-        const path = pathSegments.shift();
-        if (!path) {
-          break;
-        }
-
-        if (to) {
-          to = to[path];
-        }
-        from = from[path];
-      }
-
-      if (!from) {
-        return;
-      }
-
-      const fromValue = this.formatTranslationValue(from);
-      if (!fromValue) {
-        return;
-      }
-
-      const toValue = to ? this.formatTranslationValue(to) : null;
-
-      translations.push({
-        uuid,
-        type,
-        attribute,
-        from: fromValue,
-        to: toValue
-      });
-    });
-
-    return translations;
-  }
-
-  private formatTranslationValue(value: any): string | null {
-    if (value === null || value === undefined) {
-      return null;
-    }
-
-    if (Array.isArray(value)) {
-      const normalized = value
-        .map((entry) => this.formatTranslationValue(entry))
-        .filter((entry) => !!entry) as string[];
-      return normalized.length > 0 ? normalized.join(', ') : null;
-    }
-
-    if (typeof value === 'object') {
-      if ('name' in value && value.name) {
-        return String(value.name);
-      }
-
-      if ('arguments' in value && Array.isArray(value.arguments)) {
-        return value.arguments.join(' ');
-      }
-
-      return null;
-    }
-
-    if (typeof value === 'number') {
-      return value.toString();
-    }
-
-    if (typeof value === 'string') {
-      const trimmed = value.trim();
-      return trimmed.length > 0 ? trimmed : null;
-    }
-
-    return null;
-  }
-
-  private getTranslationCounts(bundles: TranslationBundle[]): {
-    total: number;
-    localized: number;
-  } {
-    return bundles.reduce(
-      (counts, bundle) => {
-        bundle.translations.forEach((translation) => {
-          counts.total += 1;
-          if (translation.to && translation.to.trim().length > 0) {
-            counts.localized += 1;
-          }
-        });
-        return counts;
-      },
-      { total: 0, localized: 0 }
+    return getTranslationCounts(
+      buildTranslationBundles(this.definition, languageCode)
     );
   }
 
@@ -2040,6 +1757,18 @@ export class Editor extends RapidElement {
     return Object.values(this.definition._ui.nodes).some(
       (nodeUI: any) => nodeUI?.config?.localizeCategories
     );
+  }
+
+  private handleAutoTranslateClick(): void {
+    if (!this.autoTranslateEnabled || this.viewingRevision) {
+      return;
+    }
+    const at = this.querySelector('temba-auto-translate') as any;
+    at?.start();
+  }
+
+  private handleAutoTranslateChanged(e: CustomEvent): void {
+    this.autoTranslating = !!e.detail?.running;
   }
 
   disconnectedCallback(): void {
@@ -3961,6 +3690,12 @@ export class Editor extends RapidElement {
           })
         ];
 
+    const hasPendingTranslations =
+      this.autoTranslateEnabled &&
+      Boolean(activeLanguage) &&
+      progress.total > 0 &&
+      progress.localized < progress.total;
+
     return html`
       <temba-editor-toolbar
         ?message-view=${this.showMessageTable}
@@ -3976,6 +3711,10 @@ export class Editor extends RapidElement {
         ?is-base-language=${isBaseSelected}
         .languagePercent=${percent}
         ?show-localization-tools=${Boolean(activeLanguage)}
+        ?has-pending-translations=${hasPendingTranslations ||
+        this.autoTranslating}
+        ?auto-translate-disabled=${this.viewingRevision}
+        ?auto-translating=${this.autoTranslating}
         @temba-button-clicked=${this.handleToolbarAction}
       ></temba-editor-toolbar>
     `;
@@ -4010,6 +3749,9 @@ export class Editor extends RapidElement {
         break;
       case 'search':
         this.openFlowSearch();
+        break;
+      case 'auto-translate':
+        this.handleAutoTranslateClick();
         break;
       case 'language-change':
         if (detail.isPrimary) {
@@ -4186,6 +3928,14 @@ export class Editor extends RapidElement {
         @temba-revision-reverted=${this.handleRevisionReverted}
         @temba-revisions-closed=${this.handleRevisionsClosed}
       ></temba-revisions-window>
+      ${this.autoTranslateEnabled
+        ? html`<temba-auto-translate
+            .definition=${this.definition}
+            language-code=${this.languageCode}
+            ?disabled=${this.viewingRevision}
+            @temba-auto-translate-changed=${this.handleAutoTranslateChanged}
+          ></temba-auto-translate>`
+        : ''}
       <div id="editor-container">
         ${this.renderToolbarElement()}
         <div id="editor">

--- a/src/flow/EditorToolbar.ts
+++ b/src/flow/EditorToolbar.ts
@@ -249,6 +249,15 @@ export class EditorToolbar extends RapidElement {
   @property({ type: Boolean, attribute: 'show-localization-tools' })
   showLocalizationTools = false;
 
+  @property({ type: Boolean, attribute: 'has-pending-translations' })
+  hasPendingTranslations = false;
+
+  @property({ type: Boolean, attribute: 'auto-translate-disabled' })
+  autoTranslateDisabled = false;
+
+  @property({ type: Boolean, attribute: 'auto-translating' })
+  autoTranslating = false;
+
   @state()
   private showLanguageOptions = false;
 
@@ -559,7 +568,34 @@ export class EditorToolbar extends RapidElement {
   }
 
   private renderTranslationTools(): TemplateResult {
-    // auto translate button hidden pending backend changes
-    return html``;
+    if (!this.hasPendingTranslations && !this.autoTranslating) {
+      return html``;
+    }
+    const label = this.autoTranslating
+      ? 'Stop auto translate'
+      : 'Auto translate';
+    return html`
+      <div class="toolbar-translation">
+        ${this.renderTip(
+          label,
+          html`
+            <button
+              class="toolbar-btn language-tool ${this.autoTranslating
+                ? 'active'
+                : ''}"
+              @click=${() => this.fireToolbarAction('auto-translate')}
+              ?disabled=${this.autoTranslateDisabled}
+              aria-label=${label}
+            >
+              <temba-icon
+                name=${this.autoTranslating ? 'progress_spinner' : Icon.ai}
+                size="1"
+                ?spin=${this.autoTranslating}
+              ></temba-icon>
+            </button>
+          `
+        )}
+      </div>
+    `;
   }
 }

--- a/src/flow/flow-translations.ts
+++ b/src/flow/flow-translations.ts
@@ -1,0 +1,229 @@
+import { FlowDefinition } from '../store/flow-definition';
+import { ACTION_CONFIG, NODE_CONFIG } from './config';
+import { getTranslatableCategoriesForNode } from './categoryLocalization';
+
+export type TranslationType = 'property' | 'category';
+
+export interface TranslationEntry {
+  uuid: string;
+  type: TranslationType;
+  attribute: string;
+  from: string;
+  to: string | null;
+}
+
+export interface TranslationBundle {
+  nodeUuid: string;
+  actionUuid?: string;
+  translations: TranslationEntry[];
+}
+
+export function formatTranslationValue(value: any): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    const normalized = value
+      .map((entry) => formatTranslationValue(entry))
+      .filter((entry) => !!entry) as string[];
+    return normalized.length > 0 ? normalized.join(', ') : null;
+  }
+
+  if (typeof value === 'object') {
+    if ('name' in value && value.name) {
+      return String(value.name);
+    }
+    if ('arguments' in value && Array.isArray(value.arguments)) {
+      return value.arguments.join(' ');
+    }
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return value.toString();
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  return null;
+}
+
+export function findTranslations(
+  type: TranslationType,
+  uuid: string,
+  localizableKeys: string[],
+  source: any,
+  localization: Record<string, any>
+): TranslationEntry[] {
+  const translations: TranslationEntry[] = [];
+
+  localizableKeys.forEach((attribute) => {
+    if (attribute === 'quick_replies') {
+      return;
+    }
+
+    const pathSegments = attribute.split('.');
+    let from: any = source;
+    let to: any = [];
+
+    while (pathSegments.length > 0 && from) {
+      if (from.uuid) {
+        to = localization[from.uuid];
+      }
+
+      const path = pathSegments.shift();
+      if (!path) {
+        break;
+      }
+
+      if (to) {
+        to = to[path];
+      }
+      from = from[path];
+    }
+
+    if (!from) {
+      return;
+    }
+
+    const fromValue = formatTranslationValue(from);
+    if (!fromValue) {
+      return;
+    }
+
+    const toValue = to ? formatTranslationValue(to) : null;
+
+    translations.push({
+      uuid,
+      type,
+      attribute,
+      from: fromValue,
+      to: toValue
+    });
+  });
+
+  return translations;
+}
+
+export function buildTranslationBundles(
+  definition: FlowDefinition | null | undefined,
+  languageCode: string
+): TranslationBundle[] {
+  if (!definition || !languageCode || languageCode === definition.language) {
+    return [];
+  }
+
+  const languageLocalization = definition.localization?.[languageCode] || {};
+  const bundles: TranslationBundle[] = [];
+
+  definition.nodes.forEach((node) => {
+    node.actions?.forEach((action) => {
+      const config = ACTION_CONFIG[action.type];
+      if (!config?.localizable || config.localizable.length === 0) {
+        return;
+      }
+
+      // For send_msg actions, only count 'text' for progress tracking
+      // (quick_replies and attachments are still localizable but don't count toward progress)
+      const localizableKeys =
+        action.type === 'send_msg'
+          ? config.localizable.filter((key) => key === 'text')
+          : config.localizable;
+
+      const translations = findTranslations(
+        'property',
+        action.uuid,
+        localizableKeys,
+        action,
+        languageLocalization
+      );
+
+      if (translations.length > 0) {
+        bundles.push({
+          nodeUuid: node.uuid,
+          actionUuid: action.uuid,
+          translations
+        });
+      }
+    });
+
+    const nodeUI = definition._ui?.nodes?.[node.uuid];
+    const nodeType = nodeUI?.type;
+    if (!nodeType) {
+      return;
+    }
+
+    if (nodeUI?.config?.localizeRules && node.router?.cases?.length) {
+      const ruleTranslations = node.router.cases
+        .filter((c) => c.arguments?.length > 0 && c.arguments.some((a) => a))
+        .flatMap((c) =>
+          findTranslations(
+            'property',
+            c.uuid,
+            ['arguments'],
+            c,
+            languageLocalization
+          )
+        );
+
+      if (ruleTranslations.length > 0) {
+        bundles.push({
+          nodeUuid: node.uuid,
+          translations: ruleTranslations
+        });
+      }
+    }
+
+    const nodeConfig = NODE_CONFIG[nodeType];
+    if (
+      nodeUI?.config?.localizeCategories &&
+      nodeConfig?.localizable === 'categories' &&
+      node.router?.categories?.length
+    ) {
+      const translatableCategories = getTranslatableCategoriesForNode(
+        nodeType,
+        node.router.categories
+      );
+      const categoryTranslations = translatableCategories.flatMap((category) =>
+        findTranslations(
+          'category',
+          category.uuid,
+          ['name'],
+          category,
+          languageLocalization
+        )
+      );
+
+      if (categoryTranslations.length > 0) {
+        bundles.push({
+          nodeUuid: node.uuid,
+          translations: categoryTranslations
+        });
+      }
+    }
+  });
+
+  return bundles;
+}
+
+export function getTranslationCounts(bundles: TranslationBundle[]): {
+  total: number;
+  localized: number;
+} {
+  return bundles.reduce(
+    (counts, bundle) => {
+      bundle.translations.forEach((translation) => {
+        counts.total += 1;
+        if (translation.to && translation.to.trim().length > 0) {
+          counts.localized += 1;
+        }
+      });
+      return counts;
+    },
+    { total: 0, localized: 0 }
+  );
+}

--- a/src/flow/types.ts
+++ b/src/flow/types.ts
@@ -50,7 +50,8 @@ export const CONTEXT_MENU_SHORTCUTS: Record<FlowType, ContextMenuShortcut[]> = {
 export const Features = {
   AI: 'ai',
   AIRTIME: 'airtime',
-  LOCATIONS: 'locations'
+  LOCATIONS: 'locations',
+  AUTO_TRANSLATE: 'auto_translate'
 } as const;
 
 export type Feature = (typeof Features)[keyof typeof Features];

--- a/src/layout/Dialog.ts
+++ b/src/layout/Dialog.ts
@@ -142,9 +142,24 @@ export class Dialog extends ResizeElement {
         flex-direction: row;
         align-items: center;
         font-size: 20px;
-        padding: 12px 20px;
+        padding: 12px 20px var(--dialog-header-padding-bottom, 12px);
         color: var(--header-text);
         background: var(--header-bg);
+      }
+
+      /* "flat" variant: header/footer share the body's white background
+         and lose their inner padding so the dialog reads as one
+         continuous surface. Use for content-focused dialogs that don't
+         need the tinted chrome. */
+      :host([variant='flat']) .header-text {
+        background: #fff;
+        color: var(--color-text);
+        padding-bottom: 0;
+      }
+
+      :host([variant='flat']) .dialog-footer {
+        background: #fff;
+        padding-top: 0;
       }
 
       .header-text .title {
@@ -157,8 +172,11 @@ export class Dialog extends ResizeElement {
       }
 
       .dialog-footer {
-        background: var(--color-primary-light);
-        padding: 10px;
+        background: var(
+          --dialog-footer-background,
+          var(--color-primary-light)
+        );
+        padding: var(--dialog-footer-padding-top, 10px) 10px 10px;
         display: flex;
         flex-flow: row;
         align-items: center;
@@ -226,6 +244,9 @@ export class Dialog extends ResizeElement {
 
   @property({ type: Boolean })
   hideOnClick: boolean;
+
+  @property({ type: String, reflect: true })
+  variant: string;
 
   @property({ type: Boolean })
   noFocus: boolean;

--- a/temba-modules.ts
+++ b/temba-modules.ts
@@ -85,6 +85,7 @@ import { Simulator } from './src/simulator/Simulator';
 import { FlowSearch } from './src/flow/FlowSearch';
 import { IssuesWindow } from './src/flow/IssuesWindow';
 import { RevisionsWindow } from './src/flow/RevisionsWindow';
+import { AutoTranslate } from './src/flow/AutoTranslate';
 import { MessageTable } from './src/flow/MessageTable';
 
 export function addCustomElement(name: string, comp: any) {
@@ -182,3 +183,4 @@ addCustomElement('temba-simulator', Simulator);
 addCustomElement('temba-flow-search', FlowSearch);
 addCustomElement('temba-issues-window', IssuesWindow);
 addCustomElement('temba-revisions-window', RevisionsWindow);
+addCustomElement('temba-auto-translate', AutoTranslate);

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -596,6 +596,86 @@ describe('Localization Editing', () => {
     expect(at.running).to.be.false;
   });
 
+  it('should preserve all attributes when one uuid spans multiple batches', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    // send_email has two localizable attributes (subject + body) on the
+    // same action uuid. Inflate them so they fall into separate batches.
+    const longSubject = 's'.repeat(2500);
+    const longBody = 'b'.repeat(8000);
+
+    const flowDefinition: FlowDefinition = {
+      uuid: 'multi-attr-flow',
+      name: 'Multi Attr Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {},
+      nodes: [
+        {
+          uuid: 'node-email',
+          actions: [
+            {
+              type: 'send_email',
+              uuid: 'email-1',
+              subject: longSubject,
+              body: longBody,
+              addresses: ['x@y.com']
+            } as any
+          ],
+          exits: [{ uuid: 'exit-1' }]
+        }
+      ],
+      _ui: {
+        nodes: { 'node-email': { position: { left: 0, top: 0 } } },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 1, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+
+    const calls: any[] = [];
+    (storeElement as any).postJSON = async (url: string, body: any) => {
+      calls.push(body);
+      return { status: 200, json: { items: body.items } };
+    };
+
+    await at.runAutoTranslation();
+
+    // sanity check: subject and body landed in different batches
+    expect(calls.length).to.be.greaterThan(1);
+    const allKeys = new Set(calls.flatMap((c) => Object.keys(c.items)));
+    expect(allKeys.has('email-1:subject')).to.be.true;
+    expect(allKeys.has('email-1:body')).to.be.true;
+
+    // both attributes should be present in the final localization, not
+    // overwritten by the later batch
+    const localized =
+      zustand.getState().flowDefinition?.localization?.['fra']?.['email-1'];
+    expect(localized?.subject).to.deep.equal([longSubject]);
+    expect(localized?.body).to.deep.equal([longBody]);
+  });
+
   it('should preserve selected language across renders', async () => {
     await selectLanguageInToolbar(editor, 'Spanish', 'spa');
 

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -175,7 +175,11 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
     await editor.updateComplete;
   });
 
@@ -215,7 +219,11 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
     await editor.updateComplete;
 
     const toolbar = await getToolbar(editor);
@@ -259,7 +267,11 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
     await editor.updateComplete;
 
     // Switch to a non-base language
@@ -296,7 +308,11 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
     await editor.updateComplete;
 
     // Switch to a non-base language
@@ -307,8 +323,13 @@ describe('Localization Editing', () => {
     expect(progress.total).to.equal(0);
   });
 
-  it.skip('should open auto translate dialog when clicking auto translate', async () => {
+  it('should open auto translate dialog when clicking auto translate', async () => {
     await selectLanguageInToolbar(editor, 'French', 'fra');
+
+    (storeElement as any).getResults = async () => [
+      { uuid: 'llm-1', name: 'GPT-4' },
+      { uuid: 'llm-2', name: 'Claude' }
+    ];
 
     const autoTranslateBtn = editor
       .querySelector('temba-editor-toolbar')
@@ -320,11 +341,13 @@ describe('Localization Editing', () => {
 
     autoTranslateBtn.click();
     await editor.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+    const at = editor.querySelector('temba-auto-translate') as any;
+    await at.updateComplete;
 
-    expect((editor as any).autoTranslateDialogOpen).to.be.true;
-    const dialog = editor.querySelector(
-      'temba-dialog[header="Auto translate"]'
-    );
+    expect(at.dialogOpen).to.be.true;
+    const dialog = at.shadowRoot.querySelector('.auto-translate-body');
+    expect(dialog).to.exist;
     const modelSelect = dialog?.querySelector(
       '.auto-translate-model-select'
     ) as HTMLElement;
@@ -332,6 +355,245 @@ describe('Localization Editing', () => {
     expect(modelSelect.getAttribute('endpoint')).to.equal(
       '/api/internal/llms.json'
     );
+  });
+
+  it('should hide auto translate when the auto-translate flag is off', async () => {
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const toolbar = editor.querySelector('temba-editor-toolbar') as any;
+    // sanity check: the button is there when the flag is on
+    expect(
+      toolbar?.shadowRoot?.querySelector(
+        '.toolbar-btn[aria-label="Auto translate"]'
+      )
+    ).to.exist;
+
+    // remove the feature — button should disappear
+    (editor as any).features = [];
+    await editor.updateComplete;
+    await toolbar.updateComplete;
+
+    expect(
+      toolbar?.shadowRoot?.querySelector(
+        '.toolbar-btn[aria-label="Auto translate"]'
+      )
+    ).to.not.exist;
+  });
+
+  it('should hide auto translate when everything is translated', async () => {
+    await selectLanguageInToolbar(editor, 'Spanish', 'spa');
+    await editor.updateComplete;
+
+    const toolbar = editor.querySelector('temba-editor-toolbar') as any;
+    const autoTranslateBtn = toolbar?.shadowRoot?.querySelector(
+      '.toolbar-btn[aria-label="Auto translate"]'
+    );
+    // spa has text translated; no pending, no button
+    expect(autoTranslateBtn).to.not.exist;
+  });
+
+  it('should auto-skip picker when only one LLM is available', async () => {
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+
+    (storeElement as any).getResults = async () => [
+      { uuid: 'llm-only', name: 'SoloGPT' }
+    ];
+
+    const autoTranslateBtn = editor
+      .querySelector('temba-editor-toolbar')
+      ?.shadowRoot?.querySelector(
+        '.toolbar-btn[aria-label="Auto translate"]'
+      ) as HTMLButtonElement;
+    autoTranslateBtn.click();
+    await editor.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+    const at = editor.querySelector('temba-auto-translate') as any;
+    await at.updateComplete;
+
+    expect(at.selectedModel?.uuid).to.equal('llm-only');
+    const dialog = at.shadowRoot.querySelector('.auto-translate-body');
+    expect(dialog?.querySelector('.auto-translate-model-select')).to.not.exist;
+    expect(dialog?.querySelector('.auto-translate-single-model')).to.exist;
+  });
+
+  it('should show empty state when no LLMs are configured', async () => {
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+
+    (storeElement as any).getResults = async () => [];
+
+    const autoTranslateBtn = editor
+      .querySelector('temba-editor-toolbar')
+      ?.shadowRoot?.querySelector(
+        '.toolbar-btn[aria-label="Auto translate"]'
+      ) as HTMLButtonElement;
+    autoTranslateBtn.click();
+    await editor.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+    const at = editor.querySelector('temba-auto-translate') as any;
+    await at.updateComplete;
+
+    const dialog = at.shadowRoot.querySelector('.auto-translate-body');
+    expect(dialog?.querySelector('.auto-translate-empty')).to.exist;
+    const link = dialog?.querySelector(
+      '.auto-translate-empty a'
+    ) as HTMLAnchorElement;
+    expect(link).to.exist;
+    expect(link.getAttribute('href')).to.equal('/ai/');
+  });
+
+  it('should batch translation requests by serialized payload size', async () => {
+    editor?.remove();
+
+    setupWorkspace();
+
+    // build a flow with enough send_msg actions that the total serialized
+    // payload exceeds the 10,000-char batch threshold
+    const longText = 'x'.repeat(3000);
+    const nodes = [];
+    for (let i = 0; i < 5; i++) {
+      nodes.push({
+        uuid: `node-${i}`,
+        actions: [
+          {
+            type: 'send_msg',
+            uuid: `action-${i}`,
+            text: longText
+          } as SendMsg
+        ],
+        exits: [{ uuid: `exit-${i}` }]
+      });
+    }
+
+    const flowDefinition: FlowDefinition = {
+      uuid: 'batch-flow',
+      name: 'Batch Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {},
+      nodes,
+      _ui: {
+        nodes: Object.fromEntries(
+          nodes.map((n) => [n.uuid, { position: { left: 0, top: 0 } }])
+        ),
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 5, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+
+    const calls: any[] = [];
+    (storeElement as any).postJSON = async (url: string, body: any) => {
+      calls.push({ url, body });
+      return { status: 200, json: { items: body.items } };
+    };
+
+    await at.runAutoTranslation();
+
+    expect(calls.length).to.be.greaterThan(1);
+    for (const c of calls) {
+      const itemKeys = Object.keys(c.body.items as Record<string, string[]>);
+      // each batch's full serialized payload stays within the limit
+      // (individual oversize items are still shipped on their own; the
+      // fixture values are each ~3000 chars which fits)
+      const serialized = JSON.stringify(c.body).length;
+      if (itemKeys.length > 1) {
+        expect(serialized).to.be.at.most(10000);
+      }
+    }
+  });
+
+  it('should interrupt translation between batches', async () => {
+    editor?.remove();
+
+    setupWorkspace();
+
+    const longText = 'y'.repeat(600);
+    const nodes = [];
+    for (let i = 0; i < 6; i++) {
+      nodes.push({
+        uuid: `node-${i}`,
+        actions: [
+          {
+            type: 'send_msg',
+            uuid: `action-${i}`,
+            text: longText
+          } as SendMsg
+        ],
+        exits: [{ uuid: `exit-${i}` }]
+      });
+    }
+
+    const flowDefinition: FlowDefinition = {
+      uuid: 'interrupt-flow',
+      name: 'Interrupt Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {},
+      nodes,
+      _ui: {
+        nodes: Object.fromEntries(
+          nodes.map((n) => [n.uuid, { position: { left: 0, top: 0 } }])
+        ),
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 6, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+
+    let callCount = 0;
+    (storeElement as any).postJSON = async (url: string, body: any) => {
+      callCount += 1;
+      if (callCount === 1) {
+        // request interrupt after first batch completes
+        at.interrupt = true;
+      }
+      return { status: 200, json: { items: body.items } };
+    };
+
+    await at.runAutoTranslation();
+
+    expect(callCount).to.equal(1);
+    expect(at.running).to.be.false;
   });
 
   it('should preserve selected language across renders', async () => {


### PR DESCRIPTION
Brings back the auto-translate UI that was disabled pending backend support, now wired to the new batched POST `/llm/translate/<uuid>/` endpoint. Adds a new `<temba-auto-translate>` component (with shared `flow-translations.ts` helpers) that batches untranslated content under a 10K-char serialized payload limit, surfaces a model picker (auto-skipped when only one LLM is configured, with a "configure" link when none are), and applies results per-batch so a Stop preserves any work already done. The toolbar shows the icon when the editor's `features` list includes `auto_translate` and the active language has pending translations.

Also introduces a `variant="flat"` preset on `<temba-dialog>` for white, seamless header/footer chrome and switches `<temba-button>` focus indication from `:focus` to `:focus-visible` (with an `:active` darken) so clicks no longer leave a persistent ring.

## Test plan
- [ ] Pick a non-base language with untranslated content and confirm the AI star icon shows in the toolbar
- [ ] With multiple LLMs, the picker dialog lists them and Translate is gated until one is selected
- [ ] With one LLM, the picker skips selection
- [ ] With no LLMs, the dialog points to `/ai/`
- [ ] During a multi-batch run, Stop disables itself, switches to "Stopping..." and halts after the in-flight batch
- [ ] On a 4xx response, the error dialog appears with the friendly help text and Show details exposes the raw response