### PR TITLE
Dedupe auto-translate payloads and reuse existing translations

### DIFF
--- a/src/flow/AutoTranslate.ts
+++ b/src/flow/AutoTranslate.ts
@@ -250,21 +250,60 @@ export class AutoTranslate extends RapidElement {
   /**
    * Builds batches of translation requests from all untranslated entries,
    * grouping so each request's serialized payload stays under
-   * TRANSLATION_BATCH_CHAR_LIMIT.
+   * TRANSLATION_BATCH_CHAR_LIMIT. Skips entries whose source matches a
+   * translation already present in the flow (those are returned in
+   * preTranslated for direct application), and dedupes pending entries
+   * sharing identical source arrays so each unique array is sent at most
+   * once (duplicates are returned in duplicateKeyToCanonical for
+   * propagation when the canonical key's translation lands).
    */
   private buildTranslationBatches(): {
     keyToEntries: Map<string, TranslationEntry[]>;
     batches: { items: Record<string, string[]> }[];
+    preTranslated: Map<string, string[]>;
+    duplicateKeyToCanonical: Map<string, string>;
   } {
     const keyToEntries = new Map<string, TranslationEntry[]>();
     const batches: { items: Record<string, string[]> }[] = [];
+    const preTranslated = new Map<string, string[]>();
+    const duplicateKeyToCanonical = new Map<string, string>();
 
     if (!this.definition) {
-      return { keyToEntries, batches };
+      return { keyToEntries, batches, preTranslated, duplicateKeyToCanonical };
     }
 
     const bundles = buildTranslationBundles(this.definition, this.languageCode);
-    const pending: { key: string; entry: TranslationEntry }[] = [];
+
+    // Map source-content -> already-stored translation array, built from
+    // entries that have a translation in the live localization map. Reading
+    // the stored array (not entry.to) preserves the original shape.
+    const existingByContent = new Map<string, string[]>();
+    const localization =
+      this.definition.localization?.[this.languageCode] || {};
+
+    for (const bundle of bundles) {
+      for (const entry of bundle.translations) {
+        if (!entry.to || entry.to.trim().length === 0) {
+          continue;
+        }
+        if (!entry.from || entry.from.trim().length === 0) {
+          continue;
+        }
+        const stored = localization[entry.uuid]?.[entry.attribute];
+        if (!Array.isArray(stored) || stored.length === 0) {
+          continue;
+        }
+        const contentKey = JSON.stringify([entry.from]);
+        if (!existingByContent.has(contentKey)) {
+          existingByContent.set(contentKey, stored);
+        }
+      }
+    }
+
+    // Collect pending entries (no translation yet) preserving order, and
+    // group source values per key in case the same key yields multiple
+    // entries.
+    const valuesByKey = new Map<string, string[]>();
 
     for (const bundle of bundles) {
       for (const entry of bundle.translations) {
@@ -275,11 +314,38 @@ export class AutoTranslate extends RapidElement {
           continue;
         }
         const key = `${entry.uuid}:${entry.attribute}`;
-        pending.push({ key, entry });
         const list = keyToEntries.get(key) || [];
         list.push(entry);
         keyToEntries.set(key, list);
+        const values = valuesByKey.get(key) || [];
+        values.push(entry.from);
+        valuesByKey.set(key, values);
       }
+    }
+
+    // Split pending keys into pre-translated (matching an existing
+    // translation), duplicates (sharing content with an earlier pending
+    // key), and unique canonical keys that need to be sent to the LLM.
+    const canonicalByContent = new Map<string, string>();
+    const canonicalKeysWithValues: { key: string; values: string[] }[] = [];
+
+    for (const [key, values] of valuesByKey) {
+      const contentKey = JSON.stringify(values);
+
+      const existing = existingByContent.get(contentKey);
+      if (existing && existing.length === values.length) {
+        preTranslated.set(key, existing);
+        continue;
+      }
+
+      const canonical = canonicalByContent.get(contentKey);
+      if (canonical) {
+        duplicateKeyToCanonical.set(key, canonical);
+        continue;
+      }
+
+      canonicalByContent.set(contentKey, key);
+      canonicalKeysWithValues.push({ key, values });
     }
 
     const source = this.definition.language;
@@ -289,18 +355,15 @@ export class AutoTranslate extends RapidElement {
 
     let current: Record<string, string[]> = {};
 
-    for (const { key, entry } of pending) {
-      const prevList = current[key];
-      const nextList = prevList ? [...prevList, entry.from] : [entry.from];
-      const tentative = { ...current, [key]: nextList };
-
+    for (const { key, values } of canonicalKeysWithValues) {
+      const tentative = { ...current, [key]: values };
       const tentativeSize = measurePayload(tentative);
       const batchHasItems = Object.keys(current).length > 0;
 
       if (tentativeSize > TRANSLATION_BATCH_CHAR_LIMIT && batchHasItems) {
         // a single oversized entry still ships on its own
         batches.push({ items: current });
-        current = { [key]: [entry.from] };
+        current = { [key]: values };
       } else {
         current = tentative;
       }
@@ -310,7 +373,7 @@ export class AutoTranslate extends RapidElement {
       batches.push({ items: current });
     }
 
-    return { keyToEntries, batches };
+    return { keyToEntries, batches, preTranslated, duplicateKeyToCanonical };
   }
 
   /**
@@ -326,9 +389,29 @@ export class AutoTranslate extends RapidElement {
       return;
     }
 
-    const { keyToEntries, batches } = this.buildTranslationBatches();
+    const { keyToEntries, batches, preTranslated, duplicateKeyToCanonical } =
+      this.buildTranslationBatches();
+
+    // Apply entries that match an existing translation immediately so we
+    // don't need an LLM round-trip for them.
+    if (preTranslated.size > 0) {
+      this.applyBatchTranslations(
+        Object.fromEntries(preTranslated),
+        keyToEntries
+      );
+    }
+
     if (batches.length === 0) {
       return;
+    }
+
+    // Inverse of duplicateKeyToCanonical so we can quickly find which keys
+    // need to be back-filled when a canonical key's translation lands.
+    const duplicatesByCanonical = new Map<string, string[]>();
+    for (const [dup, canonical] of duplicateKeyToCanonical) {
+      const list = duplicatesByCanonical.get(canonical) || [];
+      list.push(dup);
+      duplicatesByCanonical.set(canonical, list);
     }
 
     this.running = true;
@@ -358,7 +441,16 @@ export class AutoTranslate extends RapidElement {
 
         if (response.status >= 200 && response.status < 300) {
           const returned: Record<string, string[]> = response.json?.items || {};
-          this.applyBatchTranslations(returned, keyToEntries);
+          const expanded: Record<string, string[]> = { ...returned };
+          for (const canonical of Object.keys(returned)) {
+            const dups = duplicatesByCanonical.get(canonical);
+            if (dups) {
+              for (const dup of dups) {
+                expanded[dup] = returned[canonical];
+              }
+            }
+          }
+          this.applyBatchTranslations(expanded, keyToEntries);
         } else {
           this.error =
             response.json?.error ||
@@ -550,7 +642,8 @@ export class AutoTranslate extends RapidElement {
     return html`
       <p>
         All remaining text for <strong>${languageName}</strong> will be
-        translated automatically. Remember, AI models can make mistakes so it is important to review all of your translations to verify they are correct.
+        translated automatically. Remember, AI models can make mistakes so it is
+        important to review all of your translations to verify they are correct.
       </p>
       ${this.models.length > 1
         ? html`<temba-select
@@ -610,13 +703,11 @@ export class AutoTranslate extends RapidElement {
     return html`
       <div class="auto-translate-error-block">
         <p class="auto-translate-error-help">
-          Any translations already applied have been kept. You can try again,
-          or check the AI model's settings if the problem persists.
+          Any translations already applied have been kept. You can try again, or
+          check the AI model's settings if the problem persists.
         </p>
         ${this.errorExpanded
-          ? html`<pre class="auto-translate-error-details">
-${this.error}</pre
-            >`
+          ? html`<pre class="auto-translate-error-details">${this.error}</pre>`
           : html`<button
               class="auto-translate-error-toggle"
               type="button"

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -446,8 +446,8 @@ describe('Localization Editing', () => {
     setupWorkspace();
 
     // build a flow with enough send_msg actions that the total serialized
-    // payload exceeds the 10,000-char batch threshold
-    const longText = 'x'.repeat(3000);
+    // payload exceeds the 10,000-char batch threshold. Each text needs to
+    // be unique or dedup will collapse them into a single payload entry.
     const nodes = [];
     for (let i = 0; i < 5; i++) {
       nodes.push({
@@ -456,7 +456,7 @@ describe('Localization Editing', () => {
           {
             type: 'send_msg',
             uuid: `action-${i}`,
-            text: longText
+            text: `${i} ${'x'.repeat(3000)}`
           } as SendMsg
         ],
         exits: [{ uuid: `exit-${i}` }]
@@ -527,7 +527,8 @@ describe('Localization Editing', () => {
 
     setupWorkspace();
 
-    const longText = 'y'.repeat(600);
+    // Each text is unique so dedup doesn't collapse them — we want enough
+    // distinct entries to span multiple batches and verify interrupt.
     const nodes = [];
     for (let i = 0; i < 6; i++) {
       nodes.push({
@@ -536,7 +537,7 @@ describe('Localization Editing', () => {
           {
             type: 'send_msg',
             uuid: `action-${i}`,
-            text: longText
+            text: `${i} ${'y'.repeat(600)}`
           } as SendMsg
         ],
         exits: [{ uuid: `exit-${i}` }]
@@ -674,6 +675,199 @@ describe('Localization Editing', () => {
       zustand.getState().flowDefinition?.localization?.['fra']?.['email-1'];
     expect(localized?.subject).to.deep.equal([longSubject]);
     expect(localized?.body).to.deep.equal([longBody]);
+  });
+
+  it('should reuse existing translations for matching source content', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    // action-a is already translated to French; action-b shares the same
+    // source text but is not yet translated. Auto-translate should reuse
+    // action-a's translation for action-b without sending it to the LLM.
+    const flowDefinition: FlowDefinition = {
+      uuid: 'reuse-flow',
+      name: 'Reuse Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {
+        fra: {
+          'action-a': { text: ['Bonjour le monde'] }
+        }
+      },
+      nodes: [
+        {
+          uuid: 'node-a',
+          actions: [
+            {
+              type: 'send_msg',
+              uuid: 'action-a',
+              text: 'Hello world'
+            } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-a' }]
+        },
+        {
+          uuid: 'node-b',
+          actions: [
+            {
+              type: 'send_msg',
+              uuid: 'action-b',
+              text: 'Hello world'
+            } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-b' }]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-a': { position: { left: 0, top: 0 } },
+          'node-b': { position: { left: 0, top: 100 } }
+        },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 2, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+
+    let callCount = 0;
+    (storeElement as any).postJSON = async (_url: string, body: any) => {
+      callCount += 1;
+      return { status: 200, json: { items: body.items } };
+    };
+
+    await at.runAutoTranslation();
+
+    // no LLM call needed: the only pending entry's source matches an
+    // existing translation already in the flow
+    expect(callCount).to.equal(0);
+    const localized = zustand.getState().flowDefinition?.localization?.['fra'];
+    expect(localized?.['action-b']?.text).to.deep.equal(['Bonjour le monde']);
+  });
+
+  it('should dedupe identical source arrays in the translation payload', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    // Three pending actions share the same source text and one has a
+    // distinct text. The payload should contain two unique arrays, and
+    // the duplicate source's translation should propagate to all keys
+    // sharing that source.
+    const flowDefinition: FlowDefinition = {
+      uuid: 'dedupe-flow',
+      name: 'Dedupe Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {},
+      nodes: [
+        {
+          uuid: 'node-a',
+          actions: [
+            { type: 'send_msg', uuid: 'action-a', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-a' }]
+        },
+        {
+          uuid: 'node-b',
+          actions: [
+            { type: 'send_msg', uuid: 'action-b', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-b' }]
+        },
+        {
+          uuid: 'node-c',
+          actions: [
+            { type: 'send_msg', uuid: 'action-c', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-c' }]
+        },
+        {
+          uuid: 'node-d',
+          actions: [
+            { type: 'send_msg', uuid: 'action-d', text: 'Goodbye' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-d' }]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-a': { position: { left: 0, top: 0 } },
+          'node-b': { position: { left: 0, top: 100 } },
+          'node-c': { position: { left: 0, top: 200 } },
+          'node-d': { position: { left: 0, top: 300 } }
+        },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 4, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+
+    const calls: any[] = [];
+    (storeElement as any).postJSON = async (_url: string, body: any) => {
+      calls.push(body);
+      const translated: Record<string, string[]> = {};
+      for (const [k, v] of Object.entries(
+        body.items as Record<string, string[]>
+      )) {
+        translated[k] = v.map((s) => `${s}!fr`);
+      }
+      return { status: 200, json: { items: translated } };
+    };
+
+    await at.runAutoTranslation();
+
+    // payload should contain only two keys (one canonical per unique
+    // source array) — duplicates are not sent
+    expect(calls).to.have.lengthOf(1);
+    const sentKeys = Object.keys(calls[0].items as Record<string, string[]>);
+    expect(sentKeys).to.have.lengthOf(2);
+
+    // every action including duplicates should be translated
+    const localized =
+      zustand.getState().flowDefinition?.localization?.['fra'] || {};
+    expect(localized['action-a']?.text).to.deep.equal(['Hello!fr']);
+    expect(localized['action-b']?.text).to.deep.equal(['Hello!fr']);
+    expect(localized['action-c']?.text).to.deep.equal(['Hello!fr']);
+    expect(localized['action-d']?.text).to.deep.equal(['Goodbye!fr']);
   });
 
   it('should preserve selected language across renders', async () => {


### PR DESCRIPTION
## Summary
- When a pending entry's source matches a translation already present in the flow's localization, apply that stored translation directly instead of sending it to the LLM.
- When multiple pending entries share the same source array, only the first ("canonical") key is sent in the payload; the LLM result is then propagated to every duplicate key in the same apply step.

## Test plan
- [x] `pnpm test:fast --files test/temba-localization.test.ts` passes (29 tests)
- [x] New test: pending entry whose source matches an existing translation triggers no LLM call and gets the stored value applied
- [x] New test: 3 pending entries sharing one source produce a single canonical payload key, and all 3 (plus a distinct fourth) end up correctly localized
- [x] Updated existing batching/interrupt tests to use unique per-node text so they still exercise multi-batch behavior under the new dedup