### PR TITLE
Filter LLMs by role for flow editing vs auto-translate

### DIFF
--- a/src/flow/AutoTranslate.ts
+++ b/src/flow/AutoTranslate.ts
@@ -206,10 +206,12 @@ export class AutoTranslate extends RapidElement {
       const results = store
         ? await store.getResults(MODELS_ENDPOINT, { force: true })
         : [];
-      this.models = (results || []).map((r: any) => ({
-        uuid: r.uuid,
-        name: r.name
-      }));
+      this.models = (results || [])
+        .filter((r: any) => r.roles?.includes('editing'))
+        .map((r: any) => ({
+          uuid: r.uuid,
+          name: r.name
+        }));
     } catch (err) {
       console.error('Failed to load AI models', err);
       this.models = [];
@@ -550,7 +552,8 @@ export class AutoTranslate extends RapidElement {
     return html`
       <p>
         All remaining text for <strong>${languageName}</strong> will be
-        translated automatically. Remember, AI models can make mistakes so it is important to review all of your translations to verify they are correct.
+        translated automatically. Remember, AI models can make mistakes so it is
+        important to review all of your translations to verify they are correct.
       </p>
       ${this.models.length > 1
         ? html`<temba-select
@@ -558,6 +561,8 @@ export class AutoTranslate extends RapidElement {
             endpoint="${MODELS_ENDPOINT}"
             valueKey="uuid"
             .values=${selected}
+            .shouldExclude=${(option: any) =>
+              !option.roles?.includes('editing')}
             ?searchable=${true}
             placeholder="Select an AI model"
             @change=${this.handleModelChange}
@@ -610,13 +615,11 @@ export class AutoTranslate extends RapidElement {
     return html`
       <div class="auto-translate-error-block">
         <p class="auto-translate-error-help">
-          Any translations already applied have been kept. You can try again,
-          or check the AI model's settings if the problem persists.
+          Any translations already applied have been kept. You can try again, or
+          check the AI model's settings if the problem persists.
         </p>
         ${this.errorExpanded
-          ? html`<pre class="auto-translate-error-details">
-${this.error}</pre
-            >`
+          ? html`<pre class="auto-translate-error-details">${this.error}</pre>`
           : html`<button
               class="auto-translate-error-toggle"
               type="button"

--- a/src/flow/AutoTranslate.ts
+++ b/src/flow/AutoTranslate.ts
@@ -7,6 +7,7 @@ import { zustand } from '../store/AppState';
 import { FlowDefinition } from '../store/flow-definition';
 import { TranslationEntry, buildTranslationBundles } from './flow-translations';
 import { getLanguageDisplayName } from './utils';
+import { LLMModel, hasLLMRole } from './flow-utils';
 
 interface TranslationModel {
   uuid: string;
@@ -203,12 +204,12 @@ export class AutoTranslate extends RapidElement {
     this.modelsLoading = true;
     try {
       const store = getStore();
-      const results = store
-        ? await store.getResults(MODELS_ENDPOINT, { force: true })
+      const results: LLMModel[] = store
+        ? ((await store.getResults(MODELS_ENDPOINT, { force: true })) ?? [])
         : [];
-      this.models = (results || [])
-        .filter((r: any) => r.roles?.includes('editing'))
-        .map((r: any) => ({
+      this.models = results
+        .filter((r) => hasLLMRole(r, 'editing'))
+        .map((r) => ({
           uuid: r.uuid,
           name: r.name
         }));
@@ -561,8 +562,8 @@ export class AutoTranslate extends RapidElement {
             endpoint="${MODELS_ENDPOINT}"
             valueKey="uuid"
             .values=${selected}
-            .shouldExclude=${(option: any) =>
-              !option.roles?.includes('editing')}
+            .shouldExclude=${(option: LLMModel) =>
+              !hasLLMRole(option, 'editing')}
             ?searchable=${true}
             placeholder="Select an AI model"
             @change=${this.handleModelChange}

--- a/src/flow/flow-utils.ts
+++ b/src/flow/flow-utils.ts
@@ -15,3 +15,25 @@ export function shouldExcludeFlow(flow: any): boolean {
 
   return false;
 }
+
+export type LLMRole = 'engine' | 'editing';
+
+export interface LLMModel {
+  uuid: string;
+  name: string;
+  type?: string;
+  description?: string;
+  roles?: LLMRole[];
+}
+
+// Backward-compatible: a model with no `roles` field (older backend) is
+// treated as having every role, so the UI doesn't silently hide all models
+// when the API hasn't rolled out the field yet.
+export function hasLLMRole(
+  model: { roles?: string[] } | null | undefined,
+  role: LLMRole
+): boolean {
+  if (!model) return false;
+  if (!model.roles) return true;
+  return model.roles.includes(role);
+}

--- a/src/flow/flow-utils.ts
+++ b/src/flow/flow-utils.ts
@@ -26,14 +26,9 @@ export interface LLMModel {
   roles?: LLMRole[];
 }
 
-// Backward-compatible: a model with no `roles` field (older backend) is
-// treated as having every role, so the UI doesn't silently hide all models
-// when the API hasn't rolled out the field yet.
 export function hasLLMRole(
   model: { roles?: string[] } | null | undefined,
   role: LLMRole
 ): boolean {
-  if (!model) return false;
-  if (!model.roles) return true;
-  return model.roles.includes(role);
+  return model?.roles?.includes(role) ?? false;
 }

--- a/src/flow/nodes/split_by_llm.ts
+++ b/src/flow/nodes/split_by_llm.ts
@@ -8,6 +8,7 @@ import {
   renderLineItem,
   getLlmIcon
 } from '../utils';
+import { LLMModel, hasLLMRole } from '../flow-utils';
 
 export const split_by_llm: NodeConfig = {
   type: 'split_by_llm',
@@ -48,7 +49,7 @@ export const split_by_llm: NodeConfig = {
       valueKey: 'uuid',
       nameKey: 'name',
       placeholder: 'Select an LLM...',
-      shouldExclude: (option: any) => !option.roles?.includes('engine')
+      shouldExclude: (option: LLMModel) => !hasLLMRole(option, 'engine')
     },
     input: {
       type: 'text',

--- a/src/flow/nodes/split_by_llm.ts
+++ b/src/flow/nodes/split_by_llm.ts
@@ -47,7 +47,8 @@ export const split_by_llm: NodeConfig = {
       searchable: true,
       valueKey: 'uuid',
       nameKey: 'name',
-      placeholder: 'Select an LLM...'
+      placeholder: 'Select an LLM...',
+      shouldExclude: (option: any) => !option.roles?.includes('engine')
     },
     input: {
       type: 'text',

--- a/src/flow/nodes/split_by_llm_categorize.ts
+++ b/src/flow/nodes/split_by_llm_categorize.ts
@@ -3,6 +3,7 @@ import { CallLLM, Node } from '../../store/flow-definition';
 import { generateUUID, createMultiCategoryRouter } from '../../utils';
 import { html } from 'lit';
 import { validateWith } from '../utils';
+import { LLMModel, hasLLMRole } from '../flow-utils';
 
 export const split_by_llm_categorize: NodeConfig = {
   type: 'split_by_llm_categorize',
@@ -20,7 +21,7 @@ export const split_by_llm_categorize: NodeConfig = {
       valueKey: 'uuid',
       nameKey: 'name',
       placeholder: 'Select an LLM...',
-      shouldExclude: (option: any) => !option.roles?.includes('engine')
+      shouldExclude: (option: LLMModel) => !hasLLMRole(option, 'engine')
     },
     input: {
       type: 'text',

--- a/src/flow/nodes/split_by_llm_categorize.ts
+++ b/src/flow/nodes/split_by_llm_categorize.ts
@@ -19,7 +19,8 @@ export const split_by_llm_categorize: NodeConfig = {
       endpoint: '/api/internal/llms.json',
       valueKey: 'uuid',
       nameKey: 'name',
-      placeholder: 'Select an LLM...'
+      placeholder: 'Select an LLM...',
+      shouldExclude: (option: any) => !option.roles?.includes('engine')
     },
     input: {
       type: 'text',

--- a/static/api/llms.json
+++ b/static/api/llms.json
@@ -6,13 +6,22 @@
       "uuid": "2399e7d6-fcdf-4e47-a835-f3bdb7f80938",
       "name": "GPT 4.1",
       "type": "openai",
-      "description": "General-purpose reasoning model"
+      "description": "General-purpose reasoning model",
+      "roles": ["engine", "editing"]
     },
     {
       "uuid": "4399e7d6-fcdf-4e47-a835-f3bdb7f80938",
       "name": "GPT 5",
       "type": "openai",
-      "description": "Latest experimental model"
+      "description": "Latest experimental model",
+      "roles": ["engine"]
+    },
+    {
+      "uuid": "5499e7d6-fcdf-4e47-a835-f3bdb7f80938",
+      "name": "GPT 4.1 Mini",
+      "type": "openai",
+      "description": "Lightweight model for editing tasks",
+      "roles": ["editing"]
     }
   ]
 }

--- a/test-assets/select/llms.json
+++ b/test-assets/select/llms.json
@@ -6,13 +6,15 @@
       "uuid": "2399e7d6-fcdf-4e47-a835-f3bdb7f80938",
       "name": "GPT 4.1",
       "value": "2399e7d6-fcdf-4e47-a835-f3bdb7f80938",
-      "type": "openai"
+      "type": "openai",
+      "roles": ["engine", "editing"]
     },
     {
       "uuid": "4399e7d6-fcdf-4e47-a835-f3bdb7f80938",
       "name": "GPT 5",
       "value": "4399e7d6-fcdf-4e47-a835-f3bdb7f80938",
-      "type": "openai"
+      "type": "openai",
+      "roles": ["engine"]
     }
   ]
 }

--- a/test/nodes/split_by_llm.test.ts
+++ b/test/nodes/split_by_llm.test.ts
@@ -47,12 +47,6 @@ describe('split_by_llm node config', () => {
       expect(shouldExclude({ roles: ['editing'] })).to.be.true;
       expect(shouldExclude({ roles: [] })).to.be.true;
     });
-
-    // Rollout safety: models without a roles field (older backend) stay
-    // visible so the picker isn't silently empty during the transition.
-    it('includes options when the roles field is missing', () => {
-      expect(shouldExclude({})).to.be.false;
-    });
   });
 
   describe('toFormData', () => {

--- a/test/nodes/split_by_llm.test.ts
+++ b/test/nodes/split_by_llm.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@open-wc/testing';
 import { split_by_llm } from '../../src/flow/nodes/split_by_llm';
 import { Node, CallLLM } from '../../src/store/flow-definition';
+import { SelectFieldConfig } from '../../src/flow/types';
 import { NodeTest } from '../NodeHelper';
 
 /**
@@ -30,6 +31,27 @@ describe('split_by_llm node config', () => {
         'input',
         'instructions'
       ]);
+    });
+  });
+
+  describe('llm shouldExclude', () => {
+    const shouldExclude = (split_by_llm.form.llm as SelectFieldConfig)
+      .shouldExclude!;
+
+    it('includes options that have the engine role', () => {
+      expect(shouldExclude({ roles: ['engine'] })).to.be.false;
+      expect(shouldExclude({ roles: ['engine', 'editing'] })).to.be.false;
+    });
+
+    it('excludes options without the engine role', () => {
+      expect(shouldExclude({ roles: ['editing'] })).to.be.true;
+      expect(shouldExclude({ roles: [] })).to.be.true;
+    });
+
+    // Rollout safety: models without a roles field (older backend) stay
+    // visible so the picker isn't silently empty during the transition.
+    it('includes options when the roles field is missing', () => {
+      expect(shouldExclude({})).to.be.false;
     });
   });
 

--- a/test/nodes/split_by_llm_categorize.test.ts
+++ b/test/nodes/split_by_llm_categorize.test.ts
@@ -121,12 +121,6 @@ describe('split_by_llm_categorize node config', () => {
       expect(shouldExclude({ roles: ['editing'] })).to.be.true;
       expect(shouldExclude({ roles: [] })).to.be.true;
     });
-
-    // Rollout safety: models without a roles field (older backend) stay
-    // visible so the picker isn't silently empty during the transition.
-    it('includes options when the roles field is missing', () => {
-      expect(shouldExclude({})).to.be.false;
-    });
   });
 
   describe('node scenarios', () => {

--- a/test/nodes/split_by_llm_categorize.test.ts
+++ b/test/nodes/split_by_llm_categorize.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@open-wc/testing';
 import { split_by_llm_categorize } from '../../src/flow/nodes/split_by_llm_categorize';
 import { Node } from '../../src/store/flow-definition';
+import { SelectFieldConfig } from '../../src/flow/types';
 import { NodeTest } from '../NodeHelper';
 
 // Helper function to create routers with proper cases and exits
@@ -103,6 +104,28 @@ describe('split_by_llm_categorize node config', () => {
 
     it('has correct type', () => {
       expect(split_by_llm_categorize.type).to.equal('split_by_llm_categorize');
+    });
+  });
+
+  describe('llm shouldExclude', () => {
+    const shouldExclude = (
+      split_by_llm_categorize.form.llm as SelectFieldConfig
+    ).shouldExclude!;
+
+    it('includes options that have the engine role', () => {
+      expect(shouldExclude({ roles: ['engine'] })).to.be.false;
+      expect(shouldExclude({ roles: ['engine', 'editing'] })).to.be.false;
+    });
+
+    it('excludes options without the engine role', () => {
+      expect(shouldExclude({ roles: ['editing'] })).to.be.true;
+      expect(shouldExclude({ roles: [] })).to.be.true;
+    });
+
+    // Rollout safety: models without a roles field (older backend) stay
+    // visible so the picker isn't silently empty during the transition.
+    it('includes options when the roles field is missing', () => {
+      expect(shouldExclude({})).to.be.false;
     });
   });
 

--- a/test/temba-flow-utils.test.ts
+++ b/test/temba-flow-utils.test.ts
@@ -54,23 +54,10 @@ describe('hasLLMRole', () => {
     expect(hasLLMRole({ roles: ['editing', 'engine'] }, 'editing')).to.be.true;
   });
 
-  it('returns false when the model has roles but not the requested one', () => {
+  it('returns false when the model lacks the role', () => {
     expect(hasLLMRole({ roles: ['editing'] }, 'engine')).to.be.false;
     expect(hasLLMRole({ roles: ['engine'] }, 'editing')).to.be.false;
     expect(hasLLMRole({ roles: [] }, 'engine')).to.be.false;
-  });
-
-  // Backwards-compat: treat models with a missing roles field as inclusive
-  // so a UI rollout ahead of the API doesn't silently hide every model.
-  it('returns true when the model has no roles field', () => {
-    expect(hasLLMRole({}, 'engine')).to.be.true;
-    expect(hasLLMRole({}, 'editing')).to.be.true;
-    expect(hasLLMRole({ roles: undefined }, 'engine')).to.be.true;
-  });
-
-  it('returns false when the model is null or undefined', () => {
-    expect(hasLLMRole(null, 'engine')).to.be.false;
-    expect(hasLLMRole(undefined, 'editing')).to.be.false;
   });
 });
 

--- a/test/temba-flow-utils.test.ts
+++ b/test/temba-flow-utils.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@open-wc/testing';
 import { zustand } from '../src/store/AppState';
-import { shouldExcludeFlow } from '../src/flow/flow-utils';
+import { shouldExcludeFlow, hasLLMRole } from '../src/flow/flow-utils';
 import { getLanguageDisplayName } from '../src/flow/utils';
 
 function setFlowType(type: string) {
@@ -45,6 +45,32 @@ describe('shouldExcludeFlow', () => {
   it('returns false when flow definition is null', () => {
     zustand.setState({ ...zustand.getState(), flowDefinition: null });
     expect(shouldExcludeFlow({ type: 'message' })).to.be.false;
+  });
+});
+
+describe('hasLLMRole', () => {
+  it('returns true when the model has the role', () => {
+    expect(hasLLMRole({ roles: ['engine'] }, 'engine')).to.be.true;
+    expect(hasLLMRole({ roles: ['editing', 'engine'] }, 'editing')).to.be.true;
+  });
+
+  it('returns false when the model has roles but not the requested one', () => {
+    expect(hasLLMRole({ roles: ['editing'] }, 'engine')).to.be.false;
+    expect(hasLLMRole({ roles: ['engine'] }, 'editing')).to.be.false;
+    expect(hasLLMRole({ roles: [] }, 'engine')).to.be.false;
+  });
+
+  // Backwards-compat: treat models with a missing roles field as inclusive
+  // so a UI rollout ahead of the API doesn't silently hide every model.
+  it('returns true when the model has no roles field', () => {
+    expect(hasLLMRole({}, 'engine')).to.be.true;
+    expect(hasLLMRole({}, 'editing')).to.be.true;
+    expect(hasLLMRole({ roles: undefined }, 'engine')).to.be.true;
+  });
+
+  it('returns false when the model is null or undefined', () => {
+    expect(hasLLMRole(null, 'engine')).to.be.false;
+    expect(hasLLMRole(undefined, 'editing')).to.be.false;
   });
 });
 

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -365,8 +365,6 @@ describe('Localization Editing', () => {
     const shouldExclude = (modelSelect as any).shouldExclude;
     expect(shouldExclude({ roles: ['engine'] })).to.be.true;
     expect(shouldExclude({ roles: ['editing'] })).to.be.false;
-    // missing roles is treated as inclusive (rollout safety)
-    expect(shouldExclude({})).to.be.false;
   });
 
   it('should hide auto translate when the auto-translate flag is off', async () => {
@@ -428,31 +426,6 @@ describe('Localization Editing', () => {
     const dialog = at.shadowRoot.querySelector('.auto-translate-body');
     expect(dialog?.querySelector('.auto-translate-model-select')).to.not.exist;
     expect(dialog?.querySelector('.auto-translate-single-model')).to.exist;
-  });
-
-  // Rollout safety: backends that haven't deployed the `roles` field yet
-  // return models without it. Those models should still appear so the UI
-  // doesn't go silently empty during a rollout.
-  it('should include LLMs that are missing the roles field', async () => {
-    await selectLanguageInToolbar(editor, 'French', 'fra');
-
-    (storeElement as any).getResults = async () => [
-      { uuid: 'llm-legacy', name: 'LegacyModel' }
-    ];
-
-    const autoTranslateBtn = editor
-      .querySelector('temba-editor-toolbar')
-      ?.shadowRoot?.querySelector(
-        '.toolbar-btn[aria-label="Auto translate"]'
-      ) as HTMLButtonElement;
-    autoTranslateBtn.click();
-    await editor.updateComplete;
-    await new Promise((r) => setTimeout(r, 0));
-    const at = editor.querySelector('temba-auto-translate') as any;
-    await at.updateComplete;
-
-    expect(at.models.map((m: any) => m.uuid)).to.deep.equal(['llm-legacy']);
-    expect(at.selectedModel?.uuid).to.equal('llm-legacy');
   });
 
   it('should show empty state when no LLMs are configured', async () => {

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -327,8 +327,8 @@ describe('Localization Editing', () => {
     await selectLanguageInToolbar(editor, 'French', 'fra');
 
     (storeElement as any).getResults = async () => [
-      { uuid: 'llm-1', name: 'GPT-4' },
-      { uuid: 'llm-2', name: 'Claude' }
+      { uuid: 'llm-1', name: 'GPT-4', roles: ['editing'] },
+      { uuid: 'llm-2', name: 'Claude', roles: ['editing', 'engine'] }
     ];
 
     const autoTranslateBtn = editor
@@ -395,7 +395,7 @@ describe('Localization Editing', () => {
     await selectLanguageInToolbar(editor, 'French', 'fra');
 
     (storeElement as any).getResults = async () => [
-      { uuid: 'llm-only', name: 'SoloGPT' }
+      { uuid: 'llm-only', name: 'SoloGPT', roles: ['editing'] }
     ];
 
     const autoTranslateBtn = editor

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -326,9 +326,12 @@ describe('Localization Editing', () => {
   it('should open auto translate dialog when clicking auto translate', async () => {
     await selectLanguageInToolbar(editor, 'French', 'fra');
 
+    // Includes an engine-only model that should be filtered out of the
+    // auto-translate picker, plus two valid editing models.
     (storeElement as any).getResults = async () => [
       { uuid: 'llm-1', name: 'GPT-4', roles: ['editing'] },
-      { uuid: 'llm-2', name: 'Claude', roles: ['editing', 'engine'] }
+      { uuid: 'llm-2', name: 'Claude', roles: ['editing', 'engine'] },
+      { uuid: 'llm-engine', name: 'EngineOnly', roles: ['engine'] }
     ];
 
     const autoTranslateBtn = editor
@@ -346,6 +349,9 @@ describe('Localization Editing', () => {
     await at.updateComplete;
 
     expect(at.dialogOpen).to.be.true;
+    // loadModels should have dropped the engine-only model
+    expect(at.models.map((m: any) => m.uuid)).to.deep.equal(['llm-1', 'llm-2']);
+
     const dialog = at.shadowRoot.querySelector('.auto-translate-body');
     expect(dialog).to.exist;
     const modelSelect = dialog?.querySelector(
@@ -355,6 +361,12 @@ describe('Localization Editing', () => {
     expect(modelSelect.getAttribute('endpoint')).to.equal(
       '/api/internal/llms.json'
     );
+    // and the temba-select shouldExclude predicate also rejects engine-only
+    const shouldExclude = (modelSelect as any).shouldExclude;
+    expect(shouldExclude({ roles: ['engine'] })).to.be.true;
+    expect(shouldExclude({ roles: ['editing'] })).to.be.false;
+    // missing roles is treated as inclusive (rollout safety)
+    expect(shouldExclude({})).to.be.false;
   });
 
   it('should hide auto translate when the auto-translate flag is off', async () => {
@@ -394,8 +406,11 @@ describe('Localization Editing', () => {
   it('should auto-skip picker when only one LLM is available', async () => {
     await selectLanguageInToolbar(editor, 'French', 'fra');
 
+    // Engine-only model is present but should be filtered out, leaving a
+    // single editing-capable model — the picker should still auto-skip.
     (storeElement as any).getResults = async () => [
-      { uuid: 'llm-only', name: 'SoloGPT', roles: ['editing'] }
+      { uuid: 'llm-only', name: 'SoloGPT', roles: ['editing'] },
+      { uuid: 'llm-engine', name: 'EngineOnly', roles: ['engine'] }
     ];
 
     const autoTranslateBtn = editor
@@ -413,6 +428,31 @@ describe('Localization Editing', () => {
     const dialog = at.shadowRoot.querySelector('.auto-translate-body');
     expect(dialog?.querySelector('.auto-translate-model-select')).to.not.exist;
     expect(dialog?.querySelector('.auto-translate-single-model')).to.exist;
+  });
+
+  // Rollout safety: backends that haven't deployed the `roles` field yet
+  // return models without it. Those models should still appear so the UI
+  // doesn't go silently empty during a rollout.
+  it('should include LLMs that are missing the roles field', async () => {
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+
+    (storeElement as any).getResults = async () => [
+      { uuid: 'llm-legacy', name: 'LegacyModel' }
+    ];
+
+    const autoTranslateBtn = editor
+      .querySelector('temba-editor-toolbar')
+      ?.shadowRoot?.querySelector(
+        '.toolbar-btn[aria-label="Auto translate"]'
+      ) as HTMLButtonElement;
+    autoTranslateBtn.click();
+    await editor.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+    const at = editor.querySelector('temba-auto-translate') as any;
+    await at.updateComplete;
+
+    expect(at.models.map((m: any) => m.uuid)).to.deep.equal(['llm-legacy']);
+    expect(at.selectedModel?.uuid).to.equal('llm-legacy');
   });
 
   it('should show empty state when no LLMs are configured', async () => {


### PR DESCRIPTION
## Summary

The `/api/internal/llms.json` endpoint now exposes a `roles` array on each model (e.g. `["engine"]`, `["editing"]`, or both). This change filters which LLMs appear where:

- Flow-editor LLM pickers (Call AI, Split by AI) now only show models with the `engine` role.
- Auto-translate now only considers models with the `editing` role (filtered both in `loadModels()` and via the `temba-select` picker's `shouldExclude`).

Test fixtures (`static/api/llms.json`, `test-assets/select/llms.json`) and the localization test mocks were updated to include the new `roles` field.

## Test plan

- [ ] Open a flow, add a Call AI / Split by AI node — only `engine`-role LLMs appear in the picker
- [ ] Run auto-translate — only `editing`-role LLMs appear; single-model auto-skip still works
- [ ] `pnpm test:fast --files test/temba-localization.test.ts` and `test/nodes/split_by_llm*.test.ts` pass