### PR TITLE
Fix arrow keys and Ctrl+Y yank in rich editor

### DIFF
--- a/src/display/Options.ts
+++ b/src/display/Options.ts
@@ -565,9 +565,12 @@ export class Options extends RapidElement {
     // Only intercept keys when the event originated within our owning component.
     // Without this, any temba-options with populated options would swallow arrow
     // keys document-wide, breaking cursor movement in unrelated text editors.
+    // All current usages render temba-options inside another custom element's
+    // shadow root, so scoping by host correctly distinguishes between editors.
     if (!this.block) {
-      const myHost = (this.getRootNode() as ShadowRoot).host;
-      if (myHost && !evt.composedPath().includes(myHost)) {
+      const root = this.getRootNode();
+      const host = root instanceof ShadowRoot ? root.host : null;
+      if (host && !evt.composedPath().includes(host)) {
         return;
       }
     }

--- a/src/display/Options.ts
+++ b/src/display/Options.ts
@@ -562,6 +562,16 @@ export class Options extends RapidElement {
       return;
     }
 
+    // Only intercept keys when the event originated within our owning component.
+    // Without this, any temba-options with populated options would swallow arrow
+    // keys document-wide, breaking cursor movement in unrelated text editors.
+    if (!this.block) {
+      const myHost = (this.getRootNode() as ShadowRoot).host;
+      if (myHost && !evt.composedPath().includes(myHost)) {
+        return;
+      }
+    }
+
     if (this.options && this.options.length > 0) {
       if ((evt.ctrlKey && evt.key === 'n') || evt.key === 'ArrowDown') {
         this.moveCursor(1);

--- a/src/form/RichEditor.ts
+++ b/src/form/RichEditor.ts
@@ -434,7 +434,10 @@ export class RichEditor extends FieldElement {
   }
 
   private handleKeydown(e: KeyboardEvent): void {
-    const mod = e.metaKey || e.ctrlKey;
+    // On macOS, Cmd is the undo/redo modifier; leave Ctrl alone so Cocoa
+    // text bindings like Ctrl+K (kill) and Ctrl+Y (yank) keep working.
+    const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent);
+    const mod = isMac ? e.metaKey : e.ctrlKey;
 
     // Undo/redo via keyboard: preventDefault here suppresses the subsequent
     // beforeinput event, avoiding double-handling

--- a/test/temba-node-editor.test.ts
+++ b/test/temba-node-editor.test.ts
@@ -323,10 +323,11 @@ describe('temba-node-editor', () => {
     editableDiv.focus();
     editableDiv.setSelectionRange(4, 4);
 
-    document.dispatchEvent(
+    editableDiv.dispatchEvent(
       new KeyboardEvent('keydown', {
         key: 'Tab',
-        bubbles: true
+        bubbles: true,
+        composed: true
       })
     );
 
@@ -410,10 +411,11 @@ describe('temba-node-editor', () => {
     editableDiv.focus();
     editableDiv.setSelectionRange(4, 4);
 
-    document.dispatchEvent(
+    editableDiv.dispatchEvent(
       new KeyboardEvent('keydown', {
         key: 'Enter',
-        bubbles: true
+        bubbles: true,
+        composed: true
       })
     );
 

--- a/test/temba-rich-edit.test.ts
+++ b/test/temba-rich-edit.test.ts
@@ -118,6 +118,9 @@ describe('temba-rich-edit', () => {
     expect(editor.value).to.equal('@con');
   });
 
+  // Synthesized keydowns can't drive native arrow/cursor navigation in
+  // Chromium (the browser only does that for real input from the OS), so the
+  // arrow-key tests below assert defaultPrevented instead of caret position.
   it('does not consume arrow keys in another editor when a sibling has options open', async () => {
     const wrapper = (await fixture(html`
       <div>
@@ -183,5 +186,81 @@ describe('temba-rich-edit', () => {
     await editor.updateComplete;
 
     expect(evt.defaultPrevented).to.equal(true);
+  });
+
+  it('lets Ctrl+Y pass through on macOS so Cocoa yank works', async () => {
+    const originalUA = navigator.userAgent;
+    Object.defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15',
+      configurable: true
+    });
+
+    try {
+      const editor = (await fixture(html`
+        <temba-rich-edit value="hello world" textarea></temba-rich-edit>
+      `)) as any;
+      await editor.updateComplete;
+
+      const editableDiv = editor.shadowRoot.querySelector(
+        '.highlight-editor'
+      ) as HTMLDivElement;
+      editableDiv.focus();
+
+      const evt = new KeyboardEvent('keydown', {
+        key: 'y',
+        ctrlKey: true,
+        bubbles: true,
+        composed: true,
+        cancelable: true
+      });
+      editableDiv.dispatchEvent(evt);
+      await editor.updateComplete;
+
+      expect(evt.defaultPrevented).to.equal(false);
+    } finally {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: originalUA,
+        configurable: true
+      });
+    }
+  });
+
+  it('still treats Ctrl+Y as redo on non-Mac platforms', async () => {
+    const originalUA = navigator.userAgent;
+    Object.defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+      configurable: true
+    });
+
+    try {
+      const editor = (await fixture(html`
+        <temba-rich-edit value="hello" textarea></temba-rich-edit>
+      `)) as any;
+      await editor.updateComplete;
+
+      const editableDiv = editor.shadowRoot.querySelector(
+        '.highlight-editor'
+      ) as HTMLDivElement;
+      editableDiv.focus();
+
+      const evt = new KeyboardEvent('keydown', {
+        key: 'y',
+        ctrlKey: true,
+        bubbles: true,
+        composed: true,
+        cancelable: true
+      });
+      editableDiv.dispatchEvent(evt);
+      await editor.updateComplete;
+
+      expect(evt.defaultPrevented).to.equal(true);
+    } finally {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: originalUA,
+        configurable: true
+      });
+    }
   });
 });

--- a/test/temba-rich-edit.test.ts
+++ b/test/temba-rich-edit.test.ts
@@ -66,10 +66,11 @@ describe('temba-rich-edit', () => {
       inputEvents += 1;
     });
 
-    document.dispatchEvent(
+    editableDiv.dispatchEvent(
       new KeyboardEvent('keydown', {
         key: 'Tab',
-        bubbles: true
+        bubbles: true,
+        composed: true
       })
     );
 
@@ -115,5 +116,72 @@ describe('temba-rich-edit', () => {
     // not to the earlier "@co" typing state.
     editor.performUndo();
     expect(editor.value).to.equal('@con');
+  });
+
+  it('does not consume arrow keys in another editor when a sibling has options open', async () => {
+    const wrapper = (await fixture(html`
+      <div>
+        <temba-rich-edit
+          id="popup"
+          value="@con"
+          textarea
+          session
+        ></temba-rich-edit>
+        <temba-rich-edit
+          id="active"
+          value="line one${'\n'}line two${'\n'}line three"
+          textarea
+        ></temba-rich-edit>
+      </div>
+    `)) as HTMLElement;
+
+    const popup = wrapper.querySelector('#popup') as any;
+    const active = wrapper.querySelector('#active') as any;
+    await popup.updateComplete;
+    await active.updateComplete;
+
+    popup.options = [{ name: 'contact.name' }, { name: 'contact.uuid' }];
+    await popup.updateComplete;
+
+    const activeDiv = active.shadowRoot.querySelector(
+      '.highlight-editor'
+    ) as HTMLDivElement;
+    activeDiv.focus();
+    (activeDiv as any).setSelectionRange(0, 0);
+
+    const evt = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      bubbles: true,
+      composed: true,
+      cancelable: true
+    });
+    activeDiv.dispatchEvent(evt);
+    await active.updateComplete;
+
+    expect(evt.defaultPrevented).to.equal(false);
+  });
+
+  it('still consumes arrow keys when the same editor has options open', async () => {
+    const editor = (await fixture(html`
+      <temba-rich-edit value="@con" textarea session></temba-rich-edit>
+    `)) as any;
+    editor.options = [{ name: 'contact.name' }, { name: 'contact.uuid' }];
+    await editor.updateComplete;
+
+    const editableDiv = editor.shadowRoot.querySelector(
+      '.highlight-editor'
+    ) as HTMLDivElement;
+    editableDiv.focus();
+
+    const evt = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      bubbles: true,
+      composed: true,
+      cancelable: true
+    });
+    editableDiv.dispatchEvent(evt);
+    await editor.updateComplete;
+
+    expect(evt.defaultPrevented).to.equal(true);
   });
 });


### PR DESCRIPTION
## Summary

- The `temba-options` document-level keydown handler intercepted arrow keys (and Tab/Enter/Escape) globally whenever any `temba-options` instance had populated options, breaking cursor movement in unrelated text editors on the page. It now only fires when the keydown's `composedPath()` includes the owning component's host.
- On macOS, `Ctrl+Y` was treated as redo, which blocked Cocoa's native yank text binding. Undo/redo now keys off `Cmd` on Mac and `Ctrl` elsewhere, leaving Cocoa bindings (`Ctrl+K`, `Ctrl+Y`, etc.) untouched.
- Updates two existing completion tests to dispatch keydowns from the editable div with `composed: true` (more realistic than dispatching from `document`) and adds two regression tests covering the cross-editor and same-editor arrow key behavior.

## Test plan
- [ ] `pnpm test:fast` passes
- [ ] In the flow editor, arrow up/down moves the cursor between visual lines while editing message text
- [ ] On macOS, `Ctrl+K` (kill) and `Ctrl+Y` (yank) both work in the rich editor
- [ ] On macOS, `Cmd+Z` / `Cmd+Shift+Z` / `Cmd+Y` still trigger undo/redo
- [ ] On Windows/Linux, `Ctrl+Z` / `Ctrl+Shift+Z` / `Ctrl+Y` still trigger undo/redo