### PR TITLE
Add Claude Code review workflow for PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,37 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request. Focus on:
+            - Code correctness and potential bugs
+            - Security issues
+            - Performance concerns
+            - Test coverage
+            - Adherence to existing project conventions
+
+            Use `gh pr comment` to leave your review as a single grouped comment on the PR.
+          claude_args: '--allowed-tools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"'


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-review.yml` which runs on every PR (opened/synchronize/reopened) and uses `anthropics/claude-code-action@v1` to post an automated code review.
- Authenticates via a `CLAUDE_CODE_OAUTH_TOKEN` repo secret (Claude Max OAuth), so no API billing.

## Setup required
- Generate the token locally with `claude setup-token` and add it as the `CLAUDE_CODE_OAUTH_TOKEN` repo secret before the workflow can run.

## Test plan
- [ ] Add the `CLAUDE_CODE_OAUTH_TOKEN` secret
- [ ] Confirm the workflow runs on this PR and posts a review comment