### PR TITLE
Use built-in PR review mode for Claude Code Review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,16 +22,4 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Please review this pull request. Focus on:
-            - Code correctness and potential bugs
-            - Security issues
-            - Performance concerns
-            - Test coverage
-            - Adherence to existing project conventions
-
-            Use `gh pr comment` to leave your review as a single grouped comment on the PR.
-          claude_args: '--allowed-tools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"'
+          claude_args: '--model claude-opus-4-7'


### PR DESCRIPTION
## Summary
- Drops the custom prompt and `--allowed-tools` restriction so the action's auto-detected `pull_request` review mode runs.
- Enables inline review comments (via the action's bundled `github_inline_comment` MCP tool) instead of a single grouped `gh pr comment`.
- Pins the model to `claude-opus-4-7` via `claude_args`.

## Test plan
- [ ] After merge, open a small follow-up PR and confirm the review posts inline comments + a summary