### PR TITLE
Trigger Claude review on PR events with inline comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   review:
@@ -16,10 +16,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-7'
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request. Focus on:
+            - Correctness and likely bugs
+            - Security issues
+            - Performance concerns
+            - Test coverage gaps
+            - Adherence to existing project conventions
+
+            Use inline comments for specific issues and a top-level comment
+            for the overall summary. Keep it concise — skip nits and praise.
+          claude_args: '--model claude-opus-4-7 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'


### PR DESCRIPTION
## Summary
- Without a prompt, the action defaulted to agent mode and waited for an `@claude` mention, so the previous run on PR #994 logged \`No trigger found, skipping remaining steps\`.
- Adds an explicit review prompt, enables \`track_progress: true\` so PR events force review mode, and allowlists the \`mcp__github_inline_comment__create_inline_comment\` tool so feedback can post inline.
- Keeps the model pinned to \`claude-opus-4-7\`.

## Test plan
- [ ] After merge, sync PR #994 with main and confirm the workflow posts inline comments + a summary