### PR TITLE
Add update-existing option to auto translate dialog

### DIFF
--- a/src/flow/AutoTranslate.ts
+++ b/src/flow/AutoTranslate.ts
@@ -300,7 +300,13 @@ export class AutoTranslate extends RapidElement {
     if (!updateExisting) {
       for (const bundle of bundles) {
         for (const entry of bundle.translations) {
-          if (!entry.toValues || entry.toValues.length === 0) {
+          // Skip entries with no real translation: an empty array OR an
+          // array of only empty/whitespace strings shouldn't seed reuse,
+          // or we'd silently propagate a blank to other matching sources.
+          if (
+            !entry.toValues ||
+            !entry.toValues.some((v) => v && v.trim().length > 0)
+          ) {
             continue;
           }
           if (!entry.fromValues || entry.fromValues.length === 0) {
@@ -322,6 +328,9 @@ export class AutoTranslate extends RapidElement {
     // attribute) maps to its source array (entry.fromValues), preserving
     // multi-item structure for attributes like router-case `arguments`.
     // In update mode we include entries that already have a translation.
+    // Invariant: findTranslations produces at most one entry per
+    // (uuid, attribute) pair, so the first fromValues is authoritative
+    // and any later entry with the same key is treated as a duplicate.
     const valuesByKey = new Map<string, string[]>();
 
     for (const bundle of bundles) {
@@ -534,14 +543,19 @@ export class AutoTranslate extends RapidElement {
       // Never replace an existing non-empty translation with an empty
       // value: when re-translating already-localized content the LLM may
       // return blanks for some entries; keep the prior translation in
-      // those slots.
+      // those slots. Only safe when the arrays align by index — if the
+      // source array length has changed since the last translation, the
+      // old values aren't tied to the same items anymore, so skip the
+      // per-item preserve and let the LLM result through unchanged.
+      const canPreservePerItem =
+        !!existingValues && existingValues.length === values.length;
       const mergedValues = values.map((v, i) => {
         const isEmpty =
           v === null ||
           v === undefined ||
           (typeof v === 'string' && v.trim().length === 0);
-        if (isEmpty && existingValues && existingValues[i]) {
-          return existingValues[i];
+        if (isEmpty && canPreservePerItem && existingValues![i]) {
+          return existingValues![i];
         }
         return v;
       });

--- a/src/flow/AutoTranslate.ts
+++ b/src/flow/AutoTranslate.ts
@@ -169,6 +169,9 @@ export class AutoTranslate extends RapidElement {
   @state()
   interrupt = false;
 
+  @state()
+  updateExisting = false;
+
   // Tracks whether the dialog has ever opened so we can keep it mounted
   // afterwards (so it sees its own close transition) without paying
   // for an empty hidden dialog before that.
@@ -191,6 +194,7 @@ export class AutoTranslate extends RapidElement {
     this.error = null;
     this.errorExpanded = false;
     this.selectedModel = null;
+    this.updateExisting = false;
     this.dialogOpen = true;
     await this.loadModels();
 
@@ -227,6 +231,11 @@ export class AutoTranslate extends RapidElement {
     this.selectedModel = next ? { uuid: next.uuid, name: next.name } : null;
   }
 
+  private handleUpdateExistingChange(event: Event): void {
+    const checkbox = event.target as any;
+    this.updateExisting = !!checkbox?.checked;
+  }
+
   private confirmTranslate(): void {
     if (!this.selectedModel) {
       return;
@@ -257,7 +266,10 @@ export class AutoTranslate extends RapidElement {
    * preTranslated for direct application), and dedupes pending entries
    * sharing identical source arrays so each unique array is sent at most
    * once (duplicates are returned in duplicateKeyToCanonical for
-   * propagation when the canonical key's translation lands).
+   * propagation when the canonical key's translation lands). When
+   * updateExisting is true, already-translated entries are also included
+   * and the pre-translation reuse path is skipped so all localizable
+   * entries are sent to the LLM.
    */
   private buildTranslationBatches(): {
     keyToEntries: Map<string, TranslationEntry[]>;
@@ -275,53 +287,62 @@ export class AutoTranslate extends RapidElement {
     }
 
     const bundles = buildTranslationBundles(this.definition, this.languageCode);
+    const updateExisting = this.updateExisting;
 
     // Map source-content -> already-stored translation array, built from
     // entries that have a translation in the live localization map. Reading
-    // the stored array (not entry.to) preserves the original shape.
+    // the stored array (not entry.to) preserves the original shape. Skipped
+    // in update mode so we always re-translate via the LLM.
     const existingByContent = new Map<string, string[]>();
     const localization =
       this.definition.localization?.[this.languageCode] || {};
 
-    for (const bundle of bundles) {
-      for (const entry of bundle.translations) {
-        if (!entry.to || entry.to.trim().length === 0) {
-          continue;
-        }
-        if (!entry.from || entry.from.trim().length === 0) {
-          continue;
-        }
-        const stored = localization[entry.uuid]?.[entry.attribute];
-        if (!Array.isArray(stored) || stored.length === 0) {
-          continue;
-        }
-        const contentKey = JSON.stringify([entry.from]);
-        if (!existingByContent.has(contentKey)) {
-          existingByContent.set(contentKey, stored);
+    if (!updateExisting) {
+      for (const bundle of bundles) {
+        for (const entry of bundle.translations) {
+          if (!entry.toValues || entry.toValues.length === 0) {
+            continue;
+          }
+          if (!entry.fromValues || entry.fromValues.length === 0) {
+            continue;
+          }
+          const stored = localization[entry.uuid]?.[entry.attribute];
+          if (!Array.isArray(stored) || stored.length === 0) {
+            continue;
+          }
+          const contentKey = JSON.stringify(entry.fromValues);
+          if (!existingByContent.has(contentKey)) {
+            existingByContent.set(contentKey, stored);
+          }
         }
       }
     }
 
-    // Collect pending entries (no translation yet) preserving order, and
-    // group source values per key in case the same key yields multiple
-    // entries.
+    // Collect pending entries preserving order. Each unique key (uuid +
+    // attribute) maps to its source array (entry.fromValues), preserving
+    // multi-item structure for attributes like router-case `arguments`.
+    // In update mode we include entries that already have a translation.
     const valuesByKey = new Map<string, string[]>();
 
     for (const bundle of bundles) {
       for (const entry of bundle.translations) {
-        if (entry.to && entry.to.trim().length > 0) {
+        if (
+          !updateExisting &&
+          entry.toValues &&
+          entry.toValues.some((v) => v && v.trim().length > 0)
+        ) {
           continue;
         }
-        if (!entry.from || entry.from.trim().length === 0) {
+        if (!entry.fromValues || entry.fromValues.length === 0) {
           continue;
         }
         const key = `${entry.uuid}:${entry.attribute}`;
         const list = keyToEntries.get(key) || [];
         list.push(entry);
         keyToEntries.set(key, list);
-        const values = valuesByKey.get(key) || [];
-        values.push(entry.from);
-        valuesByKey.set(key, values);
+        if (!valuesByKey.has(key)) {
+          valuesByKey.set(key, entry.fromValues);
+        }
       }
     }
 
@@ -506,8 +527,34 @@ export class AutoTranslate extends RapidElement {
       const liveDefinition = zustand.getState().flowDefinition;
       const existing =
         liveDefinition?.localization?.[this.languageCode]?.[uuid] || {};
+      const existingValues = Array.isArray(existing[attribute])
+        ? (existing[attribute] as string[])
+        : null;
+
+      // Never replace an existing non-empty translation with an empty
+      // value: when re-translating already-localized content the LLM may
+      // return blanks for some entries; keep the prior translation in
+      // those slots.
+      const mergedValues = values.map((v, i) => {
+        const isEmpty =
+          v === null ||
+          v === undefined ||
+          (typeof v === 'string' && v.trim().length === 0);
+        if (isEmpty && existingValues && existingValues[i]) {
+          return existingValues[i];
+        }
+        return v;
+      });
+
+      const hasContent = mergedValues.some(
+        (v) => v && (typeof v !== 'string' || v.trim().length > 0)
+      );
+      if (!hasContent) {
+        continue;
+      }
+
       const merged = updatesByUuid.get(uuid) || { ...existing };
-      merged[attribute] = values;
+      merged[attribute] = mergedValues;
       updatesByUuid.set(uuid, merged);
     }
 
@@ -642,7 +689,8 @@ export class AutoTranslate extends RapidElement {
     const selected = this.selectedModel ? [this.selectedModel] : [];
     const languageName = getLanguageDisplayName(this.languageCode);
     const aiClause = this.brand
-      ? html`${this.brand} uses AI for automatic translation, which can make mistakes,`
+      ? html`${this.brand} uses AI for automatic translation, which can make
+        mistakes,`
       : html`Automatic translation uses AI, which can make mistakes,`;
     return html`
       <p>
@@ -663,6 +711,12 @@ export class AutoTranslate extends RapidElement {
             @change=${this.handleModelChange}
           ></temba-select>`
         : ''}
+      <temba-checkbox
+        class="auto-translate-update-existing"
+        label="Update existing translations"
+        ?checked=${this.updateExisting}
+        @change=${this.handleUpdateExistingChange}
+      ></temba-checkbox>
     `;
   }
 

--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -3690,11 +3690,13 @@ export class Editor extends RapidElement {
           })
         ];
 
+    // shown whenever the active language has any localizable content, even
+    // at 100% — the dialog's "update existing" option lets users re-run
+    // translation on already-translated entries.
     const hasPendingTranslations =
       this.autoTranslateEnabled &&
       Boolean(activeLanguage) &&
-      progress.total > 0 &&
-      progress.localized < progress.total;
+      progress.total > 0;
 
     return html`
       <temba-editor-toolbar

--- a/src/flow/flow-translations.ts
+++ b/src/flow/flow-translations.ts
@@ -10,6 +10,12 @@ export interface TranslationEntry {
   attribute: string;
   from: string;
   to: string | null;
+  // Original array form of the source/target. For attributes whose value
+  // is an array (e.g. router case `arguments`), these preserve the per-item
+  // structure that `from`/`to` would otherwise lose to comma-joining. For
+  // scalar attributes the arrays contain a single item.
+  fromValues: string[];
+  toValues: string[] | null;
 }
 
 export interface TranslationBundle {
@@ -97,12 +103,29 @@ export function findTranslations(
 
     const toValue = to ? formatTranslationValue(to) : null;
 
+    const toArray = (value: any): string[] => {
+      if (Array.isArray(value)) {
+        return value.map((v) =>
+          v === null || v === undefined ? '' : String(v)
+        );
+      }
+      if (value === null || value === undefined) {
+        return [];
+      }
+      return [String(value)];
+    };
+
+    const fromValues = toArray(from);
+    const toValues = to !== null && to !== undefined ? toArray(to) : null;
+
     translations.push({
       uuid,
       type,
       attribute,
       from: fromValue,
-      to: toValue
+      to: toValue,
+      fromValues,
+      toValues
     });
   });
 

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -389,7 +389,7 @@ describe('Localization Editing', () => {
     ).to.not.exist;
   });
 
-  it('should hide auto translate when everything is translated', async () => {
+  it('should keep auto translate visible when everything is translated', async () => {
     await selectLanguageInToolbar(editor, 'Spanish', 'spa');
     await editor.updateComplete;
 
@@ -397,8 +397,9 @@ describe('Localization Editing', () => {
     const autoTranslateBtn = toolbar?.shadowRoot?.querySelector(
       '.toolbar-btn[aria-label="Auto translate"]'
     );
-    // spa has text translated; no pending, no button
-    expect(autoTranslateBtn).to.not.exist;
+    // spa is fully translated, but the button stays so users can update
+    // existing translations via the dialog
+    expect(autoTranslateBtn).to.exist;
   });
 
   it('should auto-skip picker when only one LLM is available', async () => {
@@ -932,6 +933,819 @@ describe('Localization Editing', () => {
     expect(localized['action-b']?.text).to.deep.equal(['Hello!fr']);
     expect(localized['action-c']?.text).to.deep.equal(['Hello!fr']);
     expect(localized['action-d']?.text).to.deep.equal(['Goodbye!fr']);
+  });
+
+  it('should not translate already-translated entries by default', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    // action-a is already translated, action-b is not. The default flow
+    // should send only action-b to the LLM.
+    const flowDefinition: FlowDefinition = {
+      uuid: 'update-default-flow',
+      name: 'Update Default Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {
+        fra: {
+          'action-a': { text: ['Bonjour'] }
+        }
+      },
+      nodes: [
+        {
+          uuid: 'node-a',
+          actions: [
+            { type: 'send_msg', uuid: 'action-a', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-a' }]
+        },
+        {
+          uuid: 'node-b',
+          actions: [
+            { type: 'send_msg', uuid: 'action-b', text: 'Goodbye' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-b' }]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-a': { position: { left: 0, top: 0 } },
+          'node-b': { position: { left: 0, top: 100 } }
+        },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 2, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+
+    const calls: any[] = [];
+    (storeElement as any).postJSON = async (_url: string, body: any) => {
+      calls.push(body);
+      const translated: Record<string, string[]> = {};
+      for (const [k, v] of Object.entries(
+        body.items as Record<string, string[]>
+      )) {
+        translated[k] = v.map((s) => `${s}!fr`);
+      }
+      return { status: 200, json: { items: translated } };
+    };
+
+    await at.runAutoTranslation();
+
+    expect(calls).to.have.lengthOf(1);
+    const sentKeys = Object.keys(calls[0].items as Record<string, string[]>);
+    // only action-b should have been sent
+    expect(sentKeys).to.deep.equal(['action-b:text']);
+
+    const localized =
+      zustand.getState().flowDefinition?.localization?.['fra'] || {};
+    // existing translation for action-a is unchanged
+    expect(localized['action-a']?.text).to.deep.equal(['Bonjour']);
+    // action-b is now translated
+    expect(localized['action-b']?.text).to.deep.equal(['Goodbye!fr']);
+  });
+
+  it('should re-translate already-translated entries when updateExisting is true', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    const flowDefinition: FlowDefinition = {
+      uuid: 'update-existing-flow',
+      name: 'Update Existing Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {
+        fra: {
+          'action-a': { text: ['Bonjour'] }
+        }
+      },
+      nodes: [
+        {
+          uuid: 'node-a',
+          actions: [
+            { type: 'send_msg', uuid: 'action-a', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-a' }]
+        },
+        {
+          uuid: 'node-b',
+          actions: [
+            { type: 'send_msg', uuid: 'action-b', text: 'Goodbye' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-b' }]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-a': { position: { left: 0, top: 0 } },
+          'node-b': { position: { left: 0, top: 100 } }
+        },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 2, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+    at.updateExisting = true;
+
+    const calls: any[] = [];
+    (storeElement as any).postJSON = async (_url: string, body: any) => {
+      calls.push(body);
+      const translated: Record<string, string[]> = {};
+      for (const [k, v] of Object.entries(
+        body.items as Record<string, string[]>
+      )) {
+        translated[k] = v.map((s) => `${s}!fr`);
+      }
+      return { status: 200, json: { items: translated } };
+    };
+
+    await at.runAutoTranslation();
+
+    // both already-translated and pending entries should have been sent
+    expect(calls).to.have.lengthOf(1);
+    const sentKeys = Object.keys(calls[0].items as Record<string, string[]>);
+    expect(sentKeys).to.include('action-a:text');
+    expect(sentKeys).to.include('action-b:text');
+
+    const localized =
+      zustand.getState().flowDefinition?.localization?.['fra'] || {};
+    // existing translation has been replaced with the new response
+    expect(localized['action-a']?.text).to.deep.equal(['Hello!fr']);
+    expect(localized['action-b']?.text).to.deep.equal(['Goodbye!fr']);
+  });
+
+  it('should re-translate multi-argument rules and propagate to duplicates in update mode', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    // Two wait-for-response style nodes that each have a single rule
+    // with 3 arguments [red, green, blue]. Node A is "translated" to
+    // matching English values; node B has no localization. Update mode
+    // should hand a 3-item source array to the LLM, get back a 3-item
+    // translated array, and write that array to both nodes' localization.
+    const flowDefinition: FlowDefinition = {
+      uuid: 'multi-arg-flow',
+      name: 'Multi Arg Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {
+        fra: {
+          'case-A': { arguments: ['red', 'green', 'blue'] }
+        }
+      },
+      nodes: [
+        {
+          uuid: 'node-A',
+          actions: [],
+          router: {
+            type: 'switch',
+            operand: '@input.text',
+            cases: [
+              {
+                uuid: 'case-A',
+                type: 'has_any_word',
+                arguments: ['red', 'green', 'blue'],
+                category_uuid: 'cat-A1'
+              }
+            ],
+            categories: [
+              { uuid: 'cat-A1', name: 'Match', exit_uuid: 'exit-A1' },
+              { uuid: 'cat-A-other', name: 'Other', exit_uuid: 'exit-A-other' }
+            ],
+            default_category_uuid: 'cat-A-other'
+          },
+          exits: [
+            { uuid: 'exit-A1', destination_uuid: null },
+            { uuid: 'exit-A-other', destination_uuid: null }
+          ]
+        },
+        {
+          uuid: 'node-B',
+          actions: [],
+          router: {
+            type: 'switch',
+            operand: '@input.text',
+            cases: [
+              {
+                uuid: 'case-B',
+                type: 'has_any_word',
+                arguments: ['red', 'green', 'blue'],
+                category_uuid: 'cat-B1'
+              }
+            ],
+            categories: [
+              { uuid: 'cat-B1', name: 'Match', exit_uuid: 'exit-B1' },
+              { uuid: 'cat-B-other', name: 'Other', exit_uuid: 'exit-B-other' }
+            ],
+            default_category_uuid: 'cat-B-other'
+          },
+          exits: [
+            { uuid: 'exit-B1', destination_uuid: null },
+            { uuid: 'exit-B-other', destination_uuid: null }
+          ]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-A': {
+            position: { left: 0, top: 0 },
+            type: 'wait_for_response',
+            config: { localizeRules: true }
+          },
+          'node-B': {
+            position: { left: 0, top: 200 },
+            type: 'wait_for_response',
+            config: { localizeRules: true }
+          }
+        },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 2, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+    at.updateExisting = true;
+
+    const calls: any[] = [];
+    (storeElement as any).postJSON = async (_url: string, body: any) => {
+      calls.push(body);
+      const items = body.items as Record<string, string[]>;
+      const dictionary: Record<string, string> = {
+        red: 'rouge',
+        green: 'vert',
+        blue: 'bleu'
+      };
+      const translated: Record<string, string[]> = {};
+      for (const [k, v] of Object.entries(items)) {
+        translated[k] = v.map((s) => dictionary[s] ?? s);
+      }
+      return { status: 200, json: { items: translated } };
+    };
+
+    await at.runAutoTranslation();
+
+    // single canonical request for the duplicated argument set
+    expect(calls).to.have.lengthOf(1);
+    const sentItems = calls[0].items as Record<string, string[]>;
+    expect(Object.keys(sentItems)).to.have.lengthOf(1);
+    const [sentValues] = Object.values(sentItems);
+    expect(sentValues).to.deep.equal(['red', 'green', 'blue']);
+
+    const localized =
+      zustand.getState().flowDefinition?.localization?.['fra'] || {};
+    // both nodes' rules end up with the per-item translated array
+    expect(localized['case-A']?.arguments).to.deep.equal([
+      'rouge',
+      'vert',
+      'bleu'
+    ]);
+    expect(localized['case-B']?.arguments).to.deep.equal([
+      'rouge',
+      'vert',
+      'bleu'
+    ]);
+  });
+
+  it('should re-translate rules even when an existing translation matches the source', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    // Two wait-for-response style nodes share the same set of rule
+    // arguments. Node A has been "translated" to the same English values
+    // as the source; node B has no localization. Update mode should
+    // discard the English-matching translation, ask the LLM for fresh
+    // translations, and apply them to every matching rule.
+    const flowDefinition: FlowDefinition = {
+      uuid: 'rules-flow',
+      name: 'Rules Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {
+        fra: {
+          'case-A1': { arguments: ['red'] },
+          'case-A2': { arguments: ['green'] },
+          'case-A3': { arguments: ['blue'] }
+        }
+      },
+      nodes: [
+        {
+          uuid: 'node-A',
+          actions: [],
+          router: {
+            type: 'switch',
+            operand: '@input.text',
+            cases: [
+              {
+                uuid: 'case-A1',
+                type: 'has_only_phrase',
+                arguments: ['red'],
+                category_uuid: 'cat-A1'
+              },
+              {
+                uuid: 'case-A2',
+                type: 'has_only_phrase',
+                arguments: ['green'],
+                category_uuid: 'cat-A2'
+              },
+              {
+                uuid: 'case-A3',
+                type: 'has_only_phrase',
+                arguments: ['blue'],
+                category_uuid: 'cat-A3'
+              }
+            ],
+            categories: [
+              { uuid: 'cat-A1', name: 'Red', exit_uuid: 'exit-A1' },
+              { uuid: 'cat-A2', name: 'Green', exit_uuid: 'exit-A2' },
+              { uuid: 'cat-A3', name: 'Blue', exit_uuid: 'exit-A3' },
+              { uuid: 'cat-A-other', name: 'Other', exit_uuid: 'exit-A-other' }
+            ],
+            default_category_uuid: 'cat-A-other'
+          },
+          exits: [
+            { uuid: 'exit-A1', destination_uuid: null },
+            { uuid: 'exit-A2', destination_uuid: null },
+            { uuid: 'exit-A3', destination_uuid: null },
+            { uuid: 'exit-A-other', destination_uuid: null }
+          ]
+        },
+        {
+          uuid: 'node-B',
+          actions: [],
+          router: {
+            type: 'switch',
+            operand: '@input.text',
+            cases: [
+              {
+                uuid: 'case-B1',
+                type: 'has_only_phrase',
+                arguments: ['red'],
+                category_uuid: 'cat-B1'
+              },
+              {
+                uuid: 'case-B2',
+                type: 'has_only_phrase',
+                arguments: ['green'],
+                category_uuid: 'cat-B2'
+              },
+              {
+                uuid: 'case-B3',
+                type: 'has_only_phrase',
+                arguments: ['blue'],
+                category_uuid: 'cat-B3'
+              }
+            ],
+            categories: [
+              { uuid: 'cat-B1', name: 'Red', exit_uuid: 'exit-B1' },
+              { uuid: 'cat-B2', name: 'Green', exit_uuid: 'exit-B2' },
+              { uuid: 'cat-B3', name: 'Blue', exit_uuid: 'exit-B3' },
+              { uuid: 'cat-B-other', name: 'Other', exit_uuid: 'exit-B-other' }
+            ],
+            default_category_uuid: 'cat-B-other'
+          },
+          exits: [
+            { uuid: 'exit-B1', destination_uuid: null },
+            { uuid: 'exit-B2', destination_uuid: null },
+            { uuid: 'exit-B3', destination_uuid: null },
+            { uuid: 'exit-B-other', destination_uuid: null }
+          ]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-A': {
+            position: { left: 0, top: 0 },
+            type: 'wait_for_response',
+            config: { localizeRules: true }
+          },
+          'node-B': {
+            position: { left: 0, top: 200 },
+            type: 'wait_for_response',
+            config: { localizeRules: true }
+          }
+        },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 2, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+    at.updateExisting = true;
+
+    const calls: any[] = [];
+    (storeElement as any).postJSON = async (_url: string, body: any) => {
+      calls.push(body);
+      const items = body.items as Record<string, string[]>;
+      const dictionary: Record<string, string> = {
+        red: 'rouge',
+        green: 'vert',
+        blue: 'bleu'
+      };
+      const translated: Record<string, string[]> = {};
+      for (const [k, v] of Object.entries(items)) {
+        translated[k] = v.map((s) => dictionary[s] ?? s);
+      }
+      return { status: 200, json: { items: translated } };
+    };
+
+    await at.runAutoTranslation();
+
+    const localized =
+      zustand.getState().flowDefinition?.localization?.['fra'] || {};
+    // node A's existing English-like translations are replaced with French
+    expect(localized['case-A1']?.arguments).to.deep.equal(['rouge']);
+    expect(localized['case-A2']?.arguments).to.deep.equal(['vert']);
+    expect(localized['case-A3']?.arguments).to.deep.equal(['bleu']);
+    // node B picks up the same fresh translations
+    expect(localized['case-B1']?.arguments).to.deep.equal(['rouge']);
+    expect(localized['case-B2']?.arguments).to.deep.equal(['vert']);
+    expect(localized['case-B3']?.arguments).to.deep.equal(['bleu']);
+  });
+
+  it('should replace all matching translations with a fresh value when updateExisting is true', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    // three actions share the same source. All are already translated,
+    // including some with different translations. Update mode should
+    // fetch one fresh translation and apply it to every instance.
+    const flowDefinition: FlowDefinition = {
+      uuid: 'replace-all-flow',
+      name: 'Replace All Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {
+        fra: {
+          'action-a': { text: ['Salut'] },
+          'action-b': { text: ['Bonjour'] },
+          'action-c': { text: ['Allo'] }
+        }
+      },
+      nodes: [
+        {
+          uuid: 'node-a',
+          actions: [
+            { type: 'send_msg', uuid: 'action-a', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-a' }]
+        },
+        {
+          uuid: 'node-b',
+          actions: [
+            { type: 'send_msg', uuid: 'action-b', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-b' }]
+        },
+        {
+          uuid: 'node-c',
+          actions: [
+            { type: 'send_msg', uuid: 'action-c', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-c' }]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-a': { position: { left: 0, top: 0 } },
+          'node-b': { position: { left: 0, top: 100 } },
+          'node-c': { position: { left: 0, top: 200 } }
+        },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 3, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+    at.updateExisting = true;
+
+    const calls: any[] = [];
+    (storeElement as any).postJSON = async (_url: string, body: any) => {
+      calls.push(body);
+      const translated: Record<string, string[]> = {};
+      for (const k of Object.keys(body.items as Record<string, string[]>)) {
+        translated[k] = ['Coucou'];
+      }
+      return { status: 200, json: { items: translated } };
+    };
+
+    await at.runAutoTranslation();
+
+    // only one canonical entry should be sent for the duplicated source
+    expect(calls).to.have.lengthOf(1);
+    const sentKeys = Object.keys(calls[0].items as Record<string, string[]>);
+    expect(sentKeys).to.have.lengthOf(1);
+
+    const localized =
+      zustand.getState().flowDefinition?.localization?.['fra'] || {};
+    // every existing translation, regardless of its prior value, gets the
+    // new translation
+    expect(localized['action-a']?.text).to.deep.equal(['Coucou']);
+    expect(localized['action-b']?.text).to.deep.equal(['Coucou']);
+    expect(localized['action-c']?.text).to.deep.equal(['Coucou']);
+  });
+
+  it('should propagate updates to entries sharing the same source when updateExisting is true', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    // action-a is already translated; action-b shares the same source.
+    // With updateExisting true, the new response should update both.
+    const flowDefinition: FlowDefinition = {
+      uuid: 'update-dedupe-flow',
+      name: 'Update Dedupe Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {
+        fra: {
+          'action-a': { text: ['Salut'] }
+        }
+      },
+      nodes: [
+        {
+          uuid: 'node-a',
+          actions: [
+            { type: 'send_msg', uuid: 'action-a', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-a' }]
+        },
+        {
+          uuid: 'node-b',
+          actions: [
+            { type: 'send_msg', uuid: 'action-b', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-b' }]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-a': { position: { left: 0, top: 0 } },
+          'node-b': { position: { left: 0, top: 100 } }
+        },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 2, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+    at.updateExisting = true;
+
+    const calls: any[] = [];
+    (storeElement as any).postJSON = async (_url: string, body: any) => {
+      calls.push(body);
+      const translated: Record<string, string[]> = {};
+      for (const [k, v] of Object.entries(
+        body.items as Record<string, string[]>
+      )) {
+        translated[k] = v.map(() => 'Bonjour');
+      }
+      return { status: 200, json: { items: translated } };
+    };
+
+    await at.runAutoTranslation();
+
+    // only one canonical entry should be sent for the duplicate source
+    expect(calls).to.have.lengthOf(1);
+    const sentKeys = Object.keys(calls[0].items as Record<string, string[]>);
+    expect(sentKeys).to.have.lengthOf(1);
+
+    const localized =
+      zustand.getState().flowDefinition?.localization?.['fra'] || {};
+    // both entries get the same updated translation
+    expect(localized['action-a']?.text).to.deep.equal(['Bonjour']);
+    expect(localized['action-b']?.text).to.deep.equal(['Bonjour']);
+  });
+
+  it('should never replace an existing translation with an empty value', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    // action-a and action-b are both already translated. The LLM returns
+    // an empty string for action-a's text — the existing translation
+    // should be preserved.
+    const flowDefinition: FlowDefinition = {
+      uuid: 'preserve-empty-flow',
+      name: 'Preserve Empty Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {
+        fra: {
+          'action-a': { text: ['Bonjour'] },
+          'action-b': { text: ['Au revoir'] }
+        }
+      },
+      nodes: [
+        {
+          uuid: 'node-a',
+          actions: [
+            { type: 'send_msg', uuid: 'action-a', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-a' }]
+        },
+        {
+          uuid: 'node-b',
+          actions: [
+            { type: 'send_msg', uuid: 'action-b', text: 'Goodbye' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-b' }]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-a': { position: { left: 0, top: 0 } },
+          'node-b': { position: { left: 0, top: 100 } }
+        },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 2, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+    at.updateExisting = true;
+
+    (storeElement as any).postJSON = async (_url: string, body: any) => {
+      const items = body.items as Record<string, string[]>;
+      const translated: Record<string, string[]> = {};
+      for (const [k, v] of Object.entries(items)) {
+        if (k === 'action-a:text') {
+          // simulate the LLM returning an empty value for this entry
+          translated[k] = [''];
+        } else {
+          translated[k] = v.map((s) => `${s}!fr`);
+        }
+      }
+      return { status: 200, json: { items: translated } };
+    };
+
+    await at.runAutoTranslation();
+
+    const localized =
+      zustand.getState().flowDefinition?.localization?.['fra'] || {};
+    // empty response keeps the prior translation
+    expect(localized['action-a']?.text).to.deep.equal(['Bonjour']);
+    // a non-empty response replaces the prior translation as expected
+    expect(localized['action-b']?.text).to.deep.equal(['Goodbye!fr']);
+  });
+
+  it('should render an unchecked update-existing checkbox in the picker', async () => {
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+
+    (storeElement as any).getResults = async () => [
+      { uuid: 'llm-only', name: 'SoloGPT', roles: ['editing'] }
+    ];
+
+    const autoTranslateBtn = editor
+      .querySelector('temba-editor-toolbar')
+      ?.shadowRoot?.querySelector(
+        '.toolbar-btn[aria-label="Auto translate"]'
+      ) as HTMLButtonElement;
+    autoTranslateBtn.click();
+    await editor.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+    const at = editor.querySelector('temba-auto-translate') as any;
+    await at.updateComplete;
+
+    const dialog = at.shadowRoot.querySelector('.auto-translate-body');
+    const checkbox = dialog?.querySelector(
+      '.auto-translate-update-existing'
+    ) as any;
+    expect(checkbox).to.exist;
+    expect(checkbox.checked).to.not.be.true;
+    expect(at.updateExisting).to.be.false;
   });
 
   it('should preserve selected language across renders', async () => {

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -935,6 +935,196 @@ describe('Localization Editing', () => {
     expect(localized['action-d']?.text).to.deep.equal(['Goodbye!fr']);
   });
 
+  it('should not seed reuse from a stored translation that contains only empty strings', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    // action-a's stored translation is just empty strings — a leftover
+    // from a save that didn't actually translate anything. action-b
+    // shares the same source and is genuinely untranslated. Default
+    // (non-update) mode should still send action-b to the LLM, not
+    // pre-translate it with the empty stored value.
+    const flowDefinition: FlowDefinition = {
+      uuid: 'empty-stored-flow',
+      name: 'Empty Stored Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {
+        fra: {
+          'action-a': { text: [''] }
+        }
+      },
+      nodes: [
+        {
+          uuid: 'node-a',
+          actions: [
+            { type: 'send_msg', uuid: 'action-a', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-a' }]
+        },
+        {
+          uuid: 'node-b',
+          actions: [
+            { type: 'send_msg', uuid: 'action-b', text: 'Hello' } as SendMsg
+          ],
+          exits: [{ uuid: 'exit-b' }]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-a': { position: { left: 0, top: 0 } },
+          'node-b': { position: { left: 0, top: 100 } }
+        },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 2, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+
+    const calls: any[] = [];
+    (storeElement as any).postJSON = async (_url: string, body: any) => {
+      calls.push(body);
+      const translated: Record<string, string[]> = {};
+      for (const [k, v] of Object.entries(
+        body.items as Record<string, string[]>
+      )) {
+        translated[k] = v.map((s) => `${s}!fr`);
+      }
+      return { status: 200, json: { items: translated } };
+    };
+
+    await at.runAutoTranslation();
+
+    // a real LLM round-trip happens (action-a's empty stored translation
+    // must NOT be reused for action-b)
+    expect(calls).to.have.lengthOf(1);
+    const sentItems = calls[0].items as Record<string, string[]>;
+    expect(Object.values(sentItems)[0]).to.deep.equal(['Hello']);
+
+    // action-b ends up with a real translation rather than the empty
+    // pre-translation that the old reuse logic would have produced
+    const localized =
+      zustand.getState().flowDefinition?.localization?.['fra'] || {};
+    expect(localized['action-b']?.text).to.deep.equal(['Hello!fr']);
+  });
+
+  it('should not splice stale per-item values when source array length grew', async () => {
+    editor?.remove();
+    setupWorkspace();
+
+    // The stored arguments translation is shorter than the current
+    // source array — a sign that the rule grew after it was last
+    // translated. If the LLM returns blanks for the new positions, the
+    // merge must NOT splice the old single value into position 0 of the
+    // new array (which would mix English into a translated row).
+    const flowDefinition: FlowDefinition = {
+      uuid: 'grew-args-flow',
+      name: 'Grew Args Flow',
+      language: 'eng',
+      type: 'messaging',
+      revision: 1,
+      spec_version: '14.3',
+      localization: {
+        fra: {
+          'case-A': { arguments: ['Red'] }
+        }
+      },
+      nodes: [
+        {
+          uuid: 'node-A',
+          actions: [],
+          router: {
+            type: 'switch',
+            operand: '@input.text',
+            cases: [
+              {
+                uuid: 'case-A',
+                type: 'has_any_word',
+                arguments: ['red', 'green', 'blue'],
+                category_uuid: 'cat-A1'
+              }
+            ],
+            categories: [
+              { uuid: 'cat-A1', name: 'Match', exit_uuid: 'exit-A1' },
+              { uuid: 'cat-A-other', name: 'Other', exit_uuid: 'exit-A-other' }
+            ],
+            default_category_uuid: 'cat-A-other'
+          },
+          exits: [
+            { uuid: 'exit-A1', destination_uuid: null },
+            { uuid: 'exit-A-other', destination_uuid: null }
+          ]
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-A': {
+            position: { left: 0, top: 0 },
+            type: 'wait_for_response',
+            config: { localizeRules: true }
+          }
+        },
+        languages: []
+      }
+    };
+
+    zustand.getState().setFlowContents({
+      definition: flowDefinition,
+      info: {
+        results: [],
+        dependencies: [],
+        counts: { nodes: 1, languages: 2 },
+        locals: []
+      }
+    });
+
+    editor = await fixture(
+      html`<temba-flow-editor
+        features='["auto_translate"]'
+      ></temba-flow-editor>`
+    );
+    await editor.updateComplete;
+    await selectLanguageInToolbar(editor, 'French', 'fra');
+    const at = editor.querySelector('temba-auto-translate') as any;
+    at.selectedModel = { uuid: 'llm-1', name: 'GPT-4' };
+    at.updateExisting = true;
+
+    (storeElement as any).postJSON = async (_url: string, _body: any) => {
+      return {
+        status: 200,
+        json: { items: { 'case-A:arguments': ['', 'vert', 'bleu'] } }
+      };
+    };
+
+    await at.runAutoTranslation();
+
+    const localized =
+      zustand.getState().flowDefinition?.localization?.['fra'] || {};
+    // because the lengths don't align, the LLM result is taken as-is —
+    // the stored 'Red' must NOT leak into position 0
+    expect(localized['case-A']?.arguments).to.deep.equal(['', 'vert', 'bleu']);
+  });
+
   it('should not translate already-translated entries by default', async () => {
     editor?.remove();
     setupWorkspace();


### PR DESCRIPTION
## Summary
- Adds an "Update existing translations" checkbox to the auto-translate dialog (default off). When checked, already-localized entries are re-sent to the LLM, duplicates sharing a source value are deduped and the fresh translation is propagated to every matching entry, and empty responses never overwrite a non-empty existing translation.
- Keeps the auto-translate toolbar button visible at 100% localization so users can still open the dialog to refresh translations.
- Fixes a pre-existing shape bug for array-valued localizable attributes (router case `arguments`): translation entries now carry the per-item arrays via new `fromValues` / `toValues` fields, so the LLM receives the real array and per-item translations are written back correctly.

## Test plan
- [x] `pnpm test:fast --files test/temba-localization.test.ts` (39/39 pass, including new tests for update mode, multi-arg rules, duplicate-source propagation, and empty-response preservation)
- [ ] Manual: open the auto-translate dialog with the box unchecked — behaves as before
- [ ] Manual: check the box and run on a flow with mixed translated/untranslated entries — every matching source ends up with the fresh translation
- [ ] Manual: open the dialog when the language is at 100% — button is still visible