### PR TITLE
Remove auto_translate feature flag and always enable

### DIFF
--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -40,7 +40,6 @@ import type { RevisionsWindow } from './RevisionsWindow';
 import {
   ACTION_GROUP_METADATA,
   CONTEXT_MENU_SHORTCUTS,
-  Features,
   FlowType,
   FlowTypes
 } from './types';
@@ -199,10 +198,6 @@ export class Editor extends RapidElement {
 
   @property({ type: Array })
   public features: string[] = [];
-
-  private get autoTranslateEnabled(): boolean {
-    return this.features?.includes(Features.AUTO_TRANSLATE) ?? false;
-  }
 
   private activityTimer: number | null = null;
   private activityInterval = 100; // Start with 100ms interval for fast initial load
@@ -1760,7 +1755,7 @@ export class Editor extends RapidElement {
   }
 
   private handleAutoTranslateClick(): void {
-    if (!this.autoTranslateEnabled || this.viewingRevision) {
+    if (this.viewingRevision) {
       return;
     }
     const at = this.querySelector('temba-auto-translate') as any;
@@ -3694,9 +3689,7 @@ export class Editor extends RapidElement {
     // at 100% — the dialog's "update existing" option lets users re-run
     // translation on already-translated entries.
     const hasPendingTranslations =
-      this.autoTranslateEnabled &&
-      Boolean(activeLanguage) &&
-      progress.total > 0;
+      Boolean(activeLanguage) && progress.total > 0;
 
     return html`
       <temba-editor-toolbar
@@ -3930,14 +3923,12 @@ export class Editor extends RapidElement {
         @temba-revision-reverted=${this.handleRevisionReverted}
         @temba-revisions-closed=${this.handleRevisionsClosed}
       ></temba-revisions-window>
-      ${this.autoTranslateEnabled
-        ? html`<temba-auto-translate
-            .definition=${this.definition}
-            language-code=${this.languageCode}
-            ?disabled=${this.viewingRevision}
-            @temba-auto-translate-changed=${this.handleAutoTranslateChanged}
-          ></temba-auto-translate>`
-        : ''}
+      <temba-auto-translate
+        .definition=${this.definition}
+        language-code=${this.languageCode}
+        ?disabled=${this.viewingRevision}
+        @temba-auto-translate-changed=${this.handleAutoTranslateChanged}
+      ></temba-auto-translate>
       <div id="editor-container">
         ${this.renderToolbarElement()}
         <div id="editor">

--- a/src/flow/types.ts
+++ b/src/flow/types.ts
@@ -50,8 +50,7 @@ export const CONTEXT_MENU_SHORTCUTS: Record<FlowType, ContextMenuShortcut[]> = {
 export const Features = {
   AI: 'ai',
   AIRTIME: 'airtime',
-  LOCATIONS: 'locations',
-  AUTO_TRANSLATE: 'auto_translate'
+  LOCATIONS: 'locations'
 } as const;
 
 export type Feature = (typeof Features)[keyof typeof Features];

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -176,9 +176,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
   });
@@ -220,9 +218,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
 
@@ -268,9 +264,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
 
@@ -309,9 +303,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
 
@@ -365,28 +357,6 @@ describe('Localization Editing', () => {
     const shouldExclude = (modelSelect as any).shouldExclude;
     expect(shouldExclude({ roles: ['engine'] })).to.be.true;
     expect(shouldExclude({ roles: ['editing'] })).to.be.false;
-  });
-
-  it('should hide auto translate when the auto-translate flag is off', async () => {
-    await selectLanguageInToolbar(editor, 'French', 'fra');
-    const toolbar = editor.querySelector('temba-editor-toolbar') as any;
-    // sanity check: the button is there when the flag is on
-    expect(
-      toolbar?.shadowRoot?.querySelector(
-        '.toolbar-btn[aria-label="Auto translate"]'
-      )
-    ).to.exist;
-
-    // remove the feature — button should disappear
-    (editor as any).features = [];
-    await editor.updateComplete;
-    await toolbar.updateComplete;
-
-    expect(
-      toolbar?.shadowRoot?.querySelector(
-        '.toolbar-btn[aria-label="Auto translate"]'
-      )
-    ).to.not.exist;
   });
 
   it('should keep auto translate visible when everything is translated', async () => {
@@ -556,9 +526,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
 
@@ -637,9 +605,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -711,9 +677,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -805,9 +769,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -897,9 +859,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -992,9 +952,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -1099,9 +1057,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -1179,9 +1135,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -1267,9 +1221,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -1405,9 +1357,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -1590,9 +1540,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -1695,9 +1643,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -1785,9 +1731,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -1877,9 +1821,7 @@ describe('Localization Editing', () => {
     });
 
     editor = await fixture(
-      html`<temba-flow-editor
-        features='["auto_translate"]'
-      ></temba-flow-editor>`
+      html`<temba-flow-editor></temba-flow-editor>`
     );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');


### PR DESCRIPTION
## Summary

The auto translate feature is no longer gated behind the `auto_translate` workspace feature; it is always enabled in the flow editor.

- Removed `Features.AUTO_TRANSLATE` and the `autoTranslateEnabled` getter on the editor.
- The `<temba-auto-translate>` component is always mounted; the toolbar's auto translate button no longer requires the feature flag.
- Dropped the test that exercised hiding the button when the flag was off and removed the now-unused `features='["auto_translate"]'` attribute from the localization test fixtures.

## Test plan

- [x] Localization tests pass (`pnpm test:fast --files test/temba-localization.test.ts`)
- [x] Full suite passes other than a pre-existing flaky `temba-slider` screenshot diff