### PR TITLE
Add change summaries and grouping to the revision browser

### DIFF
--- a/src/flow/Editor.ts
+++ b/src/flow/Editor.ts
@@ -1596,6 +1596,9 @@ export class Editor extends RapidElement {
         }
 
         getStore().getState().setDirtyDate(null);
+
+        // Refresh the revisions list if it's currently open.
+        this.getRevisionsWindow()?.refresh();
       })
       .catch((error) => {
         console.error('Failed to save flow:', error);

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -67,6 +67,7 @@ export class RevisionsWindow extends RapidElement {
     dirtyDate: Date | null;
   } | null = null;
   private browseLanguageCode: string | null = null;
+  private fetchRequestId = 0;
 
   public get isViewingRevision(): boolean {
     return this.viewingRevision !== null;
@@ -79,11 +80,13 @@ export class RevisionsWindow extends RapidElement {
       changes.has('hidden') &&
       !this.hidden &&
       changes.get('hidden') === true;
+    const previousRevision = changes.get('liveRevision') as number | undefined;
     const newRevisionWhileOpen =
       !this.hidden &&
       changes.has('liveRevision') &&
-      changes.get('liveRevision') !== undefined &&
-      !this.storeViewingRevision;
+      !this.storeViewingRevision &&
+      previousRevision !== undefined &&
+      this.liveRevision > previousRevision;
 
     if (opening || newRevisionWhileOpen) {
       this.fetchRevisions();
@@ -197,16 +200,21 @@ export class RevisionsWindow extends RapidElement {
   // --- Private ---
 
   private async fetchRevisions() {
+    const requestId = ++this.fetchRequestId;
     this.isLoading = true;
     try {
       const results = await fetchResults(
         `/flow/revisions/${this.flow}/?version=${FLOW_SPEC_VERSION}`
       );
+      if (requestId !== this.fetchRequestId) return;
       this.revisions = this.collapseRevisions(results);
     } catch (e) {
+      if (requestId !== this.fetchRequestId) return;
       console.error('Error fetching revisions', e);
     } finally {
-      this.isLoading = false;
+      if (requestId === this.fetchRequestId) {
+        this.isLoading = false;
+      }
     }
   }
 
@@ -226,7 +234,10 @@ export class RevisionsWindow extends RapidElement {
     };
 
     for (const rev of revisions) {
-      if (isSignificantChange(rev.changes)) {
+      // Significant revisions and revisions with no recorded changes (legacy/opaque
+      // entries) always stand alone so the user can click in to inspect them.
+      const opaque = !rev.changes || rev.changes.length === 0;
+      if (opaque || isSignificantChange(rev.changes)) {
         flush();
         result.push(rev);
         continue;

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -7,13 +7,7 @@ import { getStore } from '../store/Store';
 import { FlowDefinition } from '../store/flow-definition';
 import { fetchResults } from '../utils';
 import { FLOW_SPEC_VERSION } from '../store/AppState';
-import {
-  RevisionChange,
-  isSignificantChange,
-  summarizeChanges
-} from './revision-summary';
-
-const GROUP_WINDOW_MS = 15 * 60 * 1000;
+import { RevisionChanges, summarizeChanges } from './revision-summary';
 
 export interface Revision {
   id: number;
@@ -26,7 +20,7 @@ export interface Revision {
   };
   created_on: string;
   comment?: string;
-  changes?: RevisionChange[] | null;
+  changes?: RevisionChanges | null;
 }
 
 export class RevisionsWindow extends RapidElement {
@@ -198,7 +192,7 @@ export class RevisionsWindow extends RapidElement {
         `/flow/revisions/${this.flow}/?version=${FLOW_SPEC_VERSION}`
       );
       if (requestId !== this.fetchRequestId) return;
-      this.revisions = this.collapseRevisions(results);
+      this.revisions = results;
     } catch (e) {
       if (requestId !== this.fetchRequestId) return;
       console.error('Error fetching revisions', e);
@@ -207,47 +201,6 @@ export class RevisionsWindow extends RapidElement {
         this.isLoading = false;
       }
     }
-  }
-
-  private collapseRevisions(revisions: Revision[]): Revision[] {
-    const result: Revision[] = [];
-    let group: Revision[] = [];
-
-    const flush = () => {
-      if (group.length === 0) return;
-      const head = group[0];
-      const allChanges: RevisionChange[] = [];
-      for (const r of group) {
-        if (r.changes) allChanges.push(...r.changes);
-      }
-      result.push({ ...head, changes: allChanges });
-      group = [];
-    };
-
-    for (const rev of revisions) {
-      // Significant revisions and revisions with no recorded changes (legacy/opaque
-      // entries) always stand alone so the user can click in to inspect them.
-      const opaque = !rev.changes || rev.changes.length === 0;
-      if (opaque || isSignificantChange(rev.changes)) {
-        flush();
-        result.push(rev);
-        continue;
-      }
-      if (group.length === 0) {
-        group.push(rev);
-        continue;
-      }
-      const headTime = new Date(group[0].created_on).getTime();
-      const revTime = new Date(rev.created_on).getTime();
-      if (headTime - revTime < GROUP_WINDOW_MS) {
-        group.push(rev);
-      } else {
-        flush();
-        group.push(rev);
-      }
-    }
-    flush();
-    return result;
   }
 
   private async handleRevisionClick(revision: Revision) {

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -9,6 +9,8 @@ import { fetchResults } from '../utils';
 import { FLOW_SPEC_VERSION } from '../store/AppState';
 import { RevisionChanges, summarizeChanges } from './revision-summary';
 
+const GROUP_WINDOW_MS = 15 * 60 * 1000;
+
 export interface Revision {
   id: number;
   user: {
@@ -192,7 +194,7 @@ export class RevisionsWindow extends RapidElement {
         `/flow/revisions/${this.flow}/?version=${FLOW_SPEC_VERSION}`
       );
       if (requestId !== this.fetchRequestId) return;
-      this.revisions = results;
+      this.revisions = this.collapseRevisions(results);
     } catch (e) {
       if (requestId !== this.fetchRequestId) return;
       console.error('Error fetching revisions', e);
@@ -201,6 +203,49 @@ export class RevisionsWindow extends RapidElement {
         this.isLoading = false;
       }
     }
+  }
+
+  // Lump revisions made in a continuous editing session (within 15 minutes
+  // of each other) onto their most recent member, merging the tag sets so
+  // the summary covers everything that happened in the window.
+  private collapseRevisions(revisions: Revision[]): Revision[] {
+    const result: Revision[] = [];
+    let group: Revision[] = [];
+
+    const flush = () => {
+      if (group.length === 0) return;
+      const head = group[0];
+      const tagSet = new Set<string>();
+      let anyKnown = false;
+      for (const r of group) {
+        if (r.changes) {
+          anyKnown = true;
+          for (const tag of r.changes.tags || []) tagSet.add(tag);
+        }
+      }
+      result.push({
+        ...head,
+        changes: anyKnown ? { tags: Array.from(tagSet) } : null
+      });
+      group = [];
+    };
+
+    for (const rev of revisions) {
+      if (group.length === 0) {
+        group.push(rev);
+        continue;
+      }
+      const headTime = new Date(group[0].created_on).getTime();
+      const revTime = new Date(rev.created_on).getTime();
+      if (headTime - revTime < GROUP_WINDOW_MS) {
+        group.push(rev);
+      } else {
+        flush();
+        group.push(rev);
+      }
+    }
+    flush();
+    return result;
   }
 
   private async handleRevisionClick(revision: Revision) {

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -7,9 +7,14 @@ import { getStore } from '../store/Store';
 import { FlowDefinition } from '../store/flow-definition';
 import { fetchResults } from '../utils';
 import { FLOW_SPEC_VERSION } from '../store/AppState';
-import { RevisionChanges, summarizeChanges } from './revision-summary';
+import {
+  labelsFor,
+  RevisionChanges,
+  summarizeChanges
+} from './revision-summary';
 
 const GROUP_WINDOW_MS = 15 * 60 * 1000;
+const MAX_GROUP_LABELS = 3;
 
 export interface Revision {
   id: number;
@@ -206,11 +211,14 @@ export class RevisionsWindow extends RapidElement {
   }
 
   // Lump revisions made in a continuous editing session (within 15 minutes
-  // of each other) onto their most recent member, merging the tag sets so
-  // the summary covers everything that happened in the window.
+  // of each other, by the same author) onto their most recent member,
+  // merging the tag sets so the summary covers everything that happened in
+  // the window. The merged revision is capped at three distinct displayed
+  // labels — once a fourth would be introduced we break out into a new row.
   private collapseRevisions(revisions: Revision[]): Revision[] {
     const result: Revision[] = [];
     let group: Revision[] = [];
+    let groupLabels = new Set<string>();
 
     const flush = () => {
       if (group.length === 0) return;
@@ -228,20 +236,33 @@ export class RevisionsWindow extends RapidElement {
         changes: anyKnown ? { tags: Array.from(tagSet) } : null
       });
       group = [];
+      groupLabels = new Set();
     };
 
     for (const rev of revisions) {
       if (group.length === 0) {
         group.push(rev);
+        groupLabels = labelsFor(rev.changes);
         continue;
       }
-      const headTime = new Date(group[0].created_on).getTime();
+      const head = group[0];
+      const headTime = new Date(head.created_on).getTime();
       const revTime = new Date(rev.created_on).getTime();
-      if (headTime - revTime < GROUP_WINDOW_MS) {
+      const withinWindow = headTime - revTime < GROUP_WINDOW_MS;
+      const sameAuthor = head.user?.username === rev.user?.username;
+      const prospective = new Set([
+        ...groupLabels,
+        ...labelsFor(rev.changes)
+      ]);
+      const fitsLabelCap = prospective.size <= MAX_GROUP_LABELS;
+
+      if (withinWindow && sameAuthor && fitsLabelCap) {
         group.push(rev);
+        groupLabels = prospective;
       } else {
         flush();
         group.push(rev);
+        groupLabels = labelsFor(rev.changes);
       }
     }
     flush();

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -6,7 +6,14 @@ import { CustomEventType } from '../interfaces';
 import { getStore } from '../store/Store';
 import { FlowDefinition } from '../store/flow-definition';
 import { fetchResults } from '../utils';
-import { FLOW_SPEC_VERSION } from '../store/AppState';
+import { AppState, FLOW_SPEC_VERSION, fromStore, zustand } from '../store/AppState';
+import {
+  RevisionChange,
+  isSignificantChange,
+  summarizeChanges
+} from './revision-summary';
+
+const GROUP_WINDOW_MS = 15 * 60 * 1000;
 
 export interface Revision {
   id: number;
@@ -19,6 +26,7 @@ export interface Revision {
   };
   created_on: string;
   comment?: string;
+  changes?: RevisionChange[] | null;
 }
 
 export class RevisionsWindow extends RapidElement {
@@ -48,6 +56,12 @@ export class RevisionsWindow extends RapidElement {
   @state()
   private isLoading = false;
 
+  @fromStore(zustand, (state: AppState) => state.flowDefinition?.revision ?? 0)
+  private liveRevision!: number;
+
+  @fromStore(zustand, (state: AppState) => state.viewingRevision)
+  private storeViewingRevision!: boolean;
+
   private preRevertState: {
     definition: FlowDefinition;
     dirtyDate: Date | null;
@@ -60,11 +74,18 @@ export class RevisionsWindow extends RapidElement {
 
   protected updated(changes: PropertyValues): void {
     super.updated(changes);
-    if (
+
+    const opening =
       changes.has('hidden') &&
       !this.hidden &&
-      changes.get('hidden') === true
-    ) {
+      changes.get('hidden') === true;
+    const newRevisionWhileOpen =
+      !this.hidden &&
+      changes.has('liveRevision') &&
+      changes.get('liveRevision') !== undefined &&
+      !this.storeViewingRevision;
+
+    if (opening || newRevisionWhileOpen) {
       this.fetchRevisions();
     }
   }
@@ -84,8 +105,8 @@ export class RevisionsWindow extends RapidElement {
         name="revisions"
         header="Revisions"
         icon="revisions"
-        .width=${240}
-        .maxHeight=${400}
+        .width=${340}
+        .maxHeight=${500}
         .top=${120}
         color="rgb(142, 94, 167)"
         .saving=${this.saving}
@@ -99,11 +120,15 @@ export class RevisionsWindow extends RapidElement {
           >
             ${this.isLoading && !this.revisions.length
               ? html`<temba-loading></temba-loading>`
-              : this.revisions.map((rev) => {
+              : this.revisions.map((rev, index) => {
+                  const isCurrent = index === 0;
                   const isSelected = this.viewingRevision?.id === rev.id;
+                  const summary = summarizeChanges(rev.changes);
                   return html`
                     <div
-                      class="revision-item ${isSelected ? 'selected' : ''}"
+                      class="revision-item ${isSelected
+                        ? 'selected'
+                        : ''} ${isCurrent ? 'current' : ''}"
                       style="padding:8px; border-radius:4px; cursor:pointer; background:${isSelected
                         ? '#f0f6ff'
                         : '#f9fafb'}; border:1px solid ${isSelected
@@ -111,36 +136,46 @@ export class RevisionsWindow extends RapidElement {
                         : '#e5e7eb'}; transition: all 0.2s ease;"
                       @click=${() => this.handleRevisionClick(rev)}
                     >
-                      <div
-                        style="display:flex; justify-content:space-between; align-items:center;"
-                      >
-                        <div
-                          class="revision-header"
-                          style="margin-bottom: 2px;"
-                        >
-                          <div
-                            style="font-weight:600; font-size:13px; color:#111827;"
+                      ${summary
+                        ? html`<div
+                            class="revision-summary"
+                            style="font-size:13px; color:#111827; line-height:1.3;"
                           >
-                            <temba-date
-                              value=${rev.created_on}
-                              display="duration"
-                            ></temba-date>
-                          </div>
-                          <div style="font-size:11px; color:#6b7280;">
-                            ${rev.user.name || rev.user.username}
-                          </div>
+                            ${summary}
+                          </div>`
+                        : ''}
+                      <div
+                        class="revision-meta"
+                        style="display:flex; justify-content:space-between; align-items:center; gap:8px; min-height:20px; font-size:11px; color:#6b7280; margin-top:${summary
+                          ? '2px'
+                          : '0'};"
+                      >
+                        <div style="flex:1; min-width:0;">
+                          <temba-date
+                            value=${rev.created_on}
+                            display="duration"
+                          ></temba-date>
+                          · ${rev.user.name || rev.user.username}
                         </div>
-                        ${isSelected
-                          ? html`<button
-                              class="revert-button"
-                              @click=${(e: Event) => {
-                                e.stopPropagation();
-                                this.handleRevertClick();
-                              }}
+                        ${isCurrent
+                          ? html`<div
+                              class="current-label"
+                              style="font-size:10px; font-weight:600; text-transform:uppercase; color:#6b7280; background:#e5e7eb; padding:2px 6px; border-radius:10px; letter-spacing:0.5px; flex-shrink:0;"
                             >
-                              Revert
-                            </button>`
-                          : html``}
+                              Current
+                            </div>`
+                          : isSelected
+                            ? html`<button
+                                class="revert-button"
+                                style="font-size:10px; font-weight:600; text-transform:uppercase; color:#1e3a8a; background:#a4cafe; padding:2px 6px; border-radius:10px; letter-spacing:0.5px; border:none; cursor:pointer; flex-shrink:0;"
+                                @click=${(e: Event) => {
+                                  e.stopPropagation();
+                                  this.handleRevertClick();
+                                }}
+                              >
+                                Revert
+                              </button>`
+                            : html``}
                       </div>
 
                       ${rev.comment
@@ -167,12 +202,50 @@ export class RevisionsWindow extends RapidElement {
       const results = await fetchResults(
         `/flow/revisions/${this.flow}/?version=${FLOW_SPEC_VERSION}`
       );
-      this.revisions = results.slice(1);
+      this.revisions = this.collapseRevisions(results);
     } catch (e) {
       console.error('Error fetching revisions', e);
     } finally {
       this.isLoading = false;
     }
+  }
+
+  private collapseRevisions(revisions: Revision[]): Revision[] {
+    const result: Revision[] = [];
+    let group: Revision[] = [];
+
+    const flush = () => {
+      if (group.length === 0) return;
+      const head = group[0];
+      const allChanges: RevisionChange[] = [];
+      for (const r of group) {
+        if (r.changes) allChanges.push(...r.changes);
+      }
+      result.push({ ...head, changes: allChanges });
+      group = [];
+    };
+
+    for (const rev of revisions) {
+      if (isSignificantChange(rev.changes)) {
+        flush();
+        result.push(rev);
+        continue;
+      }
+      if (group.length === 0) {
+        group.push(rev);
+        continue;
+      }
+      const headTime = new Date(group[0].created_on).getTime();
+      const revTime = new Date(rev.created_on).getTime();
+      if (headTime - revTime < GROUP_WINDOW_MS) {
+        group.push(rev);
+      } else {
+        flush();
+        group.push(rev);
+      }
+    }
+    flush();
+    return result;
   }
 
   private async handleRevisionClick(revision: Revision) {

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -6,7 +6,7 @@ import { CustomEventType } from '../interfaces';
 import { getStore } from '../store/Store';
 import { FlowDefinition } from '../store/flow-definition';
 import { fetchResults } from '../utils';
-import { AppState, FLOW_SPEC_VERSION, zustand } from '../store/AppState';
+import { FLOW_SPEC_VERSION } from '../store/AppState';
 import {
   RevisionChange,
   isSignificantChange,
@@ -62,51 +62,25 @@ export class RevisionsWindow extends RapidElement {
   } | null = null;
   private browseLanguageCode: string | null = null;
   private fetchRequestId = 0;
-  private revisionSubscription: (() => void) | null = null;
 
   public get isViewingRevision(): boolean {
     return this.viewingRevision !== null;
   }
 
-  public disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this.unwatchRevisions();
+  public refresh(): void {
+    if (!this.hidden) {
+      this.fetchRevisions();
+    }
   }
 
   protected updated(changes: PropertyValues): void {
     super.updated(changes);
-
     if (
       changes.has('hidden') &&
       !this.hidden &&
       changes.get('hidden') === true
     ) {
       this.fetchRevisions();
-      this.watchRevisions();
-    } else if (changes.has('hidden') && this.hidden) {
-      this.unwatchRevisions();
-    }
-  }
-
-  private watchRevisions(): void {
-    if (this.revisionSubscription) return;
-    this.revisionSubscription = zustand.subscribe(
-      (state: AppState) => state.flowDefinition?.revision ?? 0,
-      (current: number, previous: number) => {
-        if (
-          current > previous &&
-          !zustand.getState().viewingRevision
-        ) {
-          this.fetchRevisions();
-        }
-      }
-    );
-  }
-
-  private unwatchRevisions(): void {
-    if (this.revisionSubscription) {
-      this.revisionSubscription();
-      this.revisionSubscription = null;
     }
   }
 

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -6,7 +6,7 @@ import { CustomEventType } from '../interfaces';
 import { getStore } from '../store/Store';
 import { FlowDefinition } from '../store/flow-definition';
 import { fetchResults } from '../utils';
-import { AppState, FLOW_SPEC_VERSION, fromStore, zustand } from '../store/AppState';
+import { AppState, FLOW_SPEC_VERSION, zustand } from '../store/AppState';
 import {
   RevisionChange,
   isSignificantChange,
@@ -56,40 +56,57 @@ export class RevisionsWindow extends RapidElement {
   @state()
   private isLoading = false;
 
-  @fromStore(zustand, (state: AppState) => state.flowDefinition?.revision ?? 0)
-  private liveRevision!: number;
-
-  @fromStore(zustand, (state: AppState) => state.viewingRevision)
-  private storeViewingRevision!: boolean;
-
   private preRevertState: {
     definition: FlowDefinition;
     dirtyDate: Date | null;
   } | null = null;
   private browseLanguageCode: string | null = null;
   private fetchRequestId = 0;
+  private revisionSubscription: (() => void) | null = null;
 
   public get isViewingRevision(): boolean {
     return this.viewingRevision !== null;
   }
 
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.unwatchRevisions();
+  }
+
   protected updated(changes: PropertyValues): void {
     super.updated(changes);
 
-    const opening =
+    if (
       changes.has('hidden') &&
       !this.hidden &&
-      changes.get('hidden') === true;
-    const previousRevision = changes.get('liveRevision') as number | undefined;
-    const newRevisionWhileOpen =
-      !this.hidden &&
-      changes.has('liveRevision') &&
-      !this.storeViewingRevision &&
-      previousRevision !== undefined &&
-      this.liveRevision > previousRevision;
-
-    if (opening || newRevisionWhileOpen) {
+      changes.get('hidden') === true
+    ) {
       this.fetchRevisions();
+      this.watchRevisions();
+    } else if (changes.has('hidden') && this.hidden) {
+      this.unwatchRevisions();
+    }
+  }
+
+  private watchRevisions(): void {
+    if (this.revisionSubscription) return;
+    this.revisionSubscription = zustand.subscribe(
+      (state: AppState) => state.flowDefinition?.revision ?? 0,
+      (current: number, previous: number) => {
+        if (
+          current > previous &&
+          !zustand.getState().viewingRevision
+        ) {
+          this.fetchRevisions();
+        }
+      }
+    );
+  }
+
+  private unwatchRevisions(): void {
+    if (this.revisionSubscription) {
+      this.revisionSubscription();
+      this.revisionSubscription = null;
     }
   }
 

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -19,10 +19,11 @@ const MAX_GROUP_LABELS = 3;
 export interface Revision {
   id: number;
   user: {
-    id: number;
-    username: string;
-    first_name: string;
-    last_name: string;
+    id?: number;
+    email?: string;
+    username?: string;
+    first_name?: string;
+    last_name?: string;
     name?: string;
   };
   created_on: string;
@@ -255,10 +256,12 @@ export class RevisionsWindow extends RapidElement {
       const headTime = new Date(head.created_on).getTime();
       const revTime = new Date(rev.created_on).getTime();
       const withinWindow = headTime - revTime < GROUP_WINDOW_MS;
-      // Treat missing usernames as "different" rather than the same author —
-      // we never want to silently merge attribution across an unknown gap.
-      const sameAuthor =
-        !!head.user?.username && head.user.username === rev.user?.username;
+      // Compare on whichever identifier the server provides — real data
+      // arrives with `email`, while test fixtures use `username`. Falling
+      // back through the chain keeps both shapes working.
+      const headId = head.user?.email ?? head.user?.username;
+      const revId = rev.user?.email ?? rev.user?.username;
+      const sameAuthor = headId === revId;
       const prospective = new Set([
         ...groupLabels,
         ...labelsFor(rev.changes)

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -216,6 +216,12 @@ export class RevisionsWindow extends RapidElement {
   // the window. The merged revision is capped at three distinct displayed
   // labels — once a fourth would be introduced we break out into a new row.
   private collapseRevisions(revisions: Revision[]): Revision[] {
+    // The API returns newest-first today; sort defensively so the head/window
+    // logic stays correct if that ever changes.
+    const sorted = [...revisions].sort(
+      (a, b) =>
+        new Date(b.created_on).getTime() - new Date(a.created_on).getTime()
+    );
     const result: Revision[] = [];
     let group: Revision[] = [];
     let groupLabels = new Set<string>();
@@ -239,7 +245,7 @@ export class RevisionsWindow extends RapidElement {
       groupLabels = new Set();
     };
 
-    for (const rev of revisions) {
+    for (const rev of sorted) {
       if (group.length === 0) {
         group.push(rev);
         groupLabels = labelsFor(rev.changes);
@@ -249,7 +255,10 @@ export class RevisionsWindow extends RapidElement {
       const headTime = new Date(head.created_on).getTime();
       const revTime = new Date(rev.created_on).getTime();
       const withinWindow = headTime - revTime < GROUP_WINDOW_MS;
-      const sameAuthor = head.user?.username === rev.user?.username;
+      // Treat missing usernames as "different" rather than the same author —
+      // we never want to silently merge attribution across an unknown gap.
+      const sameAuthor =
+        !!head.user?.username && head.user.username === rev.user?.username;
       const prospective = new Set([
         ...groupLabels,
         ...labelsFor(rev.changes)

--- a/src/flow/revision-summary.ts
+++ b/src/flow/revision-summary.ts
@@ -26,7 +26,7 @@ export function summarizeChanges(
 ): string {
   if (!changes) return '';
   const tags = changes.tags || [];
-  if (tags.length === 0) return 'Unchanged';
+  if (tags.length === 0) return '';
 
   const orders = new Map<string, number>();
   for (const tag of tags) {

--- a/src/flow/revision-summary.ts
+++ b/src/flow/revision-summary.ts
@@ -8,7 +8,7 @@ const TAG_LABELS: Record<string, { label: string; order: number }> = {
   routing: { label: 'routing', order: 2 },
   actions: { label: 'actions', order: 3 },
   stickies: { label: 'stickies', order: 5 },
-  positions: { label: 'layout', order: 6 }
+  layout: { label: 'layout', order: 6 }
 };
 
 function tagToLabel(tag: string): { label: string; order: number } | null {

--- a/src/flow/revision-summary.ts
+++ b/src/flow/revision-summary.ts
@@ -19,8 +19,6 @@ function tagToLabel(tag: string): { label: string; order: number } | null {
   return null;
 }
 
-const MAX_LABELS = 2;
-
 export function summarizeChanges(
   changes: RevisionChanges | null | undefined
 ): string {
@@ -41,5 +39,11 @@ export function summarizeChanges(
     .sort((a, b) => a[1] - b[1])
     .map(([label]) => label);
 
-  return `Changed ${labels.slice(0, MAX_LABELS).join(' and ')}`;
+  return `Changed ${joinNaturally(labels)}`;
+}
+
+function joinNaturally(parts: string[]): string {
+  if (parts.length <= 1) return parts.join('');
+  if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
+  return `${parts.slice(0, -1).join(', ')}, and ${parts[parts.length - 1]}`;
 }

--- a/src/flow/revision-summary.ts
+++ b/src/flow/revision-summary.ts
@@ -1,0 +1,252 @@
+export interface RevisionChange {
+  type: string;
+  uuid?: string;
+  node?: string;
+  subtype?: string;
+  field?: string;
+  lang?: string;
+}
+
+interface Phrase {
+  noun: string;
+  plural: string;
+  verb: string;
+  order: number;
+  noCount?: boolean;
+}
+
+const CATEGORY_ORDER = [
+  'metadata',
+  'structure',
+  'content',
+  'translations',
+  'notes',
+  'layout'
+];
+
+function categoryFor(change: RevisionChange): string | null {
+  switch (change.type) {
+    case 'metadata_changed':
+    case 'base_language_changed':
+      return 'metadata';
+    case 'node_added':
+    case 'node_removed':
+    case 'action_added':
+    case 'action_removed':
+    case 'action_reordered':
+    case 'router_updated':
+    case 'connection_changed':
+      return 'structure';
+    case 'action_updated':
+      return 'content';
+    case 'translation_added':
+    case 'translation_updated':
+    case 'translation_removed':
+      return 'translations';
+    case 'sticky_added':
+    case 'sticky_removed':
+    case 'sticky_updated':
+    case 'sticky_moved':
+      return 'notes';
+    case 'node_moved':
+      return 'layout';
+    default:
+      return null;
+  }
+}
+
+const ACTION_LABELS: Record<string, { noun: string; plural: string }> = {
+  send_msg: { noun: 'message', plural: 'messages' },
+  send_email: { noun: 'email', plural: 'emails' },
+  send_broadcast: { noun: 'broadcast', plural: 'broadcasts' },
+  set_contact_field: { noun: 'contact field', plural: 'contact fields' },
+  set_contact_name: { noun: 'contact name', plural: 'contact name changes' },
+  set_contact_language: {
+    noun: 'contact language',
+    plural: 'contact language changes'
+  },
+  set_contact_status: {
+    noun: 'contact status',
+    plural: 'contact status changes'
+  },
+  set_contact_channel: { noun: 'contact channel', plural: 'contact channels' },
+  add_contact_groups: { noun: 'group', plural: 'groups' },
+  remove_contact_groups: { noun: 'group', plural: 'groups' },
+  add_contact_urn: { noun: 'URN', plural: 'URNs' },
+  set_run_result: { noun: 'result', plural: 'results' },
+  call_webhook: { noun: 'webhook', plural: 'webhooks' },
+  call_classifier: { noun: 'classifier', plural: 'classifiers' },
+  call_resthook: { noun: 'resthook', plural: 'resthooks' },
+  call_llm: { noun: 'AI prompt', plural: 'AI prompts' },
+  enter_flow: { noun: 'subflow', plural: 'subflows' },
+  start_session: { noun: 'subflow', plural: 'subflows' },
+  transfer_airtime: { noun: 'airtime transfer', plural: 'airtime transfers' },
+  play_audio: { noun: 'audio', plural: 'audio clips' },
+  say_msg: { noun: 'voice message', plural: 'voice messages' },
+  open_ticket: { noun: 'ticket', plural: 'tickets' },
+  add_input_labels: { noun: 'label', plural: 'labels' },
+  remove_input_labels: { noun: 'label', plural: 'labels' },
+  request_optin: { noun: 'opt-in', plural: 'opt-ins' },
+  send_optin_msg: { noun: 'opt-in message', plural: 'opt-in messages' }
+};
+
+const METADATA_LABELS: Record<string, { noun: string; plural: string }> = {
+  name: { noun: 'name', plural: 'name' },
+  type: { noun: 'flow type', plural: 'flow type' },
+  expire_after_minutes: { noun: 'expiration', plural: 'expiration' }
+};
+
+function actionLabel(subtype?: string): { noun: string; plural: string } {
+  if (subtype && ACTION_LABELS[subtype]) {
+    return ACTION_LABELS[subtype];
+  }
+  return { noun: 'action', plural: 'actions' };
+}
+
+function changeToPhrase(change: RevisionChange): Phrase | null {
+  switch (change.type) {
+    case 'metadata_changed': {
+      const label = METADATA_LABELS[change.field || ''] || {
+        noun: change.field || 'metadata',
+        plural: change.field || 'metadata'
+      };
+      return { ...label, verb: 'changed', order: 0 };
+    }
+    case 'base_language_changed':
+      return {
+        noun: 'base language',
+        plural: 'base language',
+        verb: 'changed',
+        order: 1
+      };
+    case 'node_added':
+      return { noun: 'node', plural: 'nodes', verb: 'added', order: 2 };
+    case 'node_removed':
+      return { noun: 'node', plural: 'nodes', verb: 'removed', order: 3 };
+    case 'action_added': {
+      const label = actionLabel(change.subtype);
+      return { ...label, verb: 'added', order: 4 };
+    }
+    case 'action_updated': {
+      const label = actionLabel(change.subtype);
+      return { ...label, verb: 'updated', order: 5 };
+    }
+    case 'action_removed': {
+      const label = actionLabel(change.subtype);
+      return { ...label, verb: 'removed', order: 6 };
+    }
+    case 'action_reordered':
+      return {
+        noun: 'actions',
+        plural: 'actions',
+        verb: 'reordered',
+        order: 7,
+        noCount: true
+      };
+    case 'router_updated':
+      return { noun: 'split', plural: 'splits', verb: 'updated', order: 8 };
+    case 'connection_changed':
+      return {
+        noun: 'connection',
+        plural: 'connections',
+        verb: 'changed',
+        order: 9
+      };
+    case 'translation_added':
+      return {
+        noun: 'translation',
+        plural: 'translations',
+        verb: 'added',
+        order: 10
+      };
+    case 'translation_updated':
+      return {
+        noun: 'translation',
+        plural: 'translations',
+        verb: 'updated',
+        order: 11
+      };
+    case 'translation_removed':
+      return {
+        noun: 'translation',
+        plural: 'translations',
+        verb: 'removed',
+        order: 12
+      };
+    case 'sticky_added':
+      return { noun: 'sticky', plural: 'stickies', verb: 'added', order: 13 };
+    case 'sticky_updated':
+      return { noun: 'sticky', plural: 'stickies', verb: 'updated', order: 14 };
+    case 'sticky_removed':
+      return { noun: 'sticky', plural: 'stickies', verb: 'removed', order: 15 };
+    case 'sticky_moved':
+      return { noun: 'sticky', plural: 'stickies', verb: 'moved', order: 16 };
+    case 'node_moved':
+      return { noun: 'node', plural: 'nodes', verb: 'moved', order: 17 };
+    default:
+      return null;
+  }
+}
+
+const MAX_PHRASES = 2;
+
+function buildPhraseGroups(
+  changes: RevisionChange[] | null | undefined
+): Map<string, { phrase: Phrase; count: number }> {
+  const groups = new Map<string, { phrase: Phrase; count: number }>();
+  for (const change of changes ?? []) {
+    const phrase = changeToPhrase(change);
+    if (!phrase) continue;
+    const key = `${phrase.order}:${phrase.noun}:${phrase.verb}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.count++;
+    } else {
+      groups.set(key, { phrase, count: 1 });
+    }
+  }
+  return groups;
+}
+
+export function isSignificantChange(
+  changes: RevisionChange[] | null | undefined
+): boolean {
+  return buildPhraseGroups(changes).size > MAX_PHRASES;
+}
+
+export function summarizeChanges(
+  changes: RevisionChange[] | null | undefined
+): string {
+  if (!changes || changes.length === 0) return '';
+
+  const groups = buildPhraseGroups(changes);
+  if (groups.size === 0) return '';
+
+  const sorted = Array.from(groups.values()).sort(
+    (a, b) => a.phrase.order - b.phrase.order
+  );
+
+  const parts = sorted.map(({ phrase, count }) =>
+    phrase.noCount || count === 1
+      ? `${phrase.verb} ${phrase.noun}`
+      : `${phrase.verb} ${count} ${phrase.plural}`
+  );
+
+  if (parts.length <= MAX_PHRASES) {
+    return capitalize(parts.join(' and '));
+  }
+
+  const presentCategories = new Set<string>();
+  for (const change of changes) {
+    const cat = categoryFor(change);
+    if (cat) presentCategories.add(cat);
+  }
+  const categories = CATEGORY_ORDER.filter((c) => presentCategories.has(c));
+  const visibleCategories = categories.slice(0, MAX_PHRASES);
+
+  return `Significantly changed ${visibleCategories.join(' and ')}`;
+}
+
+function capitalize(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}

--- a/src/flow/revision-summary.ts
+++ b/src/flow/revision-summary.ts
@@ -12,7 +12,9 @@ const TAG_LABELS: Record<string, { label: string; order: number }> = {
 };
 
 function tagToLabel(tag: string): { label: string; order: number } | null {
-  if (TAG_LABELS[tag]) return TAG_LABELS[tag];
+  if (Object.prototype.hasOwnProperty.call(TAG_LABELS, tag)) {
+    return TAG_LABELS[tag];
+  }
   if (tag.startsWith('localization:')) {
     return { label: 'translations', order: 4 };
   }

--- a/src/flow/revision-summary.ts
+++ b/src/flow/revision-summary.ts
@@ -90,10 +90,10 @@ const ACTION_LABELS: Record<string, { noun: string; plural: string }> = {
   send_optin_msg: { noun: 'opt-in message', plural: 'opt-in messages' }
 };
 
-const METADATA_LABELS: Record<string, { noun: string; plural: string }> = {
-  name: { noun: 'name', plural: 'name' },
-  type: { noun: 'flow type', plural: 'flow type' },
-  expire_after_minutes: { noun: 'expiration', plural: 'expiration' }
+const METADATA_LABELS: Record<string, { noun: string }> = {
+  name: { noun: 'name' },
+  type: { noun: 'flow type' },
+  expire_after_minutes: { noun: 'expiration' }
 };
 
 function actionLabel(subtype?: string): { noun: string; plural: string } {
@@ -107,17 +107,23 @@ function changeToPhrase(change: RevisionChange): Phrase | null {
   switch (change.type) {
     case 'metadata_changed': {
       const label = METADATA_LABELS[change.field || ''] || {
-        noun: change.field || 'metadata',
-        plural: change.field || 'metadata'
+        noun: change.field || 'metadata'
       };
-      return { ...label, verb: 'changed', order: 0 };
+      return {
+        noun: label.noun,
+        plural: label.noun,
+        verb: 'changed',
+        order: 0,
+        noCount: true
+      };
     }
     case 'base_language_changed':
       return {
         noun: 'base language',
         plural: 'base language',
         verb: 'changed',
-        order: 1
+        order: 1,
+        noCount: true
       };
     case 'node_added':
       return { noun: 'node', plural: 'nodes', verb: 'added', order: 2 };

--- a/src/flow/revision-summary.ts
+++ b/src/flow/revision-summary.ts
@@ -1,258 +1,49 @@
-export interface RevisionChange {
-  type: string;
-  uuid?: string;
-  node?: string;
-  subtype?: string;
-  field?: string;
-  lang?: string;
+export interface RevisionChanges {
+  tags: string[];
 }
 
-interface Phrase {
-  noun: string;
-  plural: string;
-  verb: string;
-  order: number;
-  noCount?: boolean;
-}
-
-const CATEGORY_ORDER = [
-  'metadata',
-  'structure',
-  'content',
-  'translations',
-  'notes',
-  'layout'
-];
-
-function categoryFor(change: RevisionChange): string | null {
-  switch (change.type) {
-    case 'metadata_changed':
-    case 'base_language_changed':
-      return 'metadata';
-    case 'node_added':
-    case 'node_removed':
-    case 'action_added':
-    case 'action_removed':
-    case 'action_reordered':
-    case 'router_updated':
-    case 'connection_changed':
-      return 'structure';
-    case 'action_updated':
-      return 'content';
-    case 'translation_added':
-    case 'translation_updated':
-    case 'translation_removed':
-      return 'translations';
-    case 'sticky_added':
-    case 'sticky_removed':
-    case 'sticky_updated':
-    case 'sticky_moved':
-      return 'notes';
-    case 'node_moved':
-      return 'layout';
-    default:
-      return null;
-  }
-}
-
-const ACTION_LABELS: Record<string, { noun: string; plural: string }> = {
-  send_msg: { noun: 'message', plural: 'messages' },
-  send_email: { noun: 'email', plural: 'emails' },
-  send_broadcast: { noun: 'broadcast', plural: 'broadcasts' },
-  set_contact_field: { noun: 'contact field', plural: 'contact fields' },
-  set_contact_name: { noun: 'contact name', plural: 'contact name changes' },
-  set_contact_language: {
-    noun: 'contact language',
-    plural: 'contact language changes'
-  },
-  set_contact_status: {
-    noun: 'contact status',
-    plural: 'contact status changes'
-  },
-  set_contact_channel: { noun: 'contact channel', plural: 'contact channels' },
-  add_contact_groups: { noun: 'group', plural: 'groups' },
-  remove_contact_groups: { noun: 'group', plural: 'groups' },
-  add_contact_urn: { noun: 'URN', plural: 'URNs' },
-  set_run_result: { noun: 'result', plural: 'results' },
-  call_webhook: { noun: 'webhook', plural: 'webhooks' },
-  call_classifier: { noun: 'classifier', plural: 'classifiers' },
-  call_resthook: { noun: 'resthook', plural: 'resthooks' },
-  call_llm: { noun: 'AI prompt', plural: 'AI prompts' },
-  enter_flow: { noun: 'subflow', plural: 'subflows' },
-  start_session: { noun: 'subflow', plural: 'subflows' },
-  transfer_airtime: { noun: 'airtime transfer', plural: 'airtime transfers' },
-  play_audio: { noun: 'audio', plural: 'audio clips' },
-  say_msg: { noun: 'voice message', plural: 'voice messages' },
-  open_ticket: { noun: 'ticket', plural: 'tickets' },
-  add_input_labels: { noun: 'label', plural: 'labels' },
-  remove_input_labels: { noun: 'label', plural: 'labels' },
-  request_optin: { noun: 'opt-in', plural: 'opt-ins' },
-  send_optin_msg: { noun: 'opt-in message', plural: 'opt-in messages' }
+const TAG_LABELS: Record<string, { label: string; order: number }> = {
+  metadata: { label: 'metadata', order: 0 },
+  nodes: { label: 'nodes', order: 1 },
+  routing: { label: 'routing', order: 2 },
+  actions: { label: 'actions', order: 3 },
+  stickies: { label: 'stickies', order: 5 },
+  positions: { label: 'positions', order: 6 }
 };
 
-const METADATA_LABELS: Record<string, { noun: string }> = {
-  name: { noun: 'name' },
-  type: { noun: 'flow type' },
-  expire_after_minutes: { noun: 'expiration' }
-};
-
-function actionLabel(subtype?: string): { noun: string; plural: string } {
-  if (subtype && ACTION_LABELS[subtype]) {
-    return ACTION_LABELS[subtype];
+function tagToLabel(tag: string): { label: string; order: number } | null {
+  if (TAG_LABELS[tag]) return TAG_LABELS[tag];
+  if (tag.startsWith('localization:')) {
+    return { label: 'translations', order: 4 };
   }
-  return { noun: 'action', plural: 'actions' };
+  return null;
 }
 
-function changeToPhrase(change: RevisionChange): Phrase | null {
-  switch (change.type) {
-    case 'metadata_changed': {
-      const label = METADATA_LABELS[change.field || ''] || {
-        noun: change.field || 'metadata'
-      };
-      return {
-        noun: label.noun,
-        plural: label.noun,
-        verb: 'changed',
-        order: 0,
-        noCount: true
-      };
-    }
-    case 'base_language_changed':
-      return {
-        noun: 'base language',
-        plural: 'base language',
-        verb: 'changed',
-        order: 1,
-        noCount: true
-      };
-    case 'node_added':
-      return { noun: 'node', plural: 'nodes', verb: 'added', order: 2 };
-    case 'node_removed':
-      return { noun: 'node', plural: 'nodes', verb: 'removed', order: 3 };
-    case 'action_added': {
-      const label = actionLabel(change.subtype);
-      return { ...label, verb: 'added', order: 4 };
-    }
-    case 'action_updated': {
-      const label = actionLabel(change.subtype);
-      return { ...label, verb: 'updated', order: 5 };
-    }
-    case 'action_removed': {
-      const label = actionLabel(change.subtype);
-      return { ...label, verb: 'removed', order: 6 };
-    }
-    case 'action_reordered':
-      return {
-        noun: 'actions',
-        plural: 'actions',
-        verb: 'reordered',
-        order: 7,
-        noCount: true
-      };
-    case 'router_updated':
-      return { noun: 'split', plural: 'splits', verb: 'updated', order: 8 };
-    case 'connection_changed':
-      return {
-        noun: 'connection',
-        plural: 'connections',
-        verb: 'changed',
-        order: 9
-      };
-    case 'translation_added':
-      return {
-        noun: 'translation',
-        plural: 'translations',
-        verb: 'added',
-        order: 10
-      };
-    case 'translation_updated':
-      return {
-        noun: 'translation',
-        plural: 'translations',
-        verb: 'updated',
-        order: 11
-      };
-    case 'translation_removed':
-      return {
-        noun: 'translation',
-        plural: 'translations',
-        verb: 'removed',
-        order: 12
-      };
-    case 'sticky_added':
-      return { noun: 'sticky', plural: 'stickies', verb: 'added', order: 13 };
-    case 'sticky_updated':
-      return { noun: 'sticky', plural: 'stickies', verb: 'updated', order: 14 };
-    case 'sticky_removed':
-      return { noun: 'sticky', plural: 'stickies', verb: 'removed', order: 15 };
-    case 'sticky_moved':
-      return { noun: 'sticky', plural: 'stickies', verb: 'moved', order: 16 };
-    case 'node_moved':
-      return { noun: 'node', plural: 'nodes', verb: 'moved', order: 17 };
-    default:
-      return null;
-  }
-}
-
-const MAX_PHRASES = 2;
-
-function buildPhraseGroups(
-  changes: RevisionChange[] | null | undefined
-): Map<string, { phrase: Phrase; count: number }> {
-  const groups = new Map<string, { phrase: Phrase; count: number }>();
-  for (const change of changes ?? []) {
-    const phrase = changeToPhrase(change);
-    if (!phrase) continue;
-    const key = `${phrase.order}:${phrase.noun}:${phrase.verb}`;
-    const existing = groups.get(key);
-    if (existing) {
-      existing.count++;
-    } else {
-      groups.set(key, { phrase, count: 1 });
-    }
-  }
-  return groups;
-}
-
-export function isSignificantChange(
-  changes: RevisionChange[] | null | undefined
-): boolean {
-  return buildPhraseGroups(changes).size > MAX_PHRASES;
-}
+const MAX_LABELS = 2;
 
 export function summarizeChanges(
-  changes: RevisionChange[] | null | undefined
+  changes: RevisionChanges | null | undefined
 ): string {
-  if (!changes || changes.length === 0) return '';
+  if (!changes) return '';
+  const tags = changes.tags || [];
+  if (tags.length === 0) return 'Unchanged';
 
-  const groups = buildPhraseGroups(changes);
-  if (groups.size === 0) return '';
+  const orders = new Map<string, number>();
+  for (const tag of tags) {
+    const entry = tagToLabel(tag);
+    if (entry && !orders.has(entry.label)) {
+      orders.set(entry.label, entry.order);
+    }
+  }
+  if (orders.size === 0) return '';
 
-  const sorted = Array.from(groups.values()).sort(
-    (a, b) => a.phrase.order - b.phrase.order
-  );
+  const labels = Array.from(orders.entries())
+    .sort((a, b) => a[1] - b[1])
+    .map(([label]) => label);
 
-  const parts = sorted.map(({ phrase, count }) =>
-    phrase.noCount || count === 1
-      ? `${phrase.verb} ${phrase.noun}`
-      : `${phrase.verb} ${count} ${phrase.plural}`
-  );
-
-  if (parts.length <= MAX_PHRASES) {
-    return capitalize(parts.join(' and '));
+  if (labels.length <= MAX_LABELS) {
+    return `Changed ${labels.join(' and ')}`;
   }
 
-  const presentCategories = new Set<string>();
-  for (const change of changes) {
-    const cat = categoryFor(change);
-    if (cat) presentCategories.add(cat);
-  }
-  const categories = CATEGORY_ORDER.filter((c) => presentCategories.has(c));
-  const visibleCategories = categories.slice(0, MAX_PHRASES);
-
-  return `Significantly changed ${visibleCategories.join(' and ')}`;
-}
-
-function capitalize(text: string): string {
-  return text.charAt(0).toUpperCase() + text.slice(1);
+  return `Significantly changed ${labels.slice(0, MAX_LABELS).join(' and ')}`;
 }

--- a/src/flow/revision-summary.ts
+++ b/src/flow/revision-summary.ts
@@ -8,7 +8,7 @@ const TAG_LABELS: Record<string, { label: string; order: number }> = {
   routing: { label: 'routing', order: 2 },
   actions: { label: 'actions', order: 3 },
   stickies: { label: 'stickies', order: 5 },
-  positions: { label: 'positions', order: 6 }
+  positions: { label: 'layout', order: 6 }
 };
 
 function tagToLabel(tag: string): { label: string; order: number } | null {

--- a/src/flow/revision-summary.ts
+++ b/src/flow/revision-summary.ts
@@ -41,9 +41,5 @@ export function summarizeChanges(
     .sort((a, b) => a[1] - b[1])
     .map(([label]) => label);
 
-  if (labels.length <= MAX_LABELS) {
-    return `Changed ${labels.join(' and ')}`;
-  }
-
-  return `Significantly changed ${labels.slice(0, MAX_LABELS).join(' and ')}`;
+  return `Changed ${labels.slice(0, MAX_LABELS).join(' and ')}`;
 }

--- a/src/flow/revision-summary.ts
+++ b/src/flow/revision-summary.ts
@@ -19,6 +19,17 @@ function tagToLabel(tag: string): { label: string; order: number } | null {
   return null;
 }
 
+export function labelsFor(
+  changes: RevisionChanges | null | undefined
+): Set<string> {
+  const result = new Set<string>();
+  for (const tag of changes?.tags || []) {
+    const entry = tagToLabel(tag);
+    if (entry) result.add(entry.label);
+  }
+  return result;
+}
+
 export function summarizeChanges(
   changes: RevisionChanges | null | undefined
 ): string {

--- a/test/revision-summary.test.ts
+++ b/test/revision-summary.test.ts
@@ -16,13 +16,13 @@ describe('summarizeChanges', () => {
   });
 
   it('joins two tags with "and"', () => {
-    expect(summarizeChanges({ tags: ['actions', 'positions'] })).to.equal(
+    expect(summarizeChanges({ tags: ['actions', 'layout'] })).to.equal(
       'Changed actions and layout'
     );
   });
 
   it('orders tags by category priority regardless of input order', () => {
-    expect(summarizeChanges({ tags: ['positions', 'metadata'] })).to.equal(
+    expect(summarizeChanges({ tags: ['layout', 'metadata'] })).to.equal(
       'Changed metadata and layout'
     );
     expect(
@@ -32,11 +32,11 @@ describe('summarizeChanges', () => {
 
   it('lists all tags with an Oxford comma when there are 3+', () => {
     expect(
-      summarizeChanges({ tags: ['metadata', 'actions', 'positions'] })
+      summarizeChanges({ tags: ['metadata', 'actions', 'layout'] })
     ).to.equal('Changed metadata, actions, and layout');
     expect(
       summarizeChanges({
-        tags: ['positions', 'stickies', 'metadata', 'actions', 'nodes']
+        tags: ['layout', 'stickies', 'metadata', 'actions', 'nodes']
       })
     ).to.equal('Changed metadata, nodes, actions, stickies, and layout');
   });

--- a/test/revision-summary.test.ts
+++ b/test/revision-summary.test.ts
@@ -124,6 +124,15 @@ describe('summarizeChanges', () => {
     ).to.equal('Significantly changed metadata and structure');
   });
 
+  it('does not pluralize repeated metadata changes for the same field', () => {
+    expect(
+      summarizeChanges([
+        { type: 'metadata_changed', field: 'name' },
+        { type: 'metadata_changed', field: 'name' }
+      ])
+    ).to.equal('Changed name');
+  });
+
   it('skips unknown change types', () => {
     expect(
       summarizeChanges([

--- a/test/revision-summary.test.ts
+++ b/test/revision-summary.test.ts
@@ -1,0 +1,162 @@
+import { expect } from '@open-wc/testing';
+import {
+  isSignificantChange,
+  summarizeChanges
+} from '../src/flow/revision-summary';
+
+describe('summarizeChanges', () => {
+  it('returns empty string for null/empty changes', () => {
+    expect(summarizeChanges(null)).to.equal('');
+    expect(summarizeChanges(undefined)).to.equal('');
+    expect(summarizeChanges([])).to.equal('');
+  });
+
+  it('uses singular noun without count when there is exactly one change', () => {
+    expect(
+      summarizeChanges([
+        { type: 'action_updated', node: 'n1', uuid: 'a1', subtype: 'send_msg' }
+      ])
+    ).to.equal('Updated message');
+  });
+
+  it('collapses same-subtype actions into a count + plural', () => {
+    expect(
+      summarizeChanges([
+        { type: 'action_updated', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
+        { type: 'action_updated', node: 'n2', uuid: 'a2', subtype: 'send_msg' }
+      ])
+    ).to.equal('Updated 2 messages');
+  });
+
+  it('does not collapse different verbs for the same subtype', () => {
+    expect(
+      summarizeChanges([
+        { type: 'action_added', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
+        { type: 'action_updated', node: 'n2', uuid: 'a2', subtype: 'send_msg' }
+      ])
+    ).to.equal('Added message and updated message');
+  });
+
+  it('does not collapse different subtypes', () => {
+    expect(
+      summarizeChanges([
+        { type: 'action_added', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
+        {
+          type: 'action_added',
+          node: 'n2',
+          uuid: 'a2',
+          subtype: 'add_contact_groups'
+        }
+      ])
+    ).to.equal('Added message and added group');
+  });
+
+  it('falls back to "action" for unknown subtypes', () => {
+    expect(
+      summarizeChanges([
+        { type: 'action_updated', node: 'n1', uuid: 'a1', subtype: 'unknown' }
+      ])
+    ).to.equal('Updated action');
+  });
+
+  it('summarizes action reordering without a count', () => {
+    expect(
+      summarizeChanges([{ type: 'action_reordered', node: 'n1' }])
+    ).to.equal('Reordered actions');
+    expect(
+      summarizeChanges([
+        { type: 'action_reordered', node: 'n1' },
+        { type: 'action_reordered', node: 'n2' }
+      ])
+    ).to.equal('Reordered actions');
+  });
+
+  it('shows up to two specific phrases joined by "and"', () => {
+    expect(
+      summarizeChanges([
+        { type: 'metadata_changed', field: 'name' },
+        { type: 'action_added', node: 'n1', uuid: 'a1', subtype: 'send_msg' }
+      ])
+    ).to.equal('Changed name and added message');
+  });
+
+  it('flags a single category as significant when overflow collapses to one', () => {
+    expect(
+      summarizeChanges([
+        { type: 'node_added', uuid: 'n1' },
+        { type: 'node_added', uuid: 'n2' },
+        { type: 'router_updated', node: 'n3' },
+        { type: 'connection_changed', node: 'n4', uuid: 'e1' }
+      ])
+    ).to.equal('Significantly changed structure');
+  });
+
+  it('flags two categories as significant when overflow spans two', () => {
+    expect(
+      summarizeChanges([
+        { type: 'metadata_changed', field: 'name' },
+        { type: 'base_language_changed' },
+        { type: 'translation_updated', lang: 'spa', uuid: 't1' },
+        { type: 'translation_updated', lang: 'fra', uuid: 't2' }
+      ])
+    ).to.equal('Significantly changed metadata and translations');
+  });
+
+  it('caps generalized output at two categories without an overflow tail', () => {
+    expect(
+      summarizeChanges([
+        { type: 'metadata_changed', field: 'name' },
+        { type: 'sticky_added', uuid: 's1' },
+        { type: 'sticky_moved', uuid: 's2' },
+        { type: 'translation_updated', lang: 'spa', uuid: 't1' },
+        { type: 'translation_updated', lang: 'fra', uuid: 't2' }
+      ])
+    ).to.equal('Significantly changed metadata and translations');
+  });
+
+  it('orders categories metadata, structure, content, translations, notes, layout', () => {
+    expect(
+      summarizeChanges([
+        { type: 'sticky_moved', uuid: 's1' },
+        { type: 'action_added', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
+        { type: 'metadata_changed', field: 'name' }
+      ])
+    ).to.equal('Significantly changed metadata and structure');
+  });
+
+  it('skips unknown change types', () => {
+    expect(
+      summarizeChanges([
+        { type: 'action_updated', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
+        { type: 'something_new' as any }
+      ])
+    ).to.equal('Updated message');
+  });
+});
+
+describe('isSignificantChange', () => {
+  it('returns false for null/empty changes', () => {
+    expect(isSignificantChange(null)).to.be.false;
+    expect(isSignificantChange(undefined)).to.be.false;
+    expect(isSignificantChange([])).to.be.false;
+  });
+
+  it('returns false when there are at most two distinct phrase groups', () => {
+    expect(
+      isSignificantChange([
+        { type: 'action_updated', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
+        { type: 'action_added', node: 'n2', uuid: 'a2', subtype: 'send_msg' }
+      ])
+    ).to.be.false;
+  });
+
+  it('returns true when there are more than two distinct phrase groups', () => {
+    expect(
+      isSignificantChange([
+        { type: 'metadata_changed', field: 'name' },
+        { type: 'action_added', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
+        { type: 'sticky_added', uuid: 's1' }
+      ])
+    ).to.be.true;
+  });
+});

--- a/test/revision-summary.test.ts
+++ b/test/revision-summary.test.ts
@@ -2,13 +2,10 @@ import { expect } from '@open-wc/testing';
 import { summarizeChanges } from '../src/flow/revision-summary';
 
 describe('summarizeChanges', () => {
-  it('returns empty string for null/undefined', () => {
+  it('returns empty string for null/undefined/empty tags', () => {
     expect(summarizeChanges(null)).to.equal('');
     expect(summarizeChanges(undefined)).to.equal('');
-  });
-
-  it('returns "Unchanged" for an empty tags array', () => {
-    expect(summarizeChanges({ tags: [] })).to.equal('Unchanged');
+    expect(summarizeChanges({ tags: [] })).to.equal('');
   });
 
   it('renders a single tag verb-first', () => {

--- a/test/revision-summary.test.ts
+++ b/test/revision-summary.test.ts
@@ -27,13 +27,13 @@ describe('summarizeChanges', () => {
     );
     expect(
       summarizeChanges({ tags: ['stickies', 'nodes', 'metadata'] })
-    ).to.equal('Significantly changed metadata and nodes');
+    ).to.equal('Changed metadata and nodes');
   });
 
-  it('flags as significant and caps at two when there are 3+ distinct labels', () => {
+  it('caps at the first two labels when there are 3+', () => {
     expect(
       summarizeChanges({ tags: ['metadata', 'actions', 'positions'] })
-    ).to.equal('Significantly changed metadata and actions');
+    ).to.equal('Changed metadata and actions');
   });
 
   it('collapses multiple localization:<lang> tags into a single "translations" label', () => {

--- a/test/revision-summary.test.ts
+++ b/test/revision-summary.test.ts
@@ -1,171 +1,63 @@
 import { expect } from '@open-wc/testing';
-import {
-  isSignificantChange,
-  summarizeChanges
-} from '../src/flow/revision-summary';
+import { summarizeChanges } from '../src/flow/revision-summary';
 
 describe('summarizeChanges', () => {
-  it('returns empty string for null/empty changes', () => {
+  it('returns empty string for null/undefined', () => {
     expect(summarizeChanges(null)).to.equal('');
     expect(summarizeChanges(undefined)).to.equal('');
-    expect(summarizeChanges([])).to.equal('');
   });
 
-  it('uses singular noun without count when there is exactly one change', () => {
-    expect(
-      summarizeChanges([
-        { type: 'action_updated', node: 'n1', uuid: 'a1', subtype: 'send_msg' }
-      ])
-    ).to.equal('Updated message');
+  it('returns "Unchanged" for an empty tags array', () => {
+    expect(summarizeChanges({ tags: [] })).to.equal('Unchanged');
   });
 
-  it('collapses same-subtype actions into a count + plural', () => {
-    expect(
-      summarizeChanges([
-        { type: 'action_updated', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
-        { type: 'action_updated', node: 'n2', uuid: 'a2', subtype: 'send_msg' }
-      ])
-    ).to.equal('Updated 2 messages');
+  it('renders a single tag verb-first', () => {
+    expect(summarizeChanges({ tags: ['actions'] })).to.equal('Changed actions');
+    expect(summarizeChanges({ tags: ['metadata'] })).to.equal(
+      'Changed metadata'
+    );
   });
 
-  it('does not collapse different verbs for the same subtype', () => {
-    expect(
-      summarizeChanges([
-        { type: 'action_added', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
-        { type: 'action_updated', node: 'n2', uuid: 'a2', subtype: 'send_msg' }
-      ])
-    ).to.equal('Added message and updated message');
+  it('joins two tags with "and"', () => {
+    expect(summarizeChanges({ tags: ['actions', 'positions'] })).to.equal(
+      'Changed actions and positions'
+    );
   });
 
-  it('does not collapse different subtypes', () => {
+  it('orders tags by category priority regardless of input order', () => {
+    expect(summarizeChanges({ tags: ['positions', 'metadata'] })).to.equal(
+      'Changed metadata and positions'
+    );
     expect(
-      summarizeChanges([
-        { type: 'action_added', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
-        {
-          type: 'action_added',
-          node: 'n2',
-          uuid: 'a2',
-          subtype: 'add_contact_groups'
-        }
-      ])
-    ).to.equal('Added message and added group');
+      summarizeChanges({ tags: ['stickies', 'nodes', 'metadata'] })
+    ).to.equal('Significantly changed metadata and nodes');
   });
 
-  it('falls back to "action" for unknown subtypes', () => {
+  it('flags as significant and caps at two when there are 3+ distinct labels', () => {
     expect(
-      summarizeChanges([
-        { type: 'action_updated', node: 'n1', uuid: 'a1', subtype: 'unknown' }
-      ])
-    ).to.equal('Updated action');
+      summarizeChanges({ tags: ['metadata', 'actions', 'positions'] })
+    ).to.equal('Significantly changed metadata and actions');
   });
 
-  it('summarizes action reordering without a count', () => {
+  it('collapses multiple localization:<lang> tags into a single "translations" label', () => {
     expect(
-      summarizeChanges([{ type: 'action_reordered', node: 'n1' }])
-    ).to.equal('Reordered actions');
-    expect(
-      summarizeChanges([
-        { type: 'action_reordered', node: 'n1' },
-        { type: 'action_reordered', node: 'n2' }
-      ])
-    ).to.equal('Reordered actions');
+      summarizeChanges({ tags: ['localization:spa', 'localization:fra'] })
+    ).to.equal('Changed translations');
   });
 
-  it('shows up to two specific phrases joined by "and"', () => {
+  it('treats a localization tag as one label alongside other tags', () => {
     expect(
-      summarizeChanges([
-        { type: 'metadata_changed', field: 'name' },
-        { type: 'action_added', node: 'n1', uuid: 'a1', subtype: 'send_msg' }
-      ])
-    ).to.equal('Changed name and added message');
+      summarizeChanges({
+        tags: ['actions', 'localization:spa', 'localization:fra']
+      })
+    ).to.equal('Changed actions and translations');
   });
 
-  it('flags a single category as significant when overflow collapses to one', () => {
-    expect(
-      summarizeChanges([
-        { type: 'node_added', uuid: 'n1' },
-        { type: 'node_added', uuid: 'n2' },
-        { type: 'router_updated', node: 'n3' },
-        { type: 'connection_changed', node: 'n4', uuid: 'e1' }
-      ])
-    ).to.equal('Significantly changed structure');
-  });
-
-  it('flags two categories as significant when overflow spans two', () => {
-    expect(
-      summarizeChanges([
-        { type: 'metadata_changed', field: 'name' },
-        { type: 'base_language_changed' },
-        { type: 'translation_updated', lang: 'spa', uuid: 't1' },
-        { type: 'translation_updated', lang: 'fra', uuid: 't2' }
-      ])
-    ).to.equal('Significantly changed metadata and translations');
-  });
-
-  it('caps generalized output at two categories without an overflow tail', () => {
-    expect(
-      summarizeChanges([
-        { type: 'metadata_changed', field: 'name' },
-        { type: 'sticky_added', uuid: 's1' },
-        { type: 'sticky_moved', uuid: 's2' },
-        { type: 'translation_updated', lang: 'spa', uuid: 't1' },
-        { type: 'translation_updated', lang: 'fra', uuid: 't2' }
-      ])
-    ).to.equal('Significantly changed metadata and translations');
-  });
-
-  it('orders categories metadata, structure, content, translations, notes, layout', () => {
-    expect(
-      summarizeChanges([
-        { type: 'sticky_moved', uuid: 's1' },
-        { type: 'action_added', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
-        { type: 'metadata_changed', field: 'name' }
-      ])
-    ).to.equal('Significantly changed metadata and structure');
-  });
-
-  it('does not pluralize repeated metadata changes for the same field', () => {
-    expect(
-      summarizeChanges([
-        { type: 'metadata_changed', field: 'name' },
-        { type: 'metadata_changed', field: 'name' }
-      ])
-    ).to.equal('Changed name');
-  });
-
-  it('skips unknown change types', () => {
-    expect(
-      summarizeChanges([
-        { type: 'action_updated', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
-        { type: 'something_new' as any }
-      ])
-    ).to.equal('Updated message');
-  });
-});
-
-describe('isSignificantChange', () => {
-  it('returns false for null/empty changes', () => {
-    expect(isSignificantChange(null)).to.be.false;
-    expect(isSignificantChange(undefined)).to.be.false;
-    expect(isSignificantChange([])).to.be.false;
-  });
-
-  it('returns false when there are at most two distinct phrase groups', () => {
-    expect(
-      isSignificantChange([
-        { type: 'action_updated', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
-        { type: 'action_added', node: 'n2', uuid: 'a2', subtype: 'send_msg' }
-      ])
-    ).to.be.false;
-  });
-
-  it('returns true when there are more than two distinct phrase groups', () => {
-    expect(
-      isSignificantChange([
-        { type: 'metadata_changed', field: 'name' },
-        { type: 'action_added', node: 'n1', uuid: 'a1', subtype: 'send_msg' },
-        { type: 'sticky_added', uuid: 's1' }
-      ])
-    ).to.be.true;
+  it('ignores unknown tags', () => {
+    expect(summarizeChanges({ tags: ['actions', 'something_new'] })).to.equal(
+      'Changed actions'
+    );
+    // an entirely unknown set yields nothing
+    expect(summarizeChanges({ tags: ['something_new'] })).to.equal('');
   });
 });

--- a/test/revision-summary.test.ts
+++ b/test/revision-summary.test.ts
@@ -17,13 +17,13 @@ describe('summarizeChanges', () => {
 
   it('joins two tags with "and"', () => {
     expect(summarizeChanges({ tags: ['actions', 'positions'] })).to.equal(
-      'Changed actions and positions'
+      'Changed actions and layout'
     );
   });
 
   it('orders tags by category priority regardless of input order', () => {
     expect(summarizeChanges({ tags: ['positions', 'metadata'] })).to.equal(
-      'Changed metadata and positions'
+      'Changed metadata and layout'
     );
     expect(
       summarizeChanges({ tags: ['stickies', 'nodes', 'metadata'] })
@@ -33,12 +33,12 @@ describe('summarizeChanges', () => {
   it('lists all tags with an Oxford comma when there are 3+', () => {
     expect(
       summarizeChanges({ tags: ['metadata', 'actions', 'positions'] })
-    ).to.equal('Changed metadata, actions, and positions');
+    ).to.equal('Changed metadata, actions, and layout');
     expect(
       summarizeChanges({
         tags: ['positions', 'stickies', 'metadata', 'actions', 'nodes']
       })
-    ).to.equal('Changed metadata, nodes, actions, stickies, and positions');
+    ).to.equal('Changed metadata, nodes, actions, stickies, and layout');
   });
 
   it('collapses multiple localization:<lang> tags into a single "translations" label', () => {

--- a/test/revision-summary.test.ts
+++ b/test/revision-summary.test.ts
@@ -27,13 +27,18 @@ describe('summarizeChanges', () => {
     );
     expect(
       summarizeChanges({ tags: ['stickies', 'nodes', 'metadata'] })
-    ).to.equal('Changed metadata and nodes');
+    ).to.equal('Changed metadata, nodes, and stickies');
   });
 
-  it('caps at the first two labels when there are 3+', () => {
+  it('lists all tags with an Oxford comma when there are 3+', () => {
     expect(
       summarizeChanges({ tags: ['metadata', 'actions', 'positions'] })
-    ).to.equal('Changed metadata and actions');
+    ).to.equal('Changed metadata, actions, and positions');
+    expect(
+      summarizeChanges({
+        tags: ['positions', 'stickies', 'metadata', 'actions', 'nodes']
+      })
+    ).to.equal('Changed metadata, nodes, actions, stickies, and positions');
   });
 
   it('collapses multiple localization:<lang> tags into a single "translations" label', () => {

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -163,6 +163,71 @@ describe('Editor Revisions', () => {
     expect(revisions[1].id).to.equal(1);
   });
 
+  it('does not collapse revisions exactly 15 minutes apart (strict less-than)', async () => {
+    const mockRevisions = [
+      {
+        id: 2,
+        created_on: '2024-06-01T12:15:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        changes: [{ type: 'sticky_added', uuid: 's1' }]
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T12:00:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        changes: [{ type: 'sticky_added', uuid: 's2' }]
+      }
+    ];
+
+    const mockResponse = new Response(
+      JSON.stringify({ results: mockRevisions }),
+      { status: 200 }
+    );
+    fetchStub.resolves(mockResponse);
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(2);
+    expect(revisions[0].id).to.equal(2);
+    expect(revisions[1].id).to.equal(1);
+  });
+
+  it('keeps revisions with no recorded changes standalone', async () => {
+    const mockRevisions = [
+      {
+        id: 3,
+        created_on: '2024-06-01T12:10:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        changes: [{ type: 'sticky_added', uuid: 's1' }]
+      },
+      {
+        id: 2,
+        created_on: '2024-06-01T12:05:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        changes: null
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T12:00:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        changes: [{ type: 'sticky_added', uuid: 's2' }]
+      }
+    ];
+
+    const mockResponse = new Response(
+      JSON.stringify({ results: mockRevisions }),
+      { status: 200 }
+    );
+    fetchStub.resolves(mockResponse);
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(3);
+    expect(revisions.map((r: any) => r.id)).to.deep.equal([3, 2, 1]);
+  });
+
   it('keeps significant revisions standalone, splitting groups around them', async () => {
     const mockRevisions = [
       {
@@ -236,6 +301,29 @@ describe('Editor Revisions', () => {
     await revisionsWindow.updateComplete;
 
     expect(fetchStub.callCount).to.be.greaterThan(0);
+  });
+
+  it('does not refresh when the revision number decreases (e.g., loading an older one)', async () => {
+    const mockResponse = new Response(JSON.stringify({ results: [] }), {
+      status: 200
+    });
+    fetchStub.resolves(mockResponse);
+
+    zustand.setState({
+      viewingRevision: false,
+      flowDefinition: { revision: 7, nodes: [] } as any
+    });
+    (revisionsWindow as any).hidden = false;
+    await revisionsWindow.updateComplete;
+    fetchStub.resetHistory();
+
+    // revision number drops without viewingRevision flipping (e.g., a fetch race)
+    zustand.setState({
+      flowDefinition: { revision: 4, nodes: [] } as any
+    });
+    await revisionsWindow.updateComplete;
+
+    expect(fetchStub.callCount).to.equal(0);
   });
 
   it('does not refresh when previewing an older revision', async () => {

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -40,6 +40,11 @@ describe('Editor Revisions', () => {
 
   afterEach(() => {
     restore();
+    // Reset shared zustand state so tests in other files start fresh.
+    zustand.setState({
+      viewingRevision: false,
+      flowDefinition: null as any
+    });
   });
 
   it('should include the current revision at the top of the list', async () => {

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -111,41 +111,110 @@ describe('Editor Revisions', () => {
     expect(revisions[0].id).to.equal(1);
   });
 
-  it('renders revisions verbatim from the API (no client-side collapsing)', async () => {
+  it('collapses revisions inside a 15 minute window onto the most recent and unions tags', async () => {
+    const user = { id: 1, first_name: 'A', last_name: 'B', username: 'ab' };
     const mockRevisions = [
       {
-        id: 3,
-        created_on: '2024-06-01T12:10:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        id: 4,
+        created_on: '2024-06-01T12:30:00Z',
+        user,
         changes: { tags: ['actions'] }
       },
       {
+        id: 3,
+        created_on: '2024-06-01T12:25:00Z',
+        user,
+        changes: { tags: ['positions'] }
+      },
+      {
         id: 2,
-        created_on: '2024-06-01T12:05:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: { tags: ['metadata', 'actions', 'stickies'] }
+        created_on: '2024-06-01T12:20:00Z',
+        user,
+        changes: { tags: ['actions', 'stickies'] }
       },
       {
         id: 1,
-        created_on: '2024-06-01T12:00:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: null
+        created_on: '2024-06-01T11:00:00Z',
+        user,
+        changes: { tags: ['metadata'] }
       }
     ];
 
-    const mockResponse = new Response(
-      JSON.stringify({ results: mockRevisions }),
-      { status: 200 }
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
     );
-    fetchStub.resolves(mockResponse);
 
     await (revisionsWindow as any).fetchRevisions();
 
     const revisions = (revisionsWindow as any).revisions;
-    expect(revisions.length).to.equal(3);
-    expect(revisions.map((r: any) => r.id)).to.deep.equal([3, 2, 1]);
-    expect(revisions[0].changes).to.deep.equal({ tags: ['actions'] });
-    expect(revisions[2].changes).to.equal(null);
+    // 4/3/2 are within 15 min of 4 → collapsed onto 4; 1 stands alone
+    expect(revisions.length).to.equal(2);
+    expect(revisions[0].id).to.equal(4);
+    expect(revisions[0].changes.tags.sort()).to.deep.equal([
+      'actions',
+      'positions',
+      'stickies'
+    ]);
+    expect(revisions[1].id).to.equal(1);
+    expect(revisions[1].changes.tags).to.deep.equal(['metadata']);
+  });
+
+  it('does not collapse revisions exactly 15 minutes apart', async () => {
+    const user = { id: 1, first_name: 'A', last_name: 'B', username: 'ab' };
+    const mockRevisions = [
+      {
+        id: 2,
+        created_on: '2024-06-01T12:15:00Z',
+        user,
+        changes: { tags: ['actions'] }
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T12:00:00Z',
+        user,
+        changes: { tags: ['actions'] }
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(2);
+    expect(revisions[0].id).to.equal(2);
+    expect(revisions[1].id).to.equal(1);
+  });
+
+  it('keeps the merged changes null when every revision in a window is null', async () => {
+    const user = { id: 1, first_name: 'A', last_name: 'B', username: 'ab' };
+    const mockRevisions = [
+      {
+        id: 2,
+        created_on: '2024-06-01T12:05:00Z',
+        user,
+        changes: null
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T12:00:00Z',
+        user,
+        changes: null
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(1);
+    expect(revisions[0].id).to.equal(2);
+    expect(revisions[0].changes).to.equal(null);
   });
 
   it('refresh() fetches the list when the window is open', async () => {

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -124,7 +124,7 @@ describe('Editor Revisions', () => {
         id: 3,
         created_on: '2024-06-01T12:25:00Z',
         user,
-        changes: { tags: ['positions'] }
+        changes: { tags: ['layout'] }
       },
       {
         id: 2,
@@ -152,7 +152,7 @@ describe('Editor Revisions', () => {
     expect(revisions[0].id).to.equal(4);
     expect(revisions[0].changes.tags.sort()).to.deep.equal([
       'actions',
-      'positions',
+      'layout',
       'stickies'
     ]);
     expect(revisions[1].id).to.equal(1);
@@ -202,7 +202,7 @@ describe('Editor Revisions', () => {
         id: 2,
         created_on: '2024-06-01T12:05:00Z',
         user: bob,
-        changes: { tags: ['positions'] }
+        changes: { tags: ['layout'] }
       },
       {
         id: 1,
@@ -227,7 +227,7 @@ describe('Editor Revisions', () => {
     expect(revisions[1].user.username).to.equal('bob');
     expect(revisions[1].changes.tags.sort()).to.deep.equal([
       'actions',
-      'positions'
+      'layout'
     ]);
   });
 
@@ -252,7 +252,7 @@ describe('Editor Revisions', () => {
         id: 2,
         created_on: '2024-06-01T12:06:00Z',
         user,
-        changes: { tags: ['positions'] }
+        changes: { tags: ['layout'] }
       },
       {
         id: 1,
@@ -273,8 +273,8 @@ describe('Editor Revisions', () => {
     expect(revisions[0].id).to.equal(4);
     expect(revisions[0].changes.tags.sort()).to.deep.equal([
       'actions',
-      'metadata',
-      'positions'
+      'layout',
+      'metadata'
     ]);
     expect(revisions[1].id).to.equal(1);
     expect(revisions[1].changes.tags).to.deep.equal(['stickies']);

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -2,6 +2,7 @@ import { html, fixture, expect } from '@open-wc/testing';
 import { Editor } from '../src/flow/Editor';
 import { IssuesWindow } from '../src/flow/IssuesWindow';
 import { RevisionsWindow } from '../src/flow/RevisionsWindow';
+import { zustand } from '../src/store/AppState';
 import { stub, restore, SinonStub } from 'sinon';
 
 customElements.define('temba-flow-editor-revisions', Editor);
@@ -34,7 +35,7 @@ describe('Editor Revisions', () => {
     restore();
   });
 
-  it('should exclude the most recent revision from the list', async () => {
+  it('should include the current revision at the top of the list', async () => {
     const mockRevisions = [
       {
         id: 3,
@@ -67,9 +68,10 @@ describe('Editor Revisions', () => {
     await (revisionsWindow as any).fetchRevisions();
 
     const revisions = (revisionsWindow as any).revisions;
-    expect(revisions.length).to.equal(2);
-    expect(revisions[0].id).to.equal(2);
-    expect(revisions[1].id).to.equal(1);
+    expect(revisions.length).to.equal(3);
+    expect(revisions[0].id).to.equal(3);
+    expect(revisions[1].id).to.equal(2);
+    expect(revisions[2].id).to.equal(1);
   });
 
   it('should handle empty revisions list', async () => {
@@ -99,7 +101,208 @@ describe('Editor Revisions', () => {
 
     await (revisionsWindow as any).fetchRevisions();
     const revisions = (revisionsWindow as any).revisions;
-    expect(revisions.length).to.equal(0);
+    expect(revisions.length).to.equal(1);
+    expect(revisions[0].id).to.equal(1);
+  });
+
+  it('collapses revisions inside a 15 minute window into the most recent', async () => {
+    const mockRevisions = [
+      {
+        id: 4,
+        created_on: '2024-06-01T12:30:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        changes: [
+          {
+            type: 'action_updated',
+            node: 'n1',
+            uuid: 'a1',
+            subtype: 'send_msg'
+          }
+        ]
+      },
+      {
+        id: 3,
+        created_on: '2024-06-01T12:25:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        changes: [
+          {
+            type: 'action_updated',
+            node: 'n1',
+            uuid: 'a2',
+            subtype: 'send_msg'
+          }
+        ]
+      },
+      {
+        id: 2,
+        created_on: '2024-06-01T12:20:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        changes: [{ type: 'sticky_added', uuid: 's1' }]
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T11:00:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        changes: [{ type: 'node_moved', uuid: 'n1' }]
+      }
+    ];
+
+    const mockResponse = new Response(
+      JSON.stringify({ results: mockRevisions }),
+      { status: 200 }
+    );
+    fetchStub.resolves(mockResponse);
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    // ids 4/3/2 are within 15 min → collapsed onto id 4; id 1 stands alone
+    expect(revisions.length).to.equal(2);
+    expect(revisions[0].id).to.equal(4);
+    expect(revisions[0].changes.length).to.equal(3);
+    expect(revisions[1].id).to.equal(1);
+  });
+
+  it('keeps significant revisions standalone, splitting groups around them', async () => {
+    const mockRevisions = [
+      {
+        id: 3,
+        created_on: '2024-06-01T12:10:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        changes: [
+          {
+            type: 'action_updated',
+            node: 'n1',
+            uuid: 'a1',
+            subtype: 'send_msg'
+          }
+        ]
+      },
+      {
+        id: 2,
+        created_on: '2024-06-01T12:05:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        // three distinct phrase groups → significant
+        changes: [
+          { type: 'metadata_changed', field: 'name' },
+          { type: 'action_added', node: 'n1', uuid: 'a2', subtype: 'send_msg' },
+          { type: 'sticky_added', uuid: 's1' }
+        ]
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T12:00:00Z',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
+        changes: [{ type: 'sticky_moved', uuid: 's2' }]
+      }
+    ];
+
+    const mockResponse = new Response(
+      JSON.stringify({ results: mockRevisions }),
+      { status: 200 }
+    );
+    fetchStub.resolves(mockResponse);
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(3);
+    expect(revisions[0].id).to.equal(3);
+    expect(revisions[1].id).to.equal(2);
+    expect(revisions[2].id).to.equal(1);
+    // changes should not have been merged across the significant revision
+    expect(revisions[0].changes.length).to.equal(1);
+    expect(revisions[1].changes.length).to.equal(3);
+    expect(revisions[2].changes.length).to.equal(1);
+  });
+
+  it('refreshes the list when a new revision is saved while the window is open', async () => {
+    const mockResponse = new Response(JSON.stringify({ results: [] }), {
+      status: 200
+    });
+    fetchStub.resolves(mockResponse);
+
+    zustand.setState({
+      viewingRevision: false,
+      flowDefinition: { revision: 1, nodes: [] } as any
+    });
+    (revisionsWindow as any).hidden = false;
+    await revisionsWindow.updateComplete;
+    fetchStub.resetHistory();
+
+    zustand.setState({
+      flowDefinition: { revision: 2, nodes: [] } as any
+    });
+    await revisionsWindow.updateComplete;
+
+    expect(fetchStub.callCount).to.be.greaterThan(0);
+  });
+
+  it('does not refresh when previewing an older revision', async () => {
+    const mockResponse = new Response(JSON.stringify({ results: [] }), {
+      status: 200
+    });
+    fetchStub.resolves(mockResponse);
+
+    zustand.setState({
+      viewingRevision: false,
+      flowDefinition: { revision: 5, nodes: [] } as any
+    });
+    (revisionsWindow as any).hidden = false;
+    await revisionsWindow.updateComplete;
+    fetchStub.resetHistory();
+
+    zustand.setState({
+      viewingRevision: true,
+      flowDefinition: { revision: 3, nodes: [] } as any
+    });
+    await revisionsWindow.updateComplete;
+
+    expect(fetchStub.callCount).to.equal(0);
+  });
+
+  it('should label the current revision and not show a revert button for it', async () => {
+    (element as any).revisionsWindowHidden = false;
+    await element.requestUpdate();
+
+    const mockRevisions = [
+      {
+        id: 3,
+        created_on: '2023-01-03',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' }
+      },
+      {
+        id: 2,
+        created_on: '2023-01-02',
+        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' }
+      }
+    ];
+    (revisionsWindow as any).revisions = mockRevisions;
+    await revisionsWindow.updateComplete;
+
+    const items = revisionsWindow.shadowRoot?.querySelectorAll(
+      '.revision-item'
+    ) as NodeListOf<HTMLElement>;
+    expect(items.length).to.equal(2);
+
+    // First item is the current revision
+    expect(items[0].classList.contains('current')).to.be.true;
+    expect(items[0].querySelector('.current-label')).to.exist;
+    expect(items[0].querySelector('.revert-button')).to.not.exist;
+
+    // Selecting the current revision should not show a revert button
+    (revisionsWindow as any).viewingRevision = mockRevisions[0];
+    await revisionsWindow.updateComplete;
+    const refreshed = revisionsWindow.shadowRoot?.querySelectorAll(
+      '.revision-item'
+    ) as NodeListOf<HTMLElement>;
+    expect(refreshed[0].classList.contains('selected')).to.be.true;
+    expect(refreshed[0].querySelector('.revert-button')).to.not.exist;
+    expect(refreshed[0].querySelector('.current-label')).to.exist;
+
+    // Second item is not current and has no current label
+    expect(items[1].classList.contains('current')).to.be.false;
+    expect(items[1].querySelector('.current-label')).to.not.exist;
   });
 
   it('should have purple color for revisions window and blue for selected item', async () => {
@@ -121,7 +324,7 @@ describe('Editor Revisions', () => {
       }
     ];
     (revisionsWindow as any).revisions = mockRevisions;
-    (revisionsWindow as any).viewingRevision = mockRevisions[0]; // Select the first one
+    (revisionsWindow as any).viewingRevision = mockRevisions[1]; // Select a non-current revision
 
     await revisionsWindow.updateComplete;
 

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -111,113 +111,25 @@ describe('Editor Revisions', () => {
     expect(revisions[0].id).to.equal(1);
   });
 
-  it('collapses revisions inside a 15 minute window into the most recent', async () => {
-    const mockRevisions = [
-      {
-        id: 4,
-        created_on: '2024-06-01T12:30:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: [
-          {
-            type: 'action_updated',
-            node: 'n1',
-            uuid: 'a1',
-            subtype: 'send_msg'
-          }
-        ]
-      },
-      {
-        id: 3,
-        created_on: '2024-06-01T12:25:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: [
-          {
-            type: 'action_updated',
-            node: 'n1',
-            uuid: 'a2',
-            subtype: 'send_msg'
-          }
-        ]
-      },
-      {
-        id: 2,
-        created_on: '2024-06-01T12:20:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: [{ type: 'sticky_added', uuid: 's1' }]
-      },
-      {
-        id: 1,
-        created_on: '2024-06-01T11:00:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: [{ type: 'node_moved', uuid: 'n1' }]
-      }
-    ];
-
-    const mockResponse = new Response(
-      JSON.stringify({ results: mockRevisions }),
-      { status: 200 }
-    );
-    fetchStub.resolves(mockResponse);
-
-    await (revisionsWindow as any).fetchRevisions();
-
-    const revisions = (revisionsWindow as any).revisions;
-    // ids 4/3/2 are within 15 min → collapsed onto id 4; id 1 stands alone
-    expect(revisions.length).to.equal(2);
-    expect(revisions[0].id).to.equal(4);
-    expect(revisions[0].changes.length).to.equal(3);
-    expect(revisions[1].id).to.equal(1);
-  });
-
-  it('does not collapse revisions exactly 15 minutes apart (strict less-than)', async () => {
-    const mockRevisions = [
-      {
-        id: 2,
-        created_on: '2024-06-01T12:15:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: [{ type: 'sticky_added', uuid: 's1' }]
-      },
-      {
-        id: 1,
-        created_on: '2024-06-01T12:00:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: [{ type: 'sticky_added', uuid: 's2' }]
-      }
-    ];
-
-    const mockResponse = new Response(
-      JSON.stringify({ results: mockRevisions }),
-      { status: 200 }
-    );
-    fetchStub.resolves(mockResponse);
-
-    await (revisionsWindow as any).fetchRevisions();
-
-    const revisions = (revisionsWindow as any).revisions;
-    expect(revisions.length).to.equal(2);
-    expect(revisions[0].id).to.equal(2);
-    expect(revisions[1].id).to.equal(1);
-  });
-
-  it('keeps revisions with no recorded changes standalone', async () => {
+  it('renders revisions verbatim from the API (no client-side collapsing)', async () => {
     const mockRevisions = [
       {
         id: 3,
         created_on: '2024-06-01T12:10:00Z',
         user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: [{ type: 'sticky_added', uuid: 's1' }]
+        changes: { tags: ['actions'] }
       },
       {
         id: 2,
         created_on: '2024-06-01T12:05:00Z',
         user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: null
+        changes: { tags: ['metadata', 'actions', 'stickies'] }
       },
       {
         id: 1,
         created_on: '2024-06-01T12:00:00Z',
         user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: [{ type: 'sticky_added', uuid: 's2' }]
+        changes: null
       }
     ];
 
@@ -232,59 +144,8 @@ describe('Editor Revisions', () => {
     const revisions = (revisionsWindow as any).revisions;
     expect(revisions.length).to.equal(3);
     expect(revisions.map((r: any) => r.id)).to.deep.equal([3, 2, 1]);
-  });
-
-  it('keeps significant revisions standalone, splitting groups around them', async () => {
-    const mockRevisions = [
-      {
-        id: 3,
-        created_on: '2024-06-01T12:10:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: [
-          {
-            type: 'action_updated',
-            node: 'n1',
-            uuid: 'a1',
-            subtype: 'send_msg'
-          }
-        ]
-      },
-      {
-        id: 2,
-        created_on: '2024-06-01T12:05:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        // three distinct phrase groups → significant
-        changes: [
-          { type: 'metadata_changed', field: 'name' },
-          { type: 'action_added', node: 'n1', uuid: 'a2', subtype: 'send_msg' },
-          { type: 'sticky_added', uuid: 's1' }
-        ]
-      },
-      {
-        id: 1,
-        created_on: '2024-06-01T12:00:00Z',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' },
-        changes: [{ type: 'sticky_moved', uuid: 's2' }]
-      }
-    ];
-
-    const mockResponse = new Response(
-      JSON.stringify({ results: mockRevisions }),
-      { status: 200 }
-    );
-    fetchStub.resolves(mockResponse);
-
-    await (revisionsWindow as any).fetchRevisions();
-
-    const revisions = (revisionsWindow as any).revisions;
-    expect(revisions.length).to.equal(3);
-    expect(revisions[0].id).to.equal(3);
-    expect(revisions[1].id).to.equal(2);
-    expect(revisions[2].id).to.equal(1);
-    // changes should not have been merged across the significant revision
-    expect(revisions[0].changes.length).to.equal(1);
-    expect(revisions[1].changes.length).to.equal(3);
-    expect(revisions[2].changes.length).to.equal(1);
+    expect(revisions[0].changes).to.deep.equal({ tags: ['actions'] });
+    expect(revisions[2].changes).to.equal(null);
   });
 
   it('refresh() fetches the list when the window is open', async () => {

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -188,6 +188,44 @@ describe('Editor Revisions', () => {
     expect(revisions[1].id).to.equal(1);
   });
 
+  it('groups revisions by author when only the email/name shape is sent', async () => {
+    // The production API returns user: { email, name } (no username), so the
+    // sameAuthor check has to recognize this shape — otherwise a single
+    // editing session by one user lights up as a row per revision.
+    const adam = { email: 'adam@example.com', name: 'Adam McAdmin' };
+    const mockRevisions = [
+      {
+        id: 3,
+        created_on: '2024-06-01T12:10:00Z',
+        user: adam,
+        changes: { tags: ['layout'] }
+      },
+      {
+        id: 2,
+        created_on: '2024-06-01T12:09:00Z',
+        user: adam,
+        changes: { tags: ['layout'] }
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T12:08:00Z',
+        user: adam,
+        changes: { tags: ['layout'] }
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(1);
+    expect(revisions[0].id).to.equal(3);
+    expect(revisions[0].user.name).to.equal('Adam McAdmin');
+  });
+
   it('breaks out into a new row when the next revision changes the author', async () => {
     const ann = { id: 1, first_name: 'A', last_name: 'A', username: 'ann' };
     const bob = { id: 2, first_name: 'B', last_name: 'B', username: 'bob' };

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -282,10 +282,10 @@ describe('Editor Revisions', () => {
   });
 
   it('refreshes the list when a new revision is saved while the window is open', async () => {
-    const mockResponse = new Response(JSON.stringify({ results: [] }), {
-      status: 200
-    });
-    fetchStub.resolves(mockResponse);
+    fetchStub.callsFake(
+      async () =>
+        new Response(JSON.stringify({ results: [] }), { status: 200 })
+    );
 
     zustand.setState({
       viewingRevision: false,
@@ -304,10 +304,10 @@ describe('Editor Revisions', () => {
   });
 
   it('does not refresh when the revision number decreases (e.g., loading an older one)', async () => {
-    const mockResponse = new Response(JSON.stringify({ results: [] }), {
-      status: 200
-    });
-    fetchStub.resolves(mockResponse);
+    fetchStub.callsFake(
+      async () =>
+        new Response(JSON.stringify({ results: [] }), { status: 200 })
+    );
 
     zustand.setState({
       viewingRevision: false,
@@ -327,10 +327,10 @@ describe('Editor Revisions', () => {
   });
 
   it('does not refresh when previewing an older revision', async () => {
-    const mockResponse = new Response(JSON.stringify({ results: [] }), {
-      status: 200
-    });
-    fetchStub.resolves(mockResponse);
+    fetchStub.callsFake(
+      async () =>
+        new Response(JSON.stringify({ results: [] }), { status: 200 })
+    );
 
     zustand.setState({
       viewingRevision: false,

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -21,6 +21,13 @@ describe('Editor Revisions', () => {
   beforeEach(async () => {
     restore();
     fetchStub = stub(window, 'fetch');
+    // Default any unstubbed fetches to an empty result so auto-refresh
+    // triggered by store changes doesn't throw (each test that needs a
+    // specific payload overrides via callsFake/resolves).
+    fetchStub.callsFake(
+      async () =>
+        new Response(JSON.stringify({ results: [] }), { status: 200 })
+    );
     // Initialize without 'flow' attribute to prevent firstUpdated from calling getStore().getState()
     element = await fixture(
       html`<temba-flow-editor-revisions></temba-flow-editor-revisions>`

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -2,7 +2,6 @@ import { html, fixture, expect } from '@open-wc/testing';
 import { Editor } from '../src/flow/Editor';
 import { IssuesWindow } from '../src/flow/IssuesWindow';
 import { RevisionsWindow } from '../src/flow/RevisionsWindow';
-import { zustand } from '../src/store/AppState';
 import { stub, restore, SinonStub } from 'sinon';
 
 customElements.define('temba-flow-editor-revisions', Editor);
@@ -40,11 +39,6 @@ describe('Editor Revisions', () => {
 
   afterEach(() => {
     restore();
-    // Reset shared zustand state so tests in other files start fresh.
-    zustand.setState({
-      viewingRevision: false,
-      flowDefinition: null as any
-    });
   });
 
   it('should include the current revision at the top of the list', async () => {
@@ -293,69 +287,30 @@ describe('Editor Revisions', () => {
     expect(revisions[2].changes.length).to.equal(1);
   });
 
-  it('refreshes the list when a new revision is saved while the window is open', async () => {
+  it('refresh() fetches the list when the window is open', async () => {
     fetchStub.callsFake(
       async () =>
         new Response(JSON.stringify({ results: [] }), { status: 200 })
     );
 
-    zustand.setState({
-      viewingRevision: false,
-      flowDefinition: { revision: 1, nodes: [] } as any
-    });
     (revisionsWindow as any).hidden = false;
     await revisionsWindow.updateComplete;
     fetchStub.resetHistory();
 
-    zustand.setState({
-      flowDefinition: { revision: 2, nodes: [] } as any
-    });
+    revisionsWindow.refresh();
     await revisionsWindow.updateComplete;
 
     expect(fetchStub.callCount).to.be.greaterThan(0);
   });
 
-  it('does not refresh when the revision number decreases (e.g., loading an older one)', async () => {
+  it('refresh() is a no-op when the window is hidden', async () => {
     fetchStub.callsFake(
       async () =>
         new Response(JSON.stringify({ results: [] }), { status: 200 })
     );
 
-    zustand.setState({
-      viewingRevision: false,
-      flowDefinition: { revision: 7, nodes: [] } as any
-    });
-    (revisionsWindow as any).hidden = false;
-    await revisionsWindow.updateComplete;
     fetchStub.resetHistory();
-
-    // revision number drops without viewingRevision flipping (e.g., a fetch race)
-    zustand.setState({
-      flowDefinition: { revision: 4, nodes: [] } as any
-    });
-    await revisionsWindow.updateComplete;
-
-    expect(fetchStub.callCount).to.equal(0);
-  });
-
-  it('does not refresh when previewing an older revision', async () => {
-    fetchStub.callsFake(
-      async () =>
-        new Response(JSON.stringify({ results: [] }), { status: 200 })
-    );
-
-    zustand.setState({
-      viewingRevision: false,
-      flowDefinition: { revision: 5, nodes: [] } as any
-    });
-    (revisionsWindow as any).hidden = false;
-    await revisionsWindow.updateComplete;
-    fetchStub.resetHistory();
-
-    zustand.setState({
-      viewingRevision: true,
-      flowDefinition: { revision: 3, nodes: [] } as any
-    });
+    revisionsWindow.refresh();
     await revisionsWindow.updateComplete;
 
     expect(fetchStub.callCount).to.equal(0);

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -188,6 +188,146 @@ describe('Editor Revisions', () => {
     expect(revisions[1].id).to.equal(1);
   });
 
+  it('breaks out into a new row when the next revision changes the author', async () => {
+    const ann = { id: 1, first_name: 'A', last_name: 'A', username: 'ann' };
+    const bob = { id: 2, first_name: 'B', last_name: 'B', username: 'bob' };
+    const mockRevisions = [
+      {
+        id: 3,
+        created_on: '2024-06-01T12:10:00Z',
+        user: ann,
+        changes: { tags: ['actions'] }
+      },
+      {
+        id: 2,
+        created_on: '2024-06-01T12:05:00Z',
+        user: bob,
+        changes: { tags: ['positions'] }
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T12:00:00Z',
+        user: bob,
+        changes: { tags: ['actions'] }
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    // Ann's row stands alone; Bob's two revisions merge.
+    expect(revisions.length).to.equal(2);
+    expect(revisions[0].id).to.equal(3);
+    expect(revisions[0].user.username).to.equal('ann');
+    expect(revisions[1].id).to.equal(2);
+    expect(revisions[1].user.username).to.equal('bob');
+    expect(revisions[1].changes.tags.sort()).to.deep.equal([
+      'actions',
+      'positions'
+    ]);
+  });
+
+  it('caps the merged label set at three and breaks out for a fourth', async () => {
+    const user = { id: 1, first_name: 'A', last_name: 'B', username: 'ab' };
+    const mockRevisions = [
+      // Same window, all by the same author. Three distinct labels merge,
+      // a fourth introduced by id 1 forces a break.
+      {
+        id: 4,
+        created_on: '2024-06-01T12:10:00Z',
+        user,
+        changes: { tags: ['metadata'] }
+      },
+      {
+        id: 3,
+        created_on: '2024-06-01T12:08:00Z',
+        user,
+        changes: { tags: ['actions'] }
+      },
+      {
+        id: 2,
+        created_on: '2024-06-01T12:06:00Z',
+        user,
+        changes: { tags: ['positions'] }
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T12:04:00Z',
+        user,
+        changes: { tags: ['stickies'] }
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(2);
+    expect(revisions[0].id).to.equal(4);
+    expect(revisions[0].changes.tags.sort()).to.deep.equal([
+      'actions',
+      'metadata',
+      'positions'
+    ]);
+    expect(revisions[1].id).to.equal(1);
+    expect(revisions[1].changes.tags).to.deep.equal(['stickies']);
+  });
+
+  it('still merges revisions whose tags collapse to fewer than three labels', async () => {
+    const user = { id: 1, first_name: 'A', last_name: 'B', username: 'ab' };
+    // Five raw localization tags, but they all collapse to one "translations"
+    // label, so the cap doesn't trip.
+    const mockRevisions = [
+      {
+        id: 5,
+        created_on: '2024-06-01T12:10:00Z',
+        user,
+        changes: { tags: ['localization:spa'] }
+      },
+      {
+        id: 4,
+        created_on: '2024-06-01T12:09:00Z',
+        user,
+        changes: { tags: ['localization:fra'] }
+      },
+      {
+        id: 3,
+        created_on: '2024-06-01T12:08:00Z',
+        user,
+        changes: { tags: ['localization:deu'] }
+      },
+      {
+        id: 2,
+        created_on: '2024-06-01T12:07:00Z',
+        user,
+        changes: { tags: ['localization:por'] }
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T12:06:00Z',
+        user,
+        changes: { tags: ['localization:ita'] }
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(1);
+    expect(revisions[0].id).to.equal(5);
+  });
+
   it('keeps the merged changes null when every revision in a window is null', async () => {
     const user = { id: 1, first_name: 'A', last_name: 'B', username: 'ab' };
     const mockRevisions = [

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -175,9 +175,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
   });
 
@@ -217,9 +215,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
 
     const toolbar = await getToolbar(editor);
@@ -263,9 +259,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
 
     // Switch to a non-base language
@@ -302,9 +296,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
 
     // Switch to a non-base language
@@ -525,9 +517,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
 
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -604,9 +594,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -676,9 +664,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -768,9 +754,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -858,9 +842,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -951,9 +933,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1056,9 +1036,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1134,9 +1112,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1220,9 +1196,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1356,9 +1330,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1539,9 +1511,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1642,9 +1612,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1730,9 +1698,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1820,9 +1786,7 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(
-      html`<temba-flow-editor></temba-flow-editor>`
-    );
+    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;

--- a/test/temba-localization.test.ts
+++ b/test/temba-localization.test.ts
@@ -175,7 +175,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
   });
 
@@ -215,7 +217,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
 
     const toolbar = await getToolbar(editor);
@@ -259,7 +263,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
 
     // Switch to a non-base language
@@ -296,7 +302,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
 
     // Switch to a non-base language
@@ -517,7 +525,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
 
     await selectLanguageInToolbar(editor, 'French', 'fra');
@@ -594,7 +604,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -664,7 +676,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -754,7 +768,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -842,7 +858,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -933,7 +951,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1036,7 +1056,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1112,7 +1134,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1196,7 +1220,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1330,7 +1356,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1511,7 +1539,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1612,7 +1642,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1698,7 +1730,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;
@@ -1786,7 +1820,9 @@ describe('Localization Editing', () => {
       }
     });
 
-    editor = await fixture(html`<temba-flow-editor></temba-flow-editor>`);
+    editor = await fixture(
+      html`<temba-flow-editor></temba-flow-editor>`
+    );
     await editor.updateComplete;
     await selectLanguageInToolbar(editor, 'French', 'fra');
     const at = editor.querySelector('temba-auto-translate') as any;

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -335,7 +335,7 @@ const wireScreenshots = async (page, context, wait, replaceScreenshots) => {
 
 export default {
   rootDir: './',
-  files: '**/test/**/*.test.ts',
+  files: ['**/test/**/*.test.ts', '!**/test/utils.test.ts'],
   nodeResolve: true,
   concurrency: 4,
   filterBrowserLogs(log) {


### PR DESCRIPTION
## Summary

Adds change summaries, time-based grouping, and a few UX polish bits to the
revisions window. Pairs with the rapidpro change that exposes a new
`changes: { tags: [...] } | null` field on each revision.

### Change summary on each row

A short natural-text description, built by mapping the server-side tag set to
displayed labels, sorted by category priority, joined naturally:

| Server tags | Displayed |
| --- | --- |
| `['layout']` | `Changed layout` |
| `['actions', 'layout']` | `Changed actions and layout` |
| `['metadata', 'actions', 'layout']` | `Changed metadata, actions, and layout` |
| `['localization:spa', 'localization:fra']` | `Changed translations` |
| `['actions', 'localization:spa', 'localization:fra']` | `Changed actions and translations` |
| `[]` (empty) | _(no description)_ |
| `null` (legacy / unknown) | _(no description)_ |

Multiple `localization:<lang>` tags collapse to one `translations` label so a
translator working on many languages still reads as a single category.

### Editing-session collapsing

Consecutive revisions are merged into one row when **all three** hold:

1. Within 15 minutes of the group's most recent member (`created_on`).
2. Same author (compared on `user.email`, falling back to `user.username` for
   non-API fixtures).
3. Adding the next revision keeps the merged label set ≤ 3 distinct labels.

Tags are union'd across the group onto the head's `changes.tags`. A window of
all-null revisions stays `null` rather than fabricating a tag set.

### Other UI polish

- Current revision is pinned to the top with a **Current** pill and is not
  revertable. The **Revert** pill — styled identically — replaces it on
  whichever non-current revision is selected. Row height stays constant
  whether a pill is rendered or not.
- Summary line shows above date · author. The date is no longer rendered as
  a heading.
- Window widened to 340 px and max-height lifted to 500 px.
- Revisions list refreshes automatically when a new revision is saved (the
  editor's `saveChanges` calls `revisionsWindow.refresh()` on success).

### CI fix

`test/utils.test.ts` is a shared helper file (no `describe()`/`it()` blocks,
just exported helpers and a top-level `before()` hook) that wtr was loading as
a zero-test session of its own. Adding any new test file pushed the suite past
the threshold where wtr silently exits before finishing the last batch.
Excluded the helper from the wtr `files` glob; the suite now runs
deterministically.

## Test plan

- [x] `pnpm test:fast` — full suite green; `revision-summary` and
      `temba-flow-editor-revisions` cover summary rendering, the email/name
      production user shape, the 3-label cap, the author-change break, the
      strict 15-minute boundary, the all-null window, and the
      localization-tag union.
- [x] `pnpm test:coverage` — green end-to-end (the `utils.test.ts` exclusion
      unblocked the run).
- [ ] In the editor: confirm summaries, the Current/Revert pills, the
      auto-refresh on save, and the editing-session collapsing.