### PR TITLE
Stabilize flaky screenshot and cookie tests

### DIFF
--- a/test/temba-simulator.test.ts
+++ b/test/temba-simulator.test.ts
@@ -41,9 +41,20 @@ const createSimulator = async (attrs: any = {}) => {
   return simulator;
 };
 
-// create simulator without overriding cookie-restored properties
-const createSimulatorRaw = async (attrs: any = {}) => {
+// create simulator without overriding cookie-restored properties.
+// `cookieValue` (when provided) is written to the simulator cookie immediately
+// before the fixture is created, so it can't be clobbered by anything that
+// happens during the async loadStore() above (e.g. a stray updated() from a
+// previous test's element).
+const createSimulatorRaw = async (
+  attrs: any = {},
+  cookieValue?: string
+) => {
   await loadStore();
+
+  if (cookieValue !== undefined) {
+    setCookie('simulator', cookieValue);
+  }
 
   const defaults = {
     flow: FLOW_UUID,
@@ -1241,47 +1252,41 @@ describe('temba-simulator', () => {
     });
 
     it('restores settings from simulator cookie', async () => {
-      setCookie(
-        'simulator',
+      const simulator = await createSimulatorRaw(
+        {},
         JSON.stringify({
           size: 'large',
           following: false,
           contextExplorerOpen: true
         })
       );
-
-      const simulator = await createSimulatorRaw();
       expect(simulator.size).to.equal('large');
       expect((simulator as any).following).to.equal(false);
       expect((simulator as any).contextExplorerOpen).to.equal(true);
     });
 
     it('ignores invalid size values from cookie', async () => {
-      setCookie(
-        'simulator',
+      const simulator = await createSimulatorRaw(
+        {},
         JSON.stringify({
           size: 'gigantic',
           following: true,
           contextExplorerOpen: false
         })
       );
-
-      const simulator = await createSimulatorRaw();
       // should keep default since 'gigantic' is not a valid size
       expect(simulator.size).to.equal('small');
     });
 
     it('ignores non-boolean following/contextExplorerOpen values from cookie', async () => {
-      setCookie(
-        'simulator',
+      const simulator = await createSimulatorRaw(
+        {},
         JSON.stringify({
           size: 'medium',
           following: 'yes',
           contextExplorerOpen: 42
         })
       );
-
-      const simulator = await createSimulatorRaw();
       expect(simulator.size).to.equal('medium');
       // should keep defaults since values aren't booleans
       expect((simulator as any).following).to.equal(true);
@@ -1289,9 +1294,7 @@ describe('temba-simulator', () => {
     });
 
     it('saves settings to cookie when properties change', async () => {
-      setCookie('simulator', '{}');
-
-      const simulator = await createSimulatorRaw();
+      const simulator = await createSimulatorRaw({}, '{}');
       simulator.size = 'large';
       await simulator.updateComplete;
 
@@ -1300,8 +1303,7 @@ describe('temba-simulator', () => {
     });
 
     it('handles malformed cookie gracefully', async () => {
-      setCookie('simulator', 'not-valid-json{');
-      const simulator = await createSimulatorRaw();
+      const simulator = await createSimulatorRaw({}, 'not-valid-json{');
       // should use defaults without throwing
       expect(simulator.size).to.equal('small');
       expect((simulator as any).following).to.equal(true);

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -133,7 +133,9 @@ before(async () => {
   await setViewport({ width: 1920, height: 1080, deviceScaleFactor: 2 });
 
   // preload Roboto so layouts that depend on text width (e.g. slider's range
-  // labels) don't shift when the font finishes loading mid-test
+  // labels) don't shift when the font finishes loading mid-test. Only the
+  // weights declared in test-assets/style.css are loadable; other weights
+  // fall back to system fonts.
   if (document.fonts && (document.fonts as any).load) {
     await Promise.all([
       (document.fonts as any).load('300 1em Roboto'),

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -131,6 +131,16 @@ before(async () => {
   normalFetch = window.fetch;
   stub(window, 'fetch').callsFake(getResponse);
   await setViewport({ width: 1920, height: 1080, deviceScaleFactor: 2 });
+
+  // preload Roboto so layouts that depend on text width (e.g. slider's range
+  // labels) don't shift when the font finishes loading mid-test
+  if (document.fonts && (document.fonts as any).load) {
+    await Promise.all([
+      (document.fonts as any).load('300 1em Roboto'),
+      (document.fonts as any).load('400 1em Roboto'),
+      (document.fonts as any).load('500 1em Roboto')
+    ]);
+  }
 });
 
 after(() => {
@@ -251,6 +261,12 @@ export const assertScreenshot = async (
   const isCopilotEnvironment = (window as any).isCopilotEnvironment;
   const threshold = isCopilotEnvironment ? 1.0 : 0.2;
   const exclude: Clip[] = [];
+
+  // wait for web fonts to load so text-dependent layouts don't shift between
+  // standalone and full-suite runs (e.g. Roboto fallback vs loaded)
+  if (document.fonts && document.fonts.ready) {
+    await document.fonts.ready;
+  }
 
   try {
     await (window as any).matchPageSnapshot(

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -140,17 +140,13 @@ const checkScreenshot = async (filename, excluded, threshold) => {
   });
 };
 
+// clear out any past tests once per process — clearing per-page would race
+// with other concurrent pages that have already written test screenshots and
+// are about to read them back, causing intermittent ENOENT failures.
+rimraf.sync(path.resolve(SCREENSHOTS, DIFF));
+rimraf.sync(path.resolve(SCREENSHOTS, TEST));
+
 const wireScreenshots = async (page, context, wait, replaceScreenshots) => {
-  // clear out any past tests once per session — clearing per-page races with
-  // other concurrent pages that have already written test screenshots and are
-  // about to read them back, causing intermittent ENOENT failures.
-  if (!globalThis.__screenshotsCleared) {
-    const diffs = path.resolve(SCREENSHOTS, DIFF);
-    const tests = path.resolve(SCREENSHOTS, TEST);
-    rimraf.sync(diffs);
-    rimraf.sync(tests);
-    globalThis.__screenshotsCleared = true;
-  }
 
   await page.exposeFunction(
     'matchPageSnapshot',

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -141,12 +141,16 @@ const checkScreenshot = async (filename, excluded, threshold) => {
 };
 
 const wireScreenshots = async (page, context, wait, replaceScreenshots) => {
-  // clear out any past tests
-  const diffs = path.resolve(SCREENSHOTS, DIFF);
-  const tests = path.resolve(SCREENSHOTS, TEST);
-
-  rimraf.sync(diffs);
-  rimraf.sync(tests);
+  // clear out any past tests once per session — clearing per-page races with
+  // other concurrent pages that have already written test screenshots and are
+  // about to read them back, causing intermittent ENOENT failures.
+  if (!globalThis.__screenshotsCleared) {
+    const diffs = path.resolve(SCREENSHOTS, DIFF);
+    const tests = path.resolve(SCREENSHOTS, TEST);
+    rimraf.sync(diffs);
+    rimraf.sync(tests);
+    globalThis.__screenshotsCleared = true;
+  }
 
   await page.exposeFunction(
     'matchPageSnapshot',


### PR DESCRIPTION
## Summary

Fix three sources of intermittent test failures uncovered by repeated full-suite runs:

- **temba-slider** (consistent ~1px shift): Roboto wasn't loaded before the first text-dependent screenshot, so layout used fallback metrics. Preload Roboto in the global `before` hook and `await document.fonts.ready` before each screenshot.
- **temba-simulator cookie persistence** (rare): the test-body `setCookie` could be raced during the async `loadStore()` that runs inside `createSimulatorRaw`. Move `setCookie` inside the helper, after `loadStore()` and immediately before `fixture()`.
- **temba-list / temba-label / temba-lightbox ENOENT** (rare): per-page `rimraf` of `screenshots/test` was deleting in-flight screenshots from other concurrent pages (concurrency: 4). Clear once per session via a `globalThis` sentinel instead.

## Test plan
- [x] Slider standalone: 10/10 pass
- [x] Full suite (font fix only): 23/25 — caught the simulator and screenshot races
- [x] Full suite (all three fixes): 15/15 pass