### PR TITLE
Fix Firefox newline rendering and yank/paste handling in rich editor

### DIFF
--- a/src/display/Options.ts
+++ b/src/display/Options.ts
@@ -562,6 +562,14 @@ export class Options extends RapidElement {
       return;
     }
 
+    // Don't intercept keys when the popup isn't visible to the user. The
+    // element can still be in the layout tree (so offsetParent is non-null)
+    // while being hidden via opacity/pointer-events, in which case handling
+    // keys would steal them from the underlying input.
+    if (!this.block && !this.visible) {
+      return;
+    }
+
     // Only intercept keys when the event originated within our owning component.
     // Without this, any temba-options with populated options would swallow arrow
     // keys document-wide, breaking cursor movement in unrelated text editors.

--- a/src/excellent/caret-utils.ts
+++ b/src/excellent/caret-utils.ts
@@ -1,8 +1,14 @@
 // ---------------------------------------------------------------------------
-// Cursor management utilities for contenteditable
-// Newlines are represented as \n characters inside <span class="tok-newline">
-// elements, so they're handled as regular text by cursor utilities.
-// Browser-added <br> artifacts are ignored (treated as zero-length).
+// Cursor management utilities for contenteditable.
+//
+// The DOM produced by our renderer is a flat list of <span> tokens (newlines
+// are "\n" characters inside <span class="tok-newline">) plus an optional
+// trailing <br data-sentinel> that exists only so Firefox renders an empty
+// final line. Browser-inserted structures (e.g. from yank/paste) are also
+// possible: a bare <br> represents a real newline, and a <div> or <p> at the
+// editable's root level represents a line block. Both are translated to "\n"
+// when computing plain-text offsets so the rebuild after handleInput sees the
+// correct value.
 // ---------------------------------------------------------------------------
 
 /** Gets the Selection object, handling shadow DOM. */
@@ -14,20 +20,56 @@ export function getSelectionFromRoot(element: HTMLElement): Selection | null {
   return window.getSelection();
 }
 
-/** Returns the plain-text length of a DOM node. Ignores browser <br> artifacts. */
-function nodeTextLength(node: Node): number {
+function isSentinelBr(node: Node): boolean {
+  return (
+    node.nodeName === 'BR' &&
+    typeof (node as Element).hasAttribute === 'function' &&
+    (node as Element).hasAttribute('data-sentinel')
+  );
+}
+
+function isBlockElement(node: Node): boolean {
+  return node.nodeName === 'DIV' || node.nodeName === 'P';
+}
+
+/** Plain-text contribution of a node and its descendants. */
+function textOfNode(node: Node): string {
   if (node.nodeType === Node.TEXT_NODE) {
-    return node.textContent.length;
+    return node.textContent || '';
   }
-  // Ignore browser-added <br> artifacts
   if (node.nodeName === 'BR') {
-    return 0;
+    return isSentinelBr(node) ? '' : '\n';
   }
-  let len = 0;
-  for (const child of Array.from(node.childNodes)) {
-    len += nodeTextLength(child);
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return '';
   }
-  return len;
+  return textOfChildren(node);
+}
+
+/** Plain-text contribution of an element's children, with block-prefix \n. */
+function textOfChildren(parent: Node): string {
+  let text = '';
+  let hasContent = false;
+  for (const child of Array.from(parent.childNodes)) {
+    if (
+      child.nodeType === Node.ELEMENT_NODE &&
+      isBlockElement(child) &&
+      hasContent
+    ) {
+      text += '\n';
+    }
+    const piece = textOfNode(child);
+    text += piece;
+    if (piece.length > 0) {
+      hasContent = true;
+    }
+  }
+  return text;
+}
+
+/** Returns the plain-text length of a DOM node. */
+function nodeTextLength(node: Node): number {
+  return textOfNode(node).length;
 }
 
 /** Converts a DOM selection position (container + offset) to a plain-text offset. */
@@ -36,38 +78,70 @@ function domPositionToTextOffset(
   targetContainer: Node,
   targetOffset: number
 ): number {
-  let total = 0;
+  // Build the text from `root` up to (target, targetOffset) and return its
+  // length. This mirrors textOfChildren so block-prefix newlines and BR
+  // newlines are accounted for the same way when reading and writing.
+  let text = '';
+  let stopped = false;
 
-  const walk = (node: Node): boolean => {
+  const walk = (node: Node): void => {
+    if (stopped) return;
+
     if (node === targetContainer) {
       if (node.nodeType === Node.TEXT_NODE) {
-        total += targetOffset;
-      } else {
-        // offset is a child index
-        for (let i = 0; i < targetOffset && i < node.childNodes.length; i++) {
-          total += nodeTextLength(node.childNodes[i]);
+        text += (node.textContent || '').substring(0, targetOffset);
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const children = Array.from(node.childNodes);
+        let hasContent = false;
+        for (let i = 0; i < Math.min(targetOffset, children.length); i++) {
+          const child = children[i];
+          if (
+            child.nodeType === Node.ELEMENT_NODE &&
+            isBlockElement(child) &&
+            hasContent
+          ) {
+            text += '\n';
+          }
+          const piece = textOfNode(child);
+          text += piece;
+          if (piece.length > 0) hasContent = true;
         }
       }
-      return true; // found
+      stopped = true;
+      return;
     }
 
     if (node.nodeType === Node.TEXT_NODE) {
-      total += node.textContent.length;
-      return false;
+      text += node.textContent || '';
+      return;
     }
-    // Ignore browser-added <br> artifacts
     if (node.nodeName === 'BR') {
-      return false;
+      if (!isSentinelBr(node)) text += '\n';
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return;
     }
 
+    let hasContent = false;
     for (const child of Array.from(node.childNodes)) {
-      if (walk(child)) return true;
+      if (stopped) break;
+      if (
+        child.nodeType === Node.ELEMENT_NODE &&
+        isBlockElement(child) &&
+        hasContent
+      ) {
+        text += '\n';
+      }
+      walk(child);
+      if (stopped) break;
+      const piece = textOfNode(child);
+      if (piece.length > 0) hasContent = true;
     }
-    return false;
   };
 
   walk(root);
-  return total;
+  return text.length;
 }
 
 /** Converts a plain-text offset to a DOM position (node + offset). */
@@ -76,49 +150,98 @@ function textOffsetToDomPosition(
   targetOffset: number
 ): { node: Node; offset: number } | null {
   let remaining = targetOffset;
+  // Track the last text node passed through so we can fall back to its end
+  // when the offset sits past all text content.
+  let lastTextNode: Node | null = null;
+  let lastTextOffset = 0;
+  let result: { node: Node; offset: number } | null = null;
 
-  const walk = (node: Node): { node: Node; offset: number } | null => {
+  const walk = (node: Node, parent: Node | null): void => {
+    if (result !== null) return;
+
     if (node.nodeType === Node.TEXT_NODE) {
-      if (remaining <= node.textContent.length) {
-        return { node, offset: remaining };
+      const len = node.textContent.length;
+      // Use strict "<" so positions at the boundary between two text nodes
+      // resolve to the START of the next node rather than the END of the
+      // previous one. Firefox doesn't paint the caret reliably when it lands
+      // at the end of an inline span whose text is just "\n", but happily
+      // renders it at the start of the following node.
+      if (remaining < len) {
+        result = { node, offset: remaining };
+        return;
       }
-      remaining -= node.textContent.length;
-      return null;
-    }
-    // Ignore browser-added <br> artifacts
-    if (node.nodeName === 'BR') {
-      return null;
+      lastTextNode = node;
+      lastTextOffset = len;
+      remaining -= len;
+      return;
     }
 
-    for (const child of Array.from(node.childNodes)) {
-      const result = walk(child);
-      if (result) return result;
+    if (node.nodeName === 'BR') {
+      if (isSentinelBr(node)) return;
+      if (remaining === 0 && parent) {
+        const idx = Array.from(parent.childNodes).indexOf(node as ChildNode);
+        if (idx >= 0) {
+          result = { node: parent, offset: idx };
+          return;
+        }
+      }
+      remaining -= 1;
+      return;
     }
-    return null;
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
+
+    let hasContent = false;
+    for (const child of Array.from(node.childNodes)) {
+      if (result !== null) return;
+      if (
+        child.nodeType === Node.ELEMENT_NODE &&
+        isBlockElement(child) &&
+        hasContent
+      ) {
+        if (remaining === 0) {
+          const idx = Array.from(node.childNodes).indexOf(child as ChildNode);
+          if (idx >= 0) {
+            result = { node, offset: idx };
+            return;
+          }
+        }
+        remaining -= 1;
+      }
+      walk(child, node);
+      if (result !== null) return;
+      const piece = textOfNode(child);
+      if (piece.length > 0) hasContent = true;
+    }
   };
 
-  return walk(root);
+  walk(root, null);
+  if (result) return result;
+
+  if (remaining === 0) {
+    // Past all content. Prefer a position before the trailing <br> sentinel
+    // so the caret can render on the empty final line in Firefox.
+    const lastChild = root.lastChild;
+    if (lastChild && lastChild.nodeName === 'BR' && isSentinelBr(lastChild)) {
+      return { node: root, offset: root.childNodes.length - 1 };
+    }
+    if (lastTextNode) {
+      return { node: lastTextNode, offset: lastTextOffset };
+    }
+  }
+  return null;
 }
 
 /**
- * Extracts plain text from the contenteditable DOM by walking our span structure.
- * Ignores browser-added <br> artifacts. Our newlines are \n chars inside spans.
+ * Extracts plain text from the contenteditable DOM. Translates non-sentinel
+ * <br> elements to "\n" and inserts a "\n" before block-level (DIV/P) children
+ * that follow other content, so yank/paste-inserted DOM structures round-trip
+ * through handleInput correctly.
  */
 export function getTextFromEditableDiv(element: HTMLElement): string {
-  let text = '';
-  for (const child of Array.from(element.childNodes)) {
-    if (child.nodeType === Node.TEXT_NODE) {
-      text += child.textContent;
-    } else if (child.nodeType === Node.ELEMENT_NODE) {
-      // Skip browser-added <br> artifacts
-      if (child.nodeName === 'BR') {
-        continue;
-      }
-      // Recurse into spans and other elements
-      text += getTextFromEditableDiv(child as HTMLElement);
-    }
-  }
-  return text;
+  return textOfChildren(element);
 }
 
 /** Gets the caret (selection start) as a plain-text offset. */
@@ -171,3 +294,6 @@ export function setCaretRange(
   selection.removeAllRanges();
   selection.addRange(range);
 }
+
+// Test-only export for unit tests.
+export const _internal = { nodeTextLength };

--- a/src/excellent/caret-utils.ts
+++ b/src/excellent/caret-utils.ts
@@ -67,11 +67,6 @@ function textOfChildren(parent: Node): string {
   return text;
 }
 
-/** Returns the plain-text length of a DOM node. */
-function nodeTextLength(node: Node): number {
-  return textOfNode(node).length;
-}
-
 /** Converts a DOM selection position (container + offset) to a plain-text offset. */
 function domPositionToTextOffset(
   root: Node,
@@ -133,10 +128,10 @@ function domPositionToTextOffset(
       ) {
         text += '\n';
       }
+      const before = text.length;
       walk(child);
       if (stopped) break;
-      const piece = textOfNode(child);
-      if (piece.length > 0) hasContent = true;
+      if (text.length > before) hasContent = true;
     }
   };
 
@@ -210,10 +205,10 @@ function textOffsetToDomPosition(
         }
         remaining -= 1;
       }
+      const before = remaining;
       walk(child, node);
       if (result !== null) return;
-      const piece = textOfNode(child);
-      if (piece.length > 0) hasContent = true;
+      if (remaining < before) hasContent = true;
     }
   };
 
@@ -221,11 +216,16 @@ function textOffsetToDomPosition(
   if (result) return result;
 
   if (remaining === 0) {
-    // Past all content. Prefer a position before the trailing <br> sentinel
-    // so the caret can render on the empty final line in Firefox.
+    // Past all content. If the editor ends in a <br>, position relative to it
+    // so the caret renders on the empty trailing line in Firefox.
     const lastChild = root.lastChild;
-    if (lastChild && lastChild.nodeName === 'BR' && isSentinelBr(lastChild)) {
-      return { node: root, offset: root.childNodes.length - 1 };
+    if (lastChild && lastChild.nodeName === 'BR') {
+      // Sentinel: render before it. Non-sentinel (transient post-yank state):
+      // render after it so the caret sits on the empty line the BR produces.
+      const offset = isSentinelBr(lastChild)
+        ? root.childNodes.length - 1
+        : root.childNodes.length;
+      return { node: root, offset };
     }
     if (lastTextNode) {
       return { node: lastTextNode, offset: lastTextOffset };
@@ -295,5 +295,3 @@ export function setCaretRange(
   selection.addRange(range);
 }
 
-// Test-only export for unit tests.
-export const _internal = { nodeTextLength };

--- a/src/form/RichEditor.ts
+++ b/src/form/RichEditor.ts
@@ -97,6 +97,7 @@ export class RichEditor extends FieldElement {
         overflow-y: auto;
         min-height: var(--textarea-min-height, 100px);
         resize: none;
+        position: relative;
       }
 
       :host(:not([textarea])) {
@@ -119,6 +120,12 @@ export class RichEditor extends FieldElement {
         content: attr(data-placeholder);
         color: var(--color-placeholder, #999);
         pointer-events: none;
+        /* Take the placeholder out of flow so the caret sits at offset 0
+           visually, not after the placeholder text (Firefox honors flow
+           strictly here while Chrome happens to overlay the caret). */
+        position: absolute;
+        inset: 0;
+        padding: var(--temba-textinput-padding);
       }
 
       /* Token styles (shared) */
@@ -302,6 +309,11 @@ export class RichEditor extends FieldElement {
 
     if (this.disableCompletion) {
       div.textContent = text || '';
+      if (text && text.endsWith('\n')) {
+        const br = document.createElement('br');
+        br.setAttribute('data-sentinel', '');
+        div.appendChild(br);
+      }
       return;
     }
 
@@ -359,6 +371,15 @@ export class RichEditor extends FieldElement {
     // Ensure there's at least an empty text node for cursor placement
     if (!text || text === '') {
       div.appendChild(document.createTextNode(''));
+    } else if (text.endsWith('\n')) {
+      // A trailing "\n" text node is collapsed by Firefox in contenteditable,
+      // making the empty final line invisible. A sentinel <br> forces the
+      // line break to render. The data-sentinel attribute distinguishes it
+      // from browser-inserted <br>s (which represent real newlines and must
+      // be preserved by the caret/text utilities).
+      const br = document.createElement('br');
+      br.setAttribute('data-sentinel', '');
+      div.appendChild(br);
     }
   }
 

--- a/src/form/RichEditor.ts
+++ b/src/form/RichEditor.ts
@@ -125,7 +125,7 @@ export class RichEditor extends FieldElement {
            strictly here while Chrome happens to overlay the caret). */
         position: absolute;
         inset: 0;
-        padding: var(--temba-textinput-padding);
+        padding: inherit;
       }
 
       /* Token styles (shared) */

--- a/test/temba-rich-edit.test.ts
+++ b/test/temba-rich-edit.test.ts
@@ -262,4 +262,159 @@ describe('temba-rich-edit', () => {
       });
     }
   });
+
+  it('inserts a newline on Enter when options popup is not visible', async () => {
+    const editor = (await fixture(html`
+      <temba-rich-edit value="hello" textarea></temba-rich-edit>
+    `)) as any;
+    await editor.updateComplete;
+
+    const editableDiv = editor.shadowRoot.querySelector(
+      '.highlight-editor'
+    ) as HTMLDivElement;
+    editableDiv.focus();
+    (editableDiv as any).setSelectionRange(5, 5);
+
+    const evt = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      composed: true,
+      cancelable: true
+    });
+    editableDiv.dispatchEvent(evt);
+    await editor.updateComplete;
+
+    expect(editor.value).to.equal('hello\n');
+  });
+
+  it('renders a sentinel <br> for trailing newlines so they are visible', async () => {
+    const editor = (await fixture(html`
+      <temba-rich-edit value="hello\n" textarea></temba-rich-edit>
+    `)) as any;
+    await editor.updateComplete;
+
+    const editableDiv = editor.shadowRoot.querySelector(
+      '.highlight-editor'
+    ) as HTMLDivElement;
+
+    // The last child should be a <br> so Firefox renders the trailing newline.
+    expect(editableDiv.lastElementChild?.tagName).to.equal('BR');
+    // Round-tripping through the text extractor should still yield the value.
+    const text = (editableDiv as any).value;
+    expect(text).to.equal('hello\n');
+  });
+
+  it('does not add a sentinel <br> when text does not end in a newline', async () => {
+    const editor = (await fixture(html`
+      <temba-rich-edit value="hello" textarea></temba-rich-edit>
+    `)) as any;
+    await editor.updateComplete;
+
+    const editableDiv = editor.shadowRoot.querySelector(
+      '.highlight-editor'
+    ) as HTMLDivElement;
+    expect(editableDiv.lastElementChild?.tagName).to.not.equal('BR');
+  });
+
+  it('preserves newlines from yanked content with intermixed <br> elements', async () => {
+    const editor = (await fixture(html`
+      <temba-rich-edit value="" textarea></temba-rich-edit>
+    `)) as any;
+    await editor.updateComplete;
+
+    const editableDiv = editor.shadowRoot.querySelector(
+      '.highlight-editor'
+    ) as HTMLDivElement;
+
+    // Simulate the DOM Chrome leaves behind after yanking multi-line text:
+    // text nodes separated by browser <br> elements (no data-sentinel attr).
+    editableDiv.textContent = '';
+    editableDiv.appendChild(document.createTextNode('line1'));
+    editableDiv.appendChild(document.createElement('br'));
+    editableDiv.appendChild(document.createTextNode('line2'));
+    editableDiv.appendChild(document.createElement('br'));
+    editableDiv.appendChild(document.createTextNode('line3'));
+
+    editableDiv.dispatchEvent(new Event('input', { bubbles: true }));
+    await editor.updateComplete;
+
+    expect(editor.value).to.equal('line1\nline2\nline3');
+  });
+
+  it('preserves newlines from yanked content split into <div> blocks', async () => {
+    const editor = (await fixture(html`
+      <temba-rich-edit value="" textarea></temba-rich-edit>
+    `)) as any;
+    await editor.updateComplete;
+
+    const editableDiv = editor.shadowRoot.querySelector(
+      '.highlight-editor'
+    ) as HTMLDivElement;
+
+    // Chrome sometimes wraps yanked lines into <div> blocks.
+    editableDiv.textContent = '';
+    editableDiv.appendChild(document.createTextNode('line1'));
+    const div2 = document.createElement('div');
+    div2.textContent = 'line2';
+    editableDiv.appendChild(div2);
+    const div3 = document.createElement('div');
+    div3.textContent = 'line3';
+    editableDiv.appendChild(div3);
+
+    editableDiv.dispatchEvent(new Event('input', { bubbles: true }));
+    await editor.updateComplete;
+
+    expect(editor.value).to.equal('line1\nline2\nline3');
+  });
+
+  it('still ignores the trailing data-sentinel <br> when reading the value', async () => {
+    const editor = (await fixture(html`
+      <temba-rich-edit value="hello\n" textarea></temba-rich-edit>
+    `)) as any;
+    await editor.updateComplete;
+
+    const editableDiv = editor.shadowRoot.querySelector(
+      '.highlight-editor'
+    ) as HTMLDivElement;
+    const lastChild = editableDiv.lastElementChild;
+    expect(lastChild?.tagName).to.equal('BR');
+    expect(lastChild?.hasAttribute('data-sentinel')).to.equal(true);
+
+    // The sentinel must not contribute an extra "\n" when round-tripping.
+    expect((editableDiv as any).value).to.equal('hello\n');
+  });
+
+  it('does not consume Enter when options array is populated but popup is not visible', async () => {
+    const editor = (await fixture(html`
+      <temba-rich-edit value="hello" textarea></temba-rich-edit>
+    `)) as any;
+    await editor.updateComplete;
+
+    const optionsEl = editor.shadowRoot.querySelector('temba-options') as any;
+    // Force the temba-options into the inconsistent state: populated options
+    // but not visible. Setting via the element directly bypasses the parent
+    // re-render that would normally tie these together.
+    optionsEl.options = [{ name: 'contact.name' }];
+    optionsEl.visible = false;
+    await optionsEl.updateComplete;
+
+    const editableDiv = editor.shadowRoot.querySelector(
+      '.highlight-editor'
+    ) as HTMLDivElement;
+    editableDiv.focus();
+    (editableDiv as any).setSelectionRange(5, 5);
+
+    const evt = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      composed: true,
+      cancelable: true
+    });
+    editableDiv.dispatchEvent(evt);
+    await editor.updateComplete;
+
+    // Enter should reach the editor and insert a newline rather than being
+    // swallowed by the hidden popup.
+    expect(editor.value).to.equal('hello\n');
+  });
 });


### PR DESCRIPTION
## Summary

- Trailing newlines now render in Firefox via a `data-sentinel` `<br>`, and the caret is placed at the parent level adjacent to it so Firefox actually paints the cursor on the empty final line.
- The empty-state placeholder is positioned absolutely so the caret sits at offset 0 instead of after the placeholder text.
- DOM-to-text walkers now translate non-sentinel `<br>` and top-level `<div>`/`<p>` children into newlines, so kill+yank round-trips multi-line content through `handleInput` correctly in Chrome.
- `Options` document-level keydown handler bails out when the popup is hidden, preventing a stale-but-invisible options array from swallowing keys.

## Test plan
- [x] `pnpm test:fast` (1763 passing)
- [ ] Manual: edit a Send Message action in Firefox; Enter inserts a newline on the first press, caret renders on the new line, placeholder appears at the start
- [ ] Manual: in Chrome on macOS, Ctrl+K across multiple lines then Ctrl+Y preserves the newlines