### PR TITLE
Render system-generated revisions with a 'System update' label

### DIFF
--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -151,7 +151,7 @@ export class RevisionsWindow extends RapidElement {
                             value=${rev.created_on}
                             display="duration"
                           ></temba-date>
-                          · ${rev.user.name || rev.user.username}
+                          · ${this.renderUser(rev.user)}
                         </div>
                         ${isCurrent
                           ? html`<div
@@ -191,6 +191,13 @@ export class RevisionsWindow extends RapidElement {
   }
 
   // --- Private ---
+
+  private renderUser(user: Revision['user']): TemplateResult | string {
+    if (user?.email === 'system') {
+      return html`<em>System update</em>`;
+    }
+    return user?.name || user?.username || '';
+  }
 
   private async fetchRevisions() {
     const requestId = ++this.fetchRequestId;
@@ -262,10 +269,7 @@ export class RevisionsWindow extends RapidElement {
       const headId = head.user?.email ?? head.user?.username;
       const revId = rev.user?.email ?? rev.user?.username;
       const sameAuthor = headId === revId;
-      const prospective = new Set([
-        ...groupLabels,
-        ...labelsFor(rev.changes)
-      ]);
+      const prospective = new Set([...groupLabels, ...labelsFor(rev.changes)]);
       const fitsLabelCap = prospective.size <= MAX_GROUP_LABELS;
 
       if (withinWindow && sameAuthor && fitsLabelCap) {

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -24,8 +24,7 @@ describe('Editor Revisions', () => {
     // triggered by store changes doesn't throw (each test that needs a
     // specific payload overrides via callsFake/resolves).
     fetchStub.callsFake(
-      async () =>
-        new Response(JSON.stringify({ results: [] }), { status: 200 })
+      async () => new Response(JSON.stringify({ results: [] }), { status: 200 })
     );
     // Initialize without 'flow' attribute to prevent firstUpdated from calling getStore().getState()
     element = await fixture(
@@ -397,8 +396,7 @@ describe('Editor Revisions', () => {
 
   it('refresh() fetches the list when the window is open', async () => {
     fetchStub.callsFake(
-      async () =>
-        new Response(JSON.stringify({ results: [] }), { status: 200 })
+      async () => new Response(JSON.stringify({ results: [] }), { status: 200 })
     );
 
     (revisionsWindow as any).hidden = false;
@@ -413,8 +411,7 @@ describe('Editor Revisions', () => {
 
   it('refresh() is a no-op when the window is hidden', async () => {
     fetchStub.callsFake(
-      async () =>
-        new Response(JSON.stringify({ results: [] }), { status: 200 })
+      async () => new Response(JSON.stringify({ results: [] }), { status: 200 })
     );
 
     fetchStub.resetHistory();
@@ -466,6 +463,37 @@ describe('Editor Revisions', () => {
     // Second item is not current and has no current label
     expect(items[1].classList.contains('current')).to.be.false;
     expect(items[1].querySelector('.current-label')).to.not.exist;
+  });
+
+  it('renders system-generated revisions with a "System update" label', async () => {
+    (element as any).revisionsWindowHidden = false;
+    await element.requestUpdate();
+
+    const mockRevisions = [
+      {
+        id: 2,
+        created_on: '2023-01-02',
+        user: { email: 'adam@example.com', name: 'Adam' }
+      },
+      {
+        id: 1,
+        created_on: '2023-01-01',
+        user: { email: 'system', name: '' }
+      }
+    ];
+    (revisionsWindow as any).revisions = mockRevisions;
+    await revisionsWindow.updateComplete;
+
+    const items = revisionsWindow.shadowRoot?.querySelectorAll(
+      '.revision-item'
+    ) as NodeListOf<HTMLElement>;
+    expect(items.length).to.equal(2);
+
+    expect(items[0].textContent).to.contain('Adam');
+    const systemMeta = items[1].querySelector('.revision-meta');
+    expect(systemMeta?.querySelector('em')?.textContent).to.equal(
+      'System update'
+    );
   });
 
   it('should have purple color for revisions window and blue for selected item', async () => {


### PR DESCRIPTION
## Summary

Revisions whose user is the system user (`email: "system"`, empty name) previously rendered as empty text in the revisions list. This adds a `renderUser()` helper that detects the system user and displays an italic "System update" label instead. Adds a test covering the new rendering.