### PR TITLE
Treat spec-only and empty-tag revisions as no-ops in the revision browser

### DIFF
--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -301,7 +301,12 @@ export class RevisionsWindow extends RapidElement {
         bypassBarriers || headTime - revTime < GROUP_WINDOW_MS;
       const sameAuthor = bypassBarriers || headId === revId;
       const prospective = new Set([...groupLabels, ...labelsFor(rev.changes)]);
-      const fitsLabelCap = prospective.size <= MAX_GROUP_LABELS;
+      // When a no-op-only chain is reaching forward to absorb its first real
+      // edit, we have to ignore the label cap too — otherwise a sweeping
+      // edit (4+ label areas) would still flush the no-op group alone with
+      // an empty summary, the exact case bypassBarriers is meant to prevent.
+      const fitsLabelCap =
+        !groupHasRealChange || prospective.size <= MAX_GROUP_LABELS;
 
       if (withinWindow && sameAuthor && fitsLabelCap) {
         group.push(rev);

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -301,12 +301,16 @@ export class RevisionsWindow extends RapidElement {
         bypassBarriers || headTime - revTime < GROUP_WINDOW_MS;
       const sameAuthor = bypassBarriers || headId === revId;
       const prospective = new Set([...groupLabels, ...labelsFor(rev.changes)]);
-      // When a no-op-only chain is reaching forward to absorb its first real
-      // edit, we have to ignore the label cap too — otherwise a sweeping
-      // edit (4+ label areas) would still flush the no-op group alone with
-      // an empty summary, the exact case bypassBarriers is meant to prevent.
+      // The label cap is meaningful only when adding a real change to a
+      // group that already has one. A no-op contributes zero labels by
+      // construction, so it never trips the cap; and a no-op-only chain
+      // reaching forward to absorb its first real edit must ignore the cap
+      // too, or a sweeping edit (4+ label areas) would still strand the
+      // no-op group as an empty-summary row.
       const fitsLabelCap =
-        !groupHasRealChange || prospective.size <= MAX_GROUP_LABELS;
+        isNoOp ||
+        !groupHasRealChange ||
+        prospective.size <= MAX_GROUP_LABELS;
 
       if (withinWindow && sameAuthor && fitsLabelCap) {
         group.push(rev);

--- a/src/flow/RevisionsWindow.ts
+++ b/src/flow/RevisionsWindow.ts
@@ -9,6 +9,7 @@ import { fetchResults } from '../utils';
 import { FLOW_SPEC_VERSION } from '../store/AppState';
 import {
   labelsFor,
+  normalizeChanges,
   RevisionChanges,
   summarizeChanges
 } from './revision-summary';
@@ -224,19 +225,36 @@ export class RevisionsWindow extends RapidElement {
   // the window. The merged revision is capped at three distinct displayed
   // labels — once a fourth would be introduced we break out into a new row.
   private collapseRevisions(revisions: Revision[]): Revision[] {
+    // Normalize at the boundary so the rest of the logic reasons about real
+    // edits only. After this step, `changes === null` is the single signal
+    // for "no-op" — used both for the author-barrier bypass and for keeping
+    // housekeeping tags out of the merged tag set and label cap.
+    const cleaned = revisions.map((r) => ({
+      ...r,
+      changes: normalizeChanges(r.changes)
+    }));
     // The API returns newest-first today; sort defensively so the head/window
     // logic stays correct if that ever changes.
-    const sorted = [...revisions].sort(
+    const sorted = [...cleaned].sort(
       (a, b) =>
         new Date(b.created_on).getTime() - new Date(a.created_on).getTime()
     );
     const result: Revision[] = [];
     let group: Revision[] = [];
     let groupLabels = new Set<string>();
+    let groupHasRealChange = false;
 
     const flush = () => {
       if (group.length === 0) return;
       const head = group[0];
+      // Pick the user from the most recent real-change revision in the
+      // group. No-op authors (typically the system, doing spec bumps)
+      // shouldn't appear as the editor when a real user's edit was
+      // absorbed into the row — that would mislabel the change as
+      // "System update" even though a real person did the work. Fall back
+      // to the head if every revision was a no-op.
+      const realChange = group.find((r) => r.changes);
+      const displayUser = realChange?.user ?? head.user;
       const tagSet = new Set<string>();
       let anyKnown = false;
       for (const r of group) {
@@ -247,38 +265,53 @@ export class RevisionsWindow extends RapidElement {
       }
       result.push({
         ...head,
+        user: displayUser,
         changes: anyKnown ? { tags: Array.from(tagSet) } : null
       });
       group = [];
       groupLabels = new Set();
+      groupHasRealChange = false;
     };
 
     for (const rev of sorted) {
       if (group.length === 0) {
         group.push(rev);
         groupLabels = labelsFor(rev.changes);
+        groupHasRealChange = !!rev.changes;
         continue;
       }
       const head = group[0];
       const headTime = new Date(head.created_on).getTime();
       const revTime = new Date(rev.created_on).getTime();
-      const withinWindow = headTime - revTime < GROUP_WINDOW_MS;
       // Compare on whichever identifier the server provides — real data
       // arrives with `email`, while test fixtures use `username`. Falling
       // back through the chain keeps both shapes working.
       const headId = head.user?.email ?? head.user?.username;
       const revId = rev.user?.email ?? rev.user?.username;
-      const sameAuthor = headId === revId;
+      // Two conditions bypass the time/author barriers:
+      //   1. The incoming rev is itself a no-op — it carries no editorial
+      //      intent and should disappear into whichever group it neighbors.
+      //   2. The group hasn't accumulated a real change yet — we never want
+      //      to surface a row showing "nothing changed", so a no-op-only
+      //      chain reaches forward to absorb the first real edit even if
+      //      that edit is far away in time or by a different author.
+      const isNoOp = !rev.changes;
+      const bypassBarriers = isNoOp || !groupHasRealChange;
+      const withinWindow =
+        bypassBarriers || headTime - revTime < GROUP_WINDOW_MS;
+      const sameAuthor = bypassBarriers || headId === revId;
       const prospective = new Set([...groupLabels, ...labelsFor(rev.changes)]);
       const fitsLabelCap = prospective.size <= MAX_GROUP_LABELS;
 
       if (withinWindow && sameAuthor && fitsLabelCap) {
         group.push(rev);
         groupLabels = prospective;
+        if (!isNoOp) groupHasRealChange = true;
       } else {
         flush();
         group.push(rev);
         groupLabels = labelsFor(rev.changes);
+        groupHasRealChange = !!rev.changes;
       }
     }
     flush();

--- a/src/flow/revision-summary.ts
+++ b/src/flow/revision-summary.ts
@@ -2,6 +2,23 @@ export interface RevisionChanges {
   tags: string[];
 }
 
+// "spec" is the housekeeping tag the system attaches when it bumps a flow's
+// spec version. It carries no editorial intent, so we strip it at the
+// boundary — every downstream consumer (summaries, label caps, no-op
+// detection) then operates on a clean tag set without needing special cases.
+const NOOP_TAGS = new Set(['spec']);
+
+// Drop tags that don't represent real edits and collapse to null when nothing
+// meaningful remains. Returning null lets `isNoOpChanges` and the collapse
+// logic treat empty-after-filtering and originally-null the same way.
+export function normalizeChanges(
+  changes: RevisionChanges | null | undefined
+): RevisionChanges | null {
+  if (!changes) return null;
+  const tags = (changes.tags || []).filter((t) => !NOOP_TAGS.has(t));
+  return tags.length === 0 ? null : { tags };
+}
+
 const TAG_LABELS: Record<string, { label: string; order: number }> = {
   metadata: { label: 'metadata', order: 0 },
   nodes: { label: 'nodes', order: 1 },
@@ -30,6 +47,14 @@ export function labelsFor(
     if (entry) result.add(entry.label);
   }
   return result;
+}
+
+// A revision is a no-op when, after stripping housekeeping tags, nothing
+// meaningful is left. These shouldn't break up adjacent edits in the browser.
+export function isNoOpChanges(
+  changes: RevisionChanges | null | undefined
+): boolean {
+  return normalizeChanges(changes) === null;
 }
 
 export function summarizeChanges(

--- a/test/revision-summary.test.ts
+++ b/test/revision-summary.test.ts
@@ -1,5 +1,9 @@
 import { expect } from '@open-wc/testing';
-import { summarizeChanges } from '../src/flow/revision-summary';
+import {
+  isNoOpChanges,
+  normalizeChanges,
+  summarizeChanges
+} from '../src/flow/revision-summary';
 
 describe('summarizeChanges', () => {
   it('returns empty string for null/undefined/empty tags', () => {
@@ -61,5 +65,52 @@ describe('summarizeChanges', () => {
     );
     // an entirely unknown set yields nothing
     expect(summarizeChanges({ tags: ['something_new'] })).to.equal('');
+  });
+
+  it('never surfaces the "spec" tag in a summary', () => {
+    expect(summarizeChanges({ tags: ['spec'] })).to.equal('');
+    expect(summarizeChanges({ tags: ['spec', 'actions'] })).to.equal(
+      'Changed actions'
+    );
+  });
+});
+
+describe('normalizeChanges', () => {
+  it('returns null for null/undefined/empty inputs', () => {
+    expect(normalizeChanges(null)).to.equal(null);
+    expect(normalizeChanges(undefined)).to.equal(null);
+    expect(normalizeChanges({ tags: [] })).to.equal(null);
+  });
+
+  it('strips the "spec" housekeeping tag', () => {
+    expect(normalizeChanges({ tags: ['spec'] })).to.equal(null);
+    expect(normalizeChanges({ tags: ['spec', 'actions'] })).to.deep.equal({
+      tags: ['actions']
+    });
+  });
+
+  it('leaves real tags untouched', () => {
+    expect(normalizeChanges({ tags: ['actions', 'layout'] })).to.deep.equal({
+      tags: ['actions', 'layout']
+    });
+  });
+});
+
+describe('isNoOpChanges', () => {
+  it('treats null/undefined and empty tag lists as no-ops', () => {
+    expect(isNoOpChanges(null)).to.equal(true);
+    expect(isNoOpChanges(undefined)).to.equal(true);
+    expect(isNoOpChanges({ tags: [] })).to.equal(true);
+  });
+
+  it('treats spec-only tag lists as no-ops', () => {
+    expect(isNoOpChanges({ tags: ['spec'] })).to.equal(true);
+    expect(isNoOpChanges({ tags: ['spec', 'spec'] })).to.equal(true);
+  });
+
+  it('treats anything beyond "spec" as a real change', () => {
+    expect(isNoOpChanges({ tags: ['spec', 'actions'] })).to.equal(false);
+    expect(isNoOpChanges({ tags: ['actions'] })).to.equal(false);
+    expect(isNoOpChanges({ tags: ['localization:spa'] })).to.equal(false);
   });
 });

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -525,6 +525,46 @@ describe('Editor Revisions', () => {
     ]);
   });
 
+  it('still folds in a trailing no-op even when the head already exceeds the label cap', async () => {
+    // The very first rev of a group bypasses the cap, so a sweeping edit
+    // can land as the head with `groupLabels.size > MAX_GROUP_LABELS`. A
+    // no-op landing right behind it contributes zero labels and shouldn't
+    // be stranded by a cap check that no longer makes sense.
+    const eric = { email: 'eric@textit.com', name: 'Eric' };
+    const system = { email: 'system', name: '' };
+    const mockRevisions = [
+      {
+        id: 2,
+        created_on: '2024-06-01T12:10:00Z',
+        user: eric,
+        changes: { tags: ['metadata', 'nodes', 'routing', 'actions'] }
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T12:08:00Z',
+        user: system,
+        changes: { tags: ['spec'] }
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(1);
+    expect(revisions[0].id).to.equal(2);
+    expect(revisions[0].user.email).to.equal('eric@textit.com');
+    expect(revisions[0].changes.tags.sort()).to.deep.equal([
+      'actions',
+      'metadata',
+      'nodes',
+      'routing'
+    ]);
+  });
+
   it('stops absorbing after the first real change is pulled in', async () => {
     // Once a no-op chain has reached forward to grab a real edit, normal
     // barriers resume — a second far-away real edit should NOT be swept up.

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -478,6 +478,53 @@ describe('Editor Revisions', () => {
     expect(revisions[0].changes.tags).to.deep.equal(['layout']);
   });
 
+  it('absorbs the first real change even when it would exceed the label cap on its own', async () => {
+    // A sweeping edit can touch 4+ distinct label areas in a single
+    // revision. If we enforced the label cap while a no-op-only chain
+    // was reaching forward to grab its first real change, the merge
+    // would fail and the no-op group would flush alone with no summary
+    // — the empty-row case the absorb-forward rule exists to avoid.
+    const system = { email: 'system', name: '' };
+    const eric = { email: 'eric@textit.com', name: 'Eric' };
+    const mockRevisions = [
+      {
+        id: 3,
+        created_on: '2026-03-19T00:00:00Z',
+        user: system,
+        changes: { tags: [] }
+      },
+      {
+        id: 2,
+        created_on: '2025-01-01T00:00:00Z',
+        user: system,
+        changes: { tags: ['spec'] }
+      },
+      {
+        id: 1,
+        created_on: '2024-01-01T00:00:00Z',
+        user: eric,
+        changes: { tags: ['metadata', 'nodes', 'routing', 'actions'] }
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(1);
+    expect(revisions[0].id).to.equal(3);
+    expect(revisions[0].user.email).to.equal('eric@textit.com');
+    expect(revisions[0].changes.tags.sort()).to.deep.equal([
+      'actions',
+      'metadata',
+      'nodes',
+      'routing'
+    ]);
+  });
+
   it('stops absorbing after the first real change is pulled in', async () => {
     // Once a no-op chain has reached forward to grab a real edit, normal
     // barriers resume — a second far-away real edit should NOT be swept up.

--- a/test/temba-flow-editor-revisions.test.ts
+++ b/test/temba-flow-editor-revisions.test.ts
@@ -41,21 +41,25 @@ describe('Editor Revisions', () => {
   });
 
   it('should include the current revision at the top of the list', async () => {
+    const user = { id: 1, first_name: 'A', last_name: 'B', username: 'ab' };
     const mockRevisions = [
       {
         id: 3,
         created_on: '2023-01-03',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' }
+        user,
+        changes: { tags: ['actions'] }
       },
       {
         id: 2,
         created_on: '2023-01-02',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' }
+        user,
+        changes: { tags: ['layout'] }
       },
       {
         id: 1,
         created_on: '2023-01-01',
-        user: { id: 1, first_name: 'A', last_name: 'B', username: 'ab' }
+        user,
+        changes: { tags: ['metadata'] }
       }
     ];
 
@@ -363,6 +367,203 @@ describe('Editor Revisions', () => {
     const revisions = (revisionsWindow as any).revisions;
     expect(revisions.length).to.equal(1);
     expect(revisions[0].id).to.equal(5);
+  });
+
+  it('collapses a system spec-only revision into adjacent edits despite a different author', async () => {
+    // The system bumps the spec version on its own behalf, which would
+    // normally fragment a real user's run of edits because the author
+    // differs. No-op revisions (empty tags or only "spec") should bypass
+    // that author barrier so the row reflects the user's actual session.
+    const adam = { email: 'adam@example.com', name: 'Adam McAdmin' };
+    const system = { email: 'system', name: 'System' };
+    const mockRevisions = [
+      {
+        id: 4,
+        created_on: '2024-06-01T12:10:00Z',
+        user: adam,
+        changes: { tags: ['actions'] }
+      },
+      {
+        id: 3,
+        created_on: '2024-06-01T12:08:00Z',
+        user: system,
+        changes: { tags: ['spec'] }
+      },
+      {
+        id: 2,
+        created_on: '2024-06-01T12:06:00Z',
+        user: adam,
+        changes: { tags: ['layout'] }
+      },
+      {
+        id: 1,
+        created_on: '2024-06-01T12:04:00Z',
+        user: system,
+        changes: null
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(1);
+    expect(revisions[0].id).to.equal(4);
+    expect(revisions[0].user.email).to.equal('adam@example.com');
+    // "spec" is stripped at the normalization boundary, so the merged tag
+    // set only carries the real edits.
+    expect(revisions[0].changes.tags.sort()).to.deep.equal([
+      'actions',
+      'layout'
+    ]);
+  });
+
+  it('absorbs a long chain of no-op revisions plus the next real change into one row', async () => {
+    // System spec bumps land months or years apart and carry no editorial
+    // intent. A chain of them should fold into a single row — and that row
+    // must reach forward to swallow the first real edit too, otherwise we'd
+    // present the user a revision where nothing actually changed.
+    const system = { email: 'system', name: '' };
+    const eric = { email: 'eric@textit.com', name: 'Gustavo Fring' };
+    const mockRevisions = [
+      {
+        id: 1253,
+        created_on: '2026-03-19T19:47:41Z',
+        user: system,
+        changes: { tags: [] }
+      },
+      {
+        id: 1254,
+        created_on: '2025-04-29T22:03:54Z',
+        user: system,
+        changes: { tags: [] }
+      },
+      {
+        id: 1255,
+        created_on: '2025-04-22T21:14:42Z',
+        user: system,
+        changes: { tags: ['spec'] }
+      },
+      {
+        id: 1256,
+        created_on: '2024-12-11T18:39:58Z',
+        user: system,
+        changes: { tags: [] }
+      },
+      {
+        id: 1261,
+        created_on: '2023-02-10T18:32:44Z',
+        user: eric,
+        changes: { tags: ['layout'] }
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(1);
+    // The id/created_on stay anchored to the newest revision so the row
+    // sits at the correct point in time, but the displayed user is eric —
+    // the system no-ops shouldn't claim authorship of his layout edit.
+    expect(revisions[0].id).to.equal(1253);
+    expect(revisions[0].created_on).to.equal('2026-03-19T19:47:41Z');
+    expect(revisions[0].user.email).to.equal('eric@textit.com');
+    expect(revisions[0].changes.tags).to.deep.equal(['layout']);
+  });
+
+  it('stops absorbing after the first real change is pulled in', async () => {
+    // Once a no-op chain has reached forward to grab a real edit, normal
+    // barriers resume — a second far-away real edit should NOT be swept up.
+    const system = { email: 'system', name: '' };
+    const eric = { email: 'eric@textit.com', name: 'Eric' };
+    const ann = { email: 'ann@example.com', name: 'Ann' };
+    const mockRevisions = [
+      {
+        id: 4,
+        created_on: '2026-03-19T00:00:00Z',
+        user: system,
+        changes: { tags: [] }
+      },
+      {
+        id: 3,
+        created_on: '2025-01-01T00:00:00Z',
+        user: system,
+        changes: { tags: ['spec'] }
+      },
+      {
+        id: 2,
+        created_on: '2024-01-01T00:00:00Z',
+        user: eric,
+        changes: { tags: ['layout'] }
+      },
+      {
+        id: 1,
+        created_on: '2023-01-01T00:00:00Z',
+        user: ann,
+        changes: { tags: ['actions'] }
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(2);
+    expect(revisions[0].id).to.equal(4);
+    expect(revisions[0].changes.tags).to.deep.equal(['layout']);
+    expect(revisions[1].id).to.equal(1);
+    expect(revisions[1].changes.tags).to.deep.equal(['actions']);
+  });
+
+  it('does not count the "spec" tag toward the label cap when collapsing', async () => {
+    // Three real labels plus a "spec" tag would naively look like four —
+    // but spec is stripped at normalization, so the cap should still allow
+    // these to merge into one row.
+    const user = { id: 1, first_name: 'A', last_name: 'B', username: 'ab' };
+    const mockRevisions = [
+      {
+        id: 4,
+        created_on: '2024-06-01T12:10:00Z',
+        user,
+        changes: { tags: ['metadata', 'spec'] }
+      },
+      {
+        id: 3,
+        created_on: '2024-06-01T12:08:00Z',
+        user,
+        changes: { tags: ['actions'] }
+      },
+      {
+        id: 2,
+        created_on: '2024-06-01T12:06:00Z',
+        user,
+        changes: { tags: ['layout'] }
+      }
+    ];
+
+    fetchStub.resolves(
+      new Response(JSON.stringify({ results: mockRevisions }), { status: 200 })
+    );
+
+    await (revisionsWindow as any).fetchRevisions();
+
+    const revisions = (revisionsWindow as any).revisions;
+    expect(revisions.length).to.equal(1);
+    expect(revisions[0].changes.tags.sort()).to.deep.equal([
+      'actions',
+      'layout',
+      'metadata'
+    ]);
   });
 
   it('keeps the merged changes null when every revision in a window is null', async () => {


### PR DESCRIPTION
## Summary
Make the revision browser ignore housekeeping revisions (system spec bumps and other empty-tag entries) when collapsing rows, so a flow's history reads as the user's actual editing sessions instead of one row per system event.

## Changes

### `src/flow/revision-summary.ts`
- New `normalizeChanges()` strips the `spec` housekeeping tag at a single boundary and collapses to `null` when nothing meaningful remains. Downstream consumers (summaries, label cap, no-op detection) all operate on clean data — no scattered special-cases.
- New `isNoOpChanges()` is a one-liner over `normalizeChanges`.

### `src/flow/RevisionsWindow.ts`
- `collapseRevisions` now normalizes incoming revisions once at the top, so `changes === null` becomes the single signal for "no editorial intent".
- Two bypass conditions skip the time-window, author, and label-cap barriers:
  1. The incoming rev is a no-op — folds into whichever group it touches.
  2. The group hasn't yet accumulated a real change — reaches forward to absorb the first real edit so we never render a row showing "nothing changed".
- `fitsLabelCap` is also bypassed when the incoming rev is a no-op (it contributes zero labels by construction, so the cap is meaningless).
- `flush()` picks the displayed `user` from the most recent real-change rev in the group, falling back to the head only when every rev was a no-op. The row's `id`/`created_on` still come from the head, so the row anchors to the newest position in time without misattributing the work.

### Tests
- New `normalizeChanges` and `isNoOpChanges` cases, plus confirmation that the `spec` tag never surfaces in summaries.
- New collapse cases: system no-op crossing an author barrier; long no-op chain absorbing the next real edit; absorb-then-stop after the first real change; spec-tag not counting toward label cap; sweeping 4-label edit absorbed across barriers; trailing no-op after a sweeping head edit.
- One pre-existing ordering test was given real `changes` so it doesn't accidentally collapse under the new rules.

## Behavior examples

| Input revisions | Before | After |
| --- | --- | --- |
| 8 system spec bumps spanning 2 years, then eric's `layout` edit | 9 rows (one per spec bump + the edit) | 1 row: "eric · 3y ago · Changed layout" |
| adam's `actions` → system `spec` → adam's `layout` (within 15 min) | 3 rows (system breaks adam's session) | 1 row: "adam · Changed actions and layout" |
| eric's sweeping `metadata, nodes, routing, actions` edit + a system spec bump right behind it | 2 rows (label cap fragments the spec bump) | 1 row: "eric · Changed …" |

## Test plan
- [x] `pnpm test:fast --files test/revision-summary.test.ts --files test/temba-flow-editor-revisions.test.ts` (36 passing)
- [x] CI green on PR #1003 (build, review, CLA)
- [x] Both auto-review threads addressed and resolved