### PR TITLE
Use full name for chat avatar initials to match user select and ticket lists

### DIFF
--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -67,6 +67,8 @@ export interface ObjectReference {
 interface User extends ObjectReference {
   avatar?: string;
   email: string;
+  first_name?: string;
+  last_name?: string;
 }
 
 export interface Msg {
@@ -1262,6 +1264,8 @@ export class Chat extends RapidElement {
               <temba-user
                 uuid=${currentMsg._user?.uuid}
                 name=${name}
+                first_name=${currentMsg._user?.first_name}
+                last_name=${currentMsg._user?.last_name}
                 avatar=${currentMsg._user?.avatar}
                 ?system=${isSystem}
               >

--- a/src/display/TembaUser.ts
+++ b/src/display/TembaUser.ts
@@ -11,7 +11,10 @@ export const getFullName = (user: {
   first_name?: string;
   last_name?: string;
 }) => {
-  return user.name || [user.first_name, user.last_name].join(' ');
+  if (user.first_name || user.last_name) {
+    return [user.first_name, user.last_name].filter(Boolean).join(' ');
+  }
+  return user.name || '';
 };
 
 export class TembaUser extends RapidElement {
@@ -60,6 +63,12 @@ export class TembaUser extends RapidElement {
   name: string;
 
   @property({ type: String })
+  first_name: string;
+
+  @property({ type: String })
+  last_name: string;
+
+  @property({ type: String })
   email: string;
 
   @property({ type: String })
@@ -75,10 +84,19 @@ export class TembaUser extends RapidElement {
       this.bgimage = `url('${DEFAULT_AVATAR}') center / contain no-repeat`;
     }
 
-    if (changed.has('name')) {
-      if (this.name) {
-        this.bgcolor = colorHash.hex(this.name);
-        this.initials = extractInitials(this.name);
+    if (
+      changed.has('name') ||
+      changed.has('first_name') ||
+      changed.has('last_name')
+    ) {
+      const fullName = getFullName({
+        name: this.name,
+        first_name: this.first_name,
+        last_name: this.last_name
+      });
+      if (fullName) {
+        this.bgcolor = colorHash.hex(fullName);
+        this.initials = extractInitials(fullName);
       } else {
         this.bgcolor = '#e6e6e6';
         this.initials = '';

--- a/test/temba-user.test.ts
+++ b/test/temba-user.test.ts
@@ -56,9 +56,9 @@ describe('temba-user', () => {
 });
 
 describe('getFullName', () => {
-  it('prefers name over first/last', () => {
+  it('prefers first/last over name', () => {
     assert.equal(
-      getFullName({ name: 'Jane Doe', first_name: 'x', last_name: 'y' }),
+      getFullName({ name: 'Jane', first_name: 'Jane', last_name: 'Doe' }),
       'Jane Doe'
     );
   });
@@ -68,5 +68,13 @@ describe('getFullName', () => {
       getFullName({ first_name: 'Jane', last_name: 'Doe' }),
       'Jane Doe'
     );
+  });
+
+  it('falls back to name when first/last are missing', () => {
+    assert.equal(getFullName({ name: 'System' }), 'System');
+  });
+
+  it('handles missing last_name', () => {
+    assert.equal(getFullName({ first_name: 'Jane' }), 'Jane');
   });
 });


### PR DESCRIPTION
## Summary
- `<temba-user>` now accepts `first_name`/`last_name` props and uses the full name (preferred over `name`) when computing avatar initials and the color hash.
- `Chat.ts` passes `_user.first_name`/`_user.last_name` from chat events through to the avatar, while still rendering the short `name` as the bubble label.
- Fixes the inconsistency where the ticket chat showed "AD" for Adam McAdmin while the assignment dropdown and ticket lists showed "AM".

## Pairing
Depends on the rapidpro change to include `first_name`/`last_name` in `User.as_chat_ref()`. Until that ships, this falls back gracefully to the existing `name`-only behavior.

## Test plan
- [x] `pnpm test:fast` — 1779 passed
- [x] Updated `getFullName` tests in `test/temba-user.test.ts`