### PR TITLE
Stop pill clicks inside CanvasNodes from also opening the action editor

### DIFF
--- a/src/flow/CanvasNode.ts
+++ b/src/flow/CanvasNode.ts
@@ -219,11 +219,16 @@ export class CanvasNode extends RapidElement {
         background: repeating-linear-gradient(120deg, tomato, tomato 6px, #ff7056 0, #ff7056 18px) !important;
       }
 
-      /* Disable links on actions/nodes with issues */
+      /* Disable links on actions/nodes with issues so clicks fall through
+         to open the editor instead of navigating. */
       .action-content.has-issues .linked-name div,
       .node.has-issues > .router .linked-name div {
         text-decoration: none !important;
         cursor: default !important;
+        pointer-events: none;
+      }
+      .action-content.has-issues .linked-pill,
+      .node.has-issues > .router .linked-pill {
         pointer-events: none;
       }
 
@@ -1094,13 +1099,16 @@ export class CanvasNode extends RapidElement {
   }
 
   /**
-   * Returns true if the click target is inside a `.linked-name` that is
-   * still active (i.e. the containing action/node has no issues).
-   * When an action/node has issues, links are visually disabled and clicks
-   * should fall through to open the editor instead.
+   * Returns true if the click target is inside a `.linked-name` or
+   * `.linked-pill` whose containing action/node has no issues. Active
+   * links handle their own navigation, so click-vs-drag and node-edit
+   * handlers bail out on them. When the action/node has issues, links are
+   * visually disabled (see CSS) and clicks fall through to open the
+   * editor instead.
    */
   private isActiveLink(target: HTMLElement, action?: Action): boolean {
-    if (!target.closest('.linked-name')) return false;
+    if (!target.closest('.linked-name') && !target.closest('.linked-pill'))
+      return false;
     if (action) return !this.issuesByAction?.has(action.uuid);
     return !(
       this.issuesByNode?.has(this.node.uuid) ||
@@ -1116,7 +1124,6 @@ export class CanvasNode extends RapidElement {
     if (
       target.closest('.remove-button') ||
       target.closest('.drag-handle') ||
-      target.closest('.linked-pill') ||
       this.isActiveLink(target, action) ||
       this.actionRemovingState.has(action.uuid)
     ) {
@@ -1145,7 +1152,6 @@ export class CanvasNode extends RapidElement {
     if (
       target.closest('.remove-button') ||
       target.closest('.drag-handle') ||
-      target.closest('.linked-pill') ||
       this.isActiveLink(target, action) ||
       this.actionRemovingState.has(action.uuid)
     ) {
@@ -1194,7 +1200,6 @@ export class CanvasNode extends RapidElement {
     if (
       target.closest('.remove-button') ||
       target.closest('.drag-handle') ||
-      target.closest('.linked-pill') ||
       this.isActiveLink(target, action) ||
       this.actionRemovingState.has(action.uuid)
     ) {
@@ -1221,7 +1226,6 @@ export class CanvasNode extends RapidElement {
     if (
       target.closest('.remove-button') ||
       target.closest('.drag-handle') ||
-      target.closest('.linked-pill') ||
       this.isActiveLink(target, action) ||
       this.actionRemovingState.has(action.uuid)
     ) {
@@ -1322,7 +1326,6 @@ export class CanvasNode extends RapidElement {
       target.closest('.exit') ||
       target.closest('.exit-wrapper') ||
       target.closest('.drag-handle') ||
-      target.closest('.linked-pill') ||
       this.isActiveLink(target) ||
       this.actionRemovingState.has(this.node.uuid)
     ) {
@@ -1350,7 +1353,6 @@ export class CanvasNode extends RapidElement {
       target.closest('.exit') ||
       target.closest('.exit-wrapper') ||
       target.closest('.drag-handle') ||
-      target.closest('.linked-pill') ||
       this.isActiveLink(target) ||
       this.actionRemovingState.has(this.node.uuid)
     ) {
@@ -1412,7 +1414,6 @@ export class CanvasNode extends RapidElement {
       target.closest('.exit') ||
       target.closest('.exit-wrapper') ||
       target.closest('.drag-handle') ||
-      target.closest('.linked-pill') ||
       this.isActiveLink(target) ||
       this.actionRemovingState.has(this.node.uuid)
     ) {
@@ -1438,7 +1439,6 @@ export class CanvasNode extends RapidElement {
       target.closest('.exit') ||
       target.closest('.exit-wrapper') ||
       target.closest('.drag-handle') ||
-      target.closest('.linked-pill') ||
       this.isActiveLink(target) ||
       this.actionRemovingState.has(this.node.uuid)
     ) {

--- a/src/flow/CanvasNode.ts
+++ b/src/flow/CanvasNode.ts
@@ -1116,6 +1116,7 @@ export class CanvasNode extends RapidElement {
     if (
       target.closest('.remove-button') ||
       target.closest('.drag-handle') ||
+      target.closest('.linked-pill') ||
       this.isActiveLink(target, action) ||
       this.actionRemovingState.has(action.uuid)
     ) {
@@ -1144,6 +1145,7 @@ export class CanvasNode extends RapidElement {
     if (
       target.closest('.remove-button') ||
       target.closest('.drag-handle') ||
+      target.closest('.linked-pill') ||
       this.isActiveLink(target, action) ||
       this.actionRemovingState.has(action.uuid)
     ) {
@@ -1192,6 +1194,7 @@ export class CanvasNode extends RapidElement {
     if (
       target.closest('.remove-button') ||
       target.closest('.drag-handle') ||
+      target.closest('.linked-pill') ||
       this.isActiveLink(target, action) ||
       this.actionRemovingState.has(action.uuid)
     ) {
@@ -1218,6 +1221,7 @@ export class CanvasNode extends RapidElement {
     if (
       target.closest('.remove-button') ||
       target.closest('.drag-handle') ||
+      target.closest('.linked-pill') ||
       this.isActiveLink(target, action) ||
       this.actionRemovingState.has(action.uuid)
     ) {
@@ -1318,6 +1322,7 @@ export class CanvasNode extends RapidElement {
       target.closest('.exit') ||
       target.closest('.exit-wrapper') ||
       target.closest('.drag-handle') ||
+      target.closest('.linked-pill') ||
       this.isActiveLink(target) ||
       this.actionRemovingState.has(this.node.uuid)
     ) {
@@ -1345,6 +1350,7 @@ export class CanvasNode extends RapidElement {
       target.closest('.exit') ||
       target.closest('.exit-wrapper') ||
       target.closest('.drag-handle') ||
+      target.closest('.linked-pill') ||
       this.isActiveLink(target) ||
       this.actionRemovingState.has(this.node.uuid)
     ) {
@@ -1406,6 +1412,7 @@ export class CanvasNode extends RapidElement {
       target.closest('.exit') ||
       target.closest('.exit-wrapper') ||
       target.closest('.drag-handle') ||
+      target.closest('.linked-pill') ||
       this.isActiveLink(target) ||
       this.actionRemovingState.has(this.node.uuid)
     ) {
@@ -1431,6 +1438,7 @@ export class CanvasNode extends RapidElement {
       target.closest('.exit') ||
       target.closest('.exit-wrapper') ||
       target.closest('.drag-handle') ||
+      target.closest('.linked-pill') ||
       this.isActiveLink(target) ||
       this.actionRemovingState.has(this.node.uuid)
     ) {

--- a/src/flow/DragManager.ts
+++ b/src/flow/DragManager.ts
@@ -127,7 +127,8 @@ export class DragManager {
     if (
       target.classList.contains('exit') ||
       target.closest('.exit') ||
-      target.closest('.linked-name')
+      target.closest('.linked-name') ||
+      target.closest('.linked-pill')
     ) {
       return;
     }
@@ -186,7 +187,8 @@ export class DragManager {
     if (
       target.classList.contains('exit') ||
       target.closest('.exit') ||
-      target.closest('.linked-name')
+      target.closest('.linked-name') ||
+      target.closest('.linked-pill')
     ) {
       return;
     }

--- a/src/flow/utils.ts
+++ b/src/flow/utils.ts
@@ -386,6 +386,7 @@ const renderLinkedObject = (
 
   const pillType = iconToPillType(icon);
   return html`<temba-label
+    class="linked-pill"
     icon=${icon || ''}
     type=${pillType || 'neutral'}
     clickable

--- a/test/temba-action-editing-integration.test.ts
+++ b/test/temba-action-editing-integration.test.ts
@@ -1,6 +1,6 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import { CanvasNode } from '../src/flow/CanvasNode';
-import { SendMsg, Node } from '../src/store/flow-definition';
+import { AddToGroup, SendMsg, Node } from '../src/store/flow-definition';
 import { CustomEventType } from '../src/interfaces';
 import '../temba-modules';
 
@@ -236,5 +236,61 @@ describe('Action Editing Integration', () => {
       testNode.actions[0]
     );
     expect(editRequestedEvent!.detail.nodeUuid).to.equal('test-node');
+  });
+
+  it('clicking a linked pill navigates without opening the action editor', async () => {
+    // Action that renders groups as clickable pills (.linked-pill).
+    const testNode: Node = {
+      uuid: 'test-node',
+      actions: [
+        {
+          type: 'add_contact_groups',
+          uuid: 'test-action',
+          groups: [{ uuid: 'group-1', name: 'Customers' }]
+        } as AddToGroup
+      ],
+      exits: []
+    };
+
+    const editorNode: CanvasNode = await fixture(html`
+      <temba-flow-node
+        .node=${testNode}
+        .ui=${{ position: { left: 0, top: 0 } }}
+      ></temba-flow-node>
+    `);
+
+    await editorNode.updateComplete;
+
+    let editRequestedEvent: CustomEvent | null = null;
+    editorNode.addEventListener(
+      CustomEventType.ActionEditRequested,
+      (event: CustomEvent) => {
+        editRequestedEvent = event;
+      }
+    );
+
+    const pill = editorNode.querySelector('.linked-pill') as HTMLElement;
+    expect(pill, 'pill should be rendered for add_contact_groups action').to
+      .exist;
+
+    // Real click on the pill: mousedown then mouseup at the same position,
+    // bubbling up through the action element. The action's mousedown/mouseup
+    // handlers must bail out so they don't queue an ActionEditRequested —
+    // otherwise a pill click would both navigate AND open the action editor.
+    pill.dispatchEvent(
+      new MouseEvent('mousedown', {
+        clientX: 100,
+        clientY: 100,
+        bubbles: true
+      })
+    );
+    pill.dispatchEvent(
+      new MouseEvent('mouseup', { clientX: 100, clientY: 100, bubbles: true })
+    );
+
+    expect(
+      editRequestedEvent,
+      'ActionEditRequested must not fire for pill clicks'
+    ).to.be.null;
   });
 });

--- a/test/temba-action-editing-integration.test.ts
+++ b/test/temba-action-editing-integration.test.ts
@@ -1,6 +1,12 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import { CanvasNode } from '../src/flow/CanvasNode';
-import { AddToGroup, SendMsg, Node } from '../src/store/flow-definition';
+import { DragManager } from '../src/flow/DragManager';
+import {
+  AddToGroup,
+  EnterFlow,
+  SendMsg,
+  Node
+} from '../src/store/flow-definition';
 import { CustomEventType } from '../src/interfaces';
 import '../temba-modules';
 
@@ -292,5 +298,141 @@ describe('Action Editing Integration', () => {
       editRequestedEvent,
       'ActionEditRequested must not fire for pill clicks'
     ).to.be.null;
+
+    // Independently verify the pill's own @click handler is wired and runs.
+    // The handler calls preventDefault, so defaultPrevented tells us it
+    // executed even though there is no temba-flow-editor ancestor in this
+    // fixture to receive the actual navigation event.
+    const clickEvent = new MouseEvent('click', {
+      cancelable: true,
+      bubbles: true
+    });
+    pill.dispatchEvent(clickEvent);
+    expect(
+      clickEvent.defaultPrevented,
+      'pill @click handler must fire to drive navigation'
+    ).to.be.true;
+  });
+
+  it('clicking a linked pill in a router node does not open the node editor', async () => {
+    // split_by_subflow renders the flow link as a clickable pill inside the
+    // router section. That pill bubbles to handleNodeMouseDown / MouseUp,
+    // which must bail via isActiveLink.
+    const testNode: Node = {
+      uuid: 'subflow-node',
+      actions: [
+        {
+          type: 'enter_flow',
+          uuid: 'enter-action',
+          flow: { uuid: 'flow-1', name: 'Onboarding' }
+        } as EnterFlow
+      ],
+      router: { type: 'switch', categories: [] } as any,
+      exits: []
+    };
+
+    const editorNode: CanvasNode = await fixture(html`
+      <temba-flow-node
+        .node=${testNode}
+        .ui=${{ position: { left: 0, top: 0 }, type: 'split_by_subflow' }}
+      ></temba-flow-node>
+    `);
+    await editorNode.updateComplete;
+
+    let nodeEditRequested: CustomEvent | null = null;
+    let actionEditRequested: CustomEvent | null = null;
+    editorNode.addEventListener(
+      CustomEventType.NodeEditRequested,
+      (e: CustomEvent) => {
+        nodeEditRequested = e;
+      }
+    );
+    editorNode.addEventListener(
+      CustomEventType.ActionEditRequested,
+      (e: CustomEvent) => {
+        actionEditRequested = e;
+      }
+    );
+
+    const pill = editorNode.querySelector('.linked-pill') as HTMLElement;
+    expect(pill, 'flow pill should render inside the router section').to.exist;
+
+    pill.dispatchEvent(
+      new MouseEvent('mousedown', { clientX: 50, clientY: 50, bubbles: true })
+    );
+    pill.dispatchEvent(
+      new MouseEvent('mouseup', { clientX: 50, clientY: 50, bubbles: true })
+    );
+
+    expect(nodeEditRequested, 'NodeEditRequested must not fire for pill clicks')
+      .to.be.null;
+    expect(
+      actionEditRequested,
+      'ActionEditRequested must not fire for pill clicks'
+    ).to.be.null;
+  });
+
+  it('DragManager.handleMouseDown bails out when target is a linked pill', () => {
+    // Direct unit test for DragManager — clicking on a pill must not begin
+    // a node drag, just like clicking on .exit or .linked-name.
+    const fakeEditor: any = {
+      isReadOnly: () => false,
+      blurActiveContentEditable: () => {},
+      selectedItems: new Set<string>(),
+      currentDragItem: null,
+      definition: {
+        _ui: {
+          nodes: { 'node-1': { position: { left: 0, top: 0 } } },
+          stickies: {}
+        }
+      },
+      querySelector: () => null
+    };
+    const dm = new DragManager(fakeEditor);
+
+    const nodeEl = document.createElement('temba-flow-node');
+    nodeEl.setAttribute('uuid', 'node-1');
+    const pill = document.createElement('temba-label');
+    pill.classList.add('linked-pill');
+    nodeEl.appendChild(pill);
+    document.body.appendChild(nodeEl);
+
+    try {
+      nodeEl.addEventListener('mousedown', (e) => dm.handleMouseDown(e));
+      pill.dispatchEvent(
+        new MouseEvent('mousedown', {
+          clientX: 5,
+          clientY: 5,
+          bubbles: true
+        })
+      );
+      expect(
+        fakeEditor.currentDragItem,
+        'pill mousedown must not set currentDragItem'
+      ).to.be.null;
+      expect(
+        fakeEditor.selectedItems.size,
+        'pill mousedown must not mutate selectedItems'
+      ).to.equal(0);
+
+      // Sanity check: a mousedown on a non-pill region of the same node
+      // still initiates the drag, so the assertion above isn't trivially
+      // true for the wrong reason.
+      const plainTarget = document.createElement('div');
+      nodeEl.appendChild(plainTarget);
+      plainTarget.dispatchEvent(
+        new MouseEvent('mousedown', {
+          clientX: 5,
+          clientY: 5,
+          bubbles: true
+        })
+      );
+      expect(
+        fakeEditor.currentDragItem,
+        'mousedown outside a pill should begin a drag'
+      ).to.not.be.null;
+    } finally {
+      document.body.removeChild(nodeEl);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Pills rendered inside actions (groups, flows, contacts) fire `@click` to navigate, but the action's `mousedown`/`mouseup` click-vs-drag handlers ran first and queued an `ActionEditRequested`. Result: clicking a pill both navigated **and** popped the action editor.
- Tagged the pill `temba-label` with `.linked-pill` and mirrored the existing `.linked-name` bail-out in `handleAction*` and `handleNode*` mouse/touch handlers plus `DragManager.handleMouseDown` / `handleItemTouchStart`.

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm test:fast` — 1785 pass, 1 pre-existing flaky screenshot test (`temba-message-editor`) unrelated to this change; passes in isolation
- [x] New test `clicking a linked pill navigates without opening the action editor` in `temba-action-editing-integration.test.ts` locks in the bail-out
- [ ] Manual smoke: in a flow, click a group/flow/contact pill on an action — should navigate without opening the action editor; clicking the action body still opens the editor; dragging the node still works