### PR TITLE
Only run Claude code review once on PR creation

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,9 +1,10 @@
 name: Code Review
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened]
 jobs:
   review:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Narrow the `Code Review` workflow trigger so the Claude review runs once at PR creation instead of on every push. Draft PRs are skipped.

## Changes

- `.github/workflows/review.yml` — change `pull_request` types from `[opened, synchronize, reopened, ready_for_review]` to `[opened]`, and add `if: github.event.pull_request.draft == false` to the job so draft PRs don't trigger a review.

## Review notes

Pre-PR review surfaced two points, both intentionally not addressed:

- 🟡 Removing `ready_for_review` means PRs opened as drafts and later marked ready won't get an automated review. This is the intended behavior — the goal is exactly one review per PR at creation time.
- 💡 No manual re-trigger mechanism (e.g. `workflow_dispatch` or `/review` comment). Out of scope for this change.

## Test plan

- [x] `pnpm test` passes (1789/1789)
- [x] `pnpm format` clean
- [x] `pnpm build` succeeds
- [ ] Opening this PR exercises the new trigger — review should fire exactly once on `opened`
- [ ] Pushing additional commits to this branch should *not* re-trigger the review