### PR TITLE
Split resthook nodes on @webhook.status, matching split_by_webhook

### DIFF
--- a/src/flow/nodes/split_by_resthook.ts
+++ b/src/flow/nodes/split_by_resthook.ts
@@ -87,10 +87,10 @@ export const split_by_resthook: NodeConfig = {
     const existingCases = originalNode.router?.cases || [];
 
     const { router, exits } = createSuccessFailureRouter(
-      '@webhook.json.status',
+      '@webhook.status',
       {
-        type: 'has_text',
-        arguments: []
+        type: 'has_number_between',
+        arguments: ['200', '299']
       },
       existingCategories,
       existingExits,

--- a/test/nodes/split_by_resthook.test.ts
+++ b/test/nodes/split_by_resthook.test.ts
@@ -226,6 +226,78 @@ describe('temba-split-by-resthook', () => {
     expect(resultNode.exits![1].destination_uuid).to.equal('another-node-uuid');
   });
 
+  it('should normalise legacy @webhook.json.status nodes on re-save', () => {
+    const originalNode: Node = {
+      uuid: 'test-node-uuid',
+      actions: [
+        {
+          type: 'call_resthook',
+          uuid: 'existing-action-uuid',
+          resthook: 'new-registration'
+        } as CallResthook
+      ],
+      router: {
+        type: 'switch',
+        cases: [
+          {
+            uuid: 'existing-case-uuid',
+            type: 'has_text',
+            arguments: [],
+            category_uuid: 'existing-success-uuid'
+          }
+        ],
+        categories: [
+          {
+            uuid: 'existing-success-uuid',
+            name: 'Success',
+            exit_uuid: 'existing-success-exit-uuid'
+          },
+          {
+            uuid: 'existing-failure-uuid',
+            name: 'Failure',
+            exit_uuid: 'existing-failure-exit-uuid'
+          }
+        ],
+        default_category_uuid: 'existing-failure-uuid',
+        operand: '@webhook.json.status'
+      },
+      exits: [
+        { uuid: 'existing-success-exit-uuid', destination_uuid: null },
+        { uuid: 'existing-failure-exit-uuid', destination_uuid: null }
+      ]
+    };
+
+    const formData = {
+      uuid: 'test-node-uuid',
+      resthook: [{ resthook: 'new-registration' }],
+      result_name: ''
+    };
+
+    const resultNode = split_by_resthook.fromFormData!(formData, originalNode);
+
+    // operand and case should be normalised to the canonical shape
+    expect(resultNode.router!.operand).to.equal('@webhook.status');
+    expect(resultNode.router!.cases).to.have.lengthOf(1);
+    expect(resultNode.router!.cases![0].type).to.equal('has_number_between');
+    expect(resultNode.router!.cases![0].arguments).to.deep.equal(['200', '299']);
+
+    // case, category, and exit UUIDs should be preserved across the rewrite
+    expect(resultNode.router!.cases![0].uuid).to.equal('existing-case-uuid');
+    expect(resultNode.router!.cases![0].category_uuid).to.equal(
+      'existing-success-uuid'
+    );
+    const successCategory = resultNode.router!.categories!.find(
+      (cat) => cat.name === 'Success'
+    );
+    const failureCategory = resultNode.router!.categories!.find(
+      (cat) => cat.name === 'Failure'
+    );
+    expect(successCategory!.uuid).to.equal('existing-success-uuid');
+    expect(successCategory!.exit_uuid).to.equal('existing-success-exit-uuid');
+    expect(failureCategory!.uuid).to.equal('existing-failure-uuid');
+    expect(failureCategory!.exit_uuid).to.equal('existing-failure-exit-uuid');
+  });
+
   it('should handle changing resthook while preserving structure', () => {
     const originalNode: Node = {
       uuid: 'test-node-uuid',

--- a/test/nodes/split_by_resthook.test.ts
+++ b/test/nodes/split_by_resthook.test.ts
@@ -18,8 +18,8 @@ describe('temba-split-by-resthook', () => {
         cases: [
           {
             uuid: 'case-1',
-            type: 'has_text',
-            arguments: [],
+            type: 'has_number_between',
+            arguments: ['200', '299'],
             category_uuid: 'cat-success'
           }
         ],
@@ -28,7 +28,7 @@ describe('temba-split-by-resthook', () => {
           { uuid: 'cat-failure', name: 'Failure', exit_uuid: 'exit-failure' }
         ],
         default_category_uuid: 'cat-failure',
-        operand: '@webhook.json.status'
+        operand: '@webhook.status'
       },
       exits: [
         { uuid: 'exit-success', destination_uuid: null },
@@ -61,8 +61,8 @@ describe('temba-split-by-resthook', () => {
         cases: [
           {
             uuid: 'case-1',
-            type: 'has_text',
-            arguments: [],
+            type: 'has_number_between',
+            arguments: ['200', '299'],
             category_uuid: 'cat-success'
           }
         ],
@@ -72,7 +72,7 @@ describe('temba-split-by-resthook', () => {
         ],
         result_name: 'payment_status',
         default_category_uuid: 'cat-failure',
-        operand: '@webhook.json.status'
+        operand: '@webhook.status'
       },
       exits: [
         { uuid: 'exit-success', destination_uuid: null },
@@ -110,7 +110,7 @@ describe('temba-split-by-resthook', () => {
     expect(action.type).to.equal('call_resthook');
 
     expect(resultNode.router!.type).to.equal('switch');
-    expect(resultNode.router!.operand).to.equal('@webhook.json.status');
+    expect(resultNode.router!.operand).to.equal('@webhook.status');
     expect(resultNode.router!.categories).to.have.lengthOf(2); // Success + Failure
     expect(resultNode.exits).to.have.lengthOf(2); // Success + Failure
 
@@ -172,8 +172,8 @@ describe('temba-split-by-resthook', () => {
         cases: [
           {
             uuid: 'existing-case-uuid',
-            type: 'has_text',
-            arguments: [],
+            type: 'has_number_between',
+            arguments: ['200', '299'],
             category_uuid: 'existing-success-uuid'
           }
         ],
@@ -190,7 +190,7 @@ describe('temba-split-by-resthook', () => {
           }
         ],
         default_category_uuid: 'existing-failure-uuid',
-        operand: '@webhook.json.status'
+        operand: '@webhook.status'
       },
       exits: [
         {
@@ -241,8 +241,8 @@ describe('temba-split-by-resthook', () => {
         cases: [
           {
             uuid: 'existing-case-uuid',
-            type: 'has_text',
-            arguments: [],
+            type: 'has_number_between',
+            arguments: ['200', '299'],
             category_uuid: 'existing-success-uuid'
           }
         ],
@@ -259,7 +259,7 @@ describe('temba-split-by-resthook', () => {
           }
         ],
         default_category_uuid: 'existing-failure-uuid',
-        operand: '@webhook.json.status'
+        operand: '@webhook.status'
       },
       exits: [
         {


### PR DESCRIPTION
## Summary
- The editor doesn't expose the router operand for either `call_webhook` or `call_resthook` splits, so they should produce the same canonical router shape.
- `split_by_resthook` was emitting `@webhook.status` → `@webhook.json.status` with a `has_text` case. That operand drills into the response body for a `status` field, and the `has_text` case routes anything without one to Failure — so resthooks whose response body doesn't happen to include a `status` key always look like failures, even on a 200.
- Align it with `split_by_webhook`: operand `@webhook.status`, case `has_number_between [200, 299]`. Re-saving an existing affected node normalises it to the canonical shape (case/category UUIDs are still preserved by `createSuccessFailureRouter`).
- Tests updated to expect the new shape.

This is the editor-side half; a follow-up flow migration in goflow can clean up flows in the wild that were authored by the old editor or carried over from the pre-14.1.0 webhook context change.

## Test plan
- [ ] CI passes (local Chromium not available to run `wtr`)
- [ ] Manually verify a freshly created Call Resthook node has `operand: "@webhook.status"` and a single `has_number_between [200, 299]` case
- [ ] Re-save a flow with a legacy `@webhook.json.status` resthook split and confirm it normalises (case/category UUIDs preserved)