### PR TITLE
Handle airtime_created events in contact chat

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -90,6 +90,28 @@ export interface AirtimeTransferredEvent extends ContactEvent {
   amount: string;
 }
 
+export type AirtimeStatus =
+  | 'created'
+  | 'confirmed'
+  | 'rejected'
+  | 'cancelled'
+  | 'submitted'
+  | 'completed'
+  | 'reversed'
+  | 'declined';
+
+export interface AirtimeCreatedEvent extends ContactEvent {
+  sender: string;
+  recipient: string;
+  currency: string;
+  amount: string;
+  external_id?: string;
+  _status?: {
+    created_on: string;
+    status: AirtimeStatus;
+  };
+}
+
 export type CallStartedEvent = ContactEvent;
 
 export interface ContactHistoryPage {

--- a/src/events/eventRenderers.ts
+++ b/src/events/eventRenderers.ts
@@ -379,10 +379,11 @@ export const renderAirtimeCreatedEvent = (
   const amount = html`${valueText(event.amount)} ${event.currency}`;
 
   switch (status) {
+    case 'reversed':
+      return html`<div>Airtime transfer reversed</div>`;
     case 'rejected':
     case 'cancelled':
     case 'declined':
-    case 'reversed':
       return html`<div>Airtime transfer failed</div>`;
     case 'completed':
       return html`<div style=${eventLineStyle}>

--- a/src/events/eventRenderers.ts
+++ b/src/events/eventRenderers.ts
@@ -1,5 +1,6 @@
 import { html, TemplateResult } from 'lit';
 import {
+  AirtimeCreatedEvent,
   AirtimeTransferredEvent,
   CallEvent,
   ChatStartedEvent,
@@ -17,6 +18,7 @@ import { getLanguageName } from '../languages';
 import { oxfordFn } from '../utils';
 
 export enum Events {
+  AIRTIME_CREATED = 'airtime_created',
   AIRTIME_TRANSFERRED = 'airtime_transferred',
   BROADCAST_CREATED = 'broadcast_created',
   CALL_CREATED = 'call_created',
@@ -370,6 +372,29 @@ export const renderAirtimeTransferredEvent = (
   </div>`;
 };
 
+export const renderAirtimeCreatedEvent = (
+  event: AirtimeCreatedEvent
+): TemplateResult => {
+  const status = event._status?.status ?? 'created';
+  const amount = html`${valueText(event.amount)} ${event.currency}`;
+
+  switch (status) {
+    case 'rejected':
+    case 'cancelled':
+    case 'declined':
+    case 'reversed':
+      return html`<div>Airtime transfer failed</div>`;
+    case 'completed':
+      return html`<div style=${eventLineStyle}>
+        Transferred ${amount} of airtime
+      </div>`;
+    default:
+      return html`<div style=${eventLineStyle}>
+        Sending ${amount} of airtime
+      </div>`;
+  }
+};
+
 export const renderContactLanguageChangedEvent = (
   event: ContactLanguageChangedEvent
 ): TemplateResult => {
@@ -559,6 +584,9 @@ export const renderEvent = (
     case Events.FAILURE:
     case Events.WARNING:
       content = renderDiagnosticEvent(event, isSimulation);
+      break;
+    case Events.AIRTIME_CREATED:
+      content = renderAirtimeCreatedEvent(event as AirtimeCreatedEvent);
       break;
     case Events.AIRTIME_TRANSFERRED:
       content = renderAirtimeTransferredEvent(event as AirtimeTransferredEvent);

--- a/test/temba-airtime-event-renderer.test.ts
+++ b/test/temba-airtime-event-renderer.test.ts
@@ -1,0 +1,66 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { renderAirtimeCreatedEvent } from '../src/events/eventRenderers';
+import { AirtimeCreatedEvent, AirtimeStatus } from '../src/events';
+
+const makeEvent = (
+  overrides: Partial<AirtimeCreatedEvent> = {}
+): AirtimeCreatedEvent => {
+  return {
+    type: 'airtime_created',
+    uuid: 'evt-1',
+    created_on: new Date(),
+    sender: 'tel:+250788111111',
+    recipient: 'tel:+250788222222',
+    currency: 'USD',
+    amount: '1.50',
+    ...overrides
+  } as AirtimeCreatedEvent;
+};
+
+const withStatus = (status: AirtimeStatus): AirtimeCreatedEvent =>
+  makeEvent({
+    _status: { created_on: '2025-11-17T19:07:58.472259Z', status }
+  });
+
+describe('renderAirtimeCreatedEvent', () => {
+  it('renders "Sending" for in-flight statuses', async () => {
+    for (const status of ['created', 'confirmed', 'submitted'] as const) {
+      const el = await fixture(
+        html`<div>${renderAirtimeCreatedEvent(withStatus(status))}</div>`
+      );
+      expect(el.textContent, status).to.contain('Sending');
+      expect(el.textContent, status).to.contain('1.50');
+      expect(el.textContent, status).to.contain('USD');
+    }
+  });
+
+  it('renders "Transferred" for completed', async () => {
+    const el = await fixture(
+      html`<div>${renderAirtimeCreatedEvent(withStatus('completed'))}</div>`
+    );
+    expect(el.textContent).to.contain('Transferred');
+    expect(el.textContent).to.contain('1.50');
+    expect(el.textContent).to.contain('USD');
+  });
+
+  it('renders "Airtime transfer failed" for terminal failure statuses', async () => {
+    for (const status of [
+      'rejected',
+      'cancelled',
+      'declined',
+      'reversed'
+    ] as const) {
+      const el = await fixture(
+        html`<div>${renderAirtimeCreatedEvent(withStatus(status))}</div>`
+      );
+      expect(el.textContent, status).to.contain('Airtime transfer failed');
+    }
+  });
+
+  it('defaults to "Sending" when _status is missing', async () => {
+    const el = await fixture(
+      html`<div>${renderAirtimeCreatedEvent(makeEvent())}</div>`
+    );
+    expect(el.textContent).to.contain('Sending');
+  });
+});

--- a/test/temba-airtime-event-renderer.test.ts
+++ b/test/temba-airtime-event-renderer.test.ts
@@ -44,17 +44,20 @@ describe('renderAirtimeCreatedEvent', () => {
   });
 
   it('renders "Airtime transfer failed" for terminal failure statuses', async () => {
-    for (const status of [
-      'rejected',
-      'cancelled',
-      'declined',
-      'reversed'
-    ] as const) {
+    for (const status of ['rejected', 'cancelled', 'declined'] as const) {
       const el = await fixture(
         html`<div>${renderAirtimeCreatedEvent(withStatus(status))}</div>`
       );
       expect(el.textContent, status).to.contain('Airtime transfer failed');
     }
+  });
+
+  it('renders "Airtime transfer reversed" for reversed (a previously completed transfer clawed back)', async () => {
+    const el = await fixture(
+      html`<div>${renderAirtimeCreatedEvent(withStatus('reversed'))}</div>`
+    );
+    expect(el.textContent).to.contain('Airtime transfer reversed');
+    expect(el.textContent).to.not.contain('failed');
   });
 
   it('defaults to "Sending" when _status is missing', async () => {


### PR DESCRIPTION
## Summary

Mailroom [#1090](https://github.com/nyaruka/mailroom/pull/1090) replaces the legacy `airtime_transferred` event with `airtime_created`, and rapidpro [#6643](https://github.com/nyaruka/rapidpro/pull/6643) expands the airtime status set to eight values. Server responses now augment `airtime_created` events with a `_status` field (same pattern used for `msg_created`):

```json
"_status": { "created_on": "2025-11-17T19:07:58.472259Z", "status": "confirmed" }
```

This PR teaches the contact chat to render the new event with wording that reflects where the transfer is in its lifecycle.

## Changes

- `AirtimeCreatedEvent` interface added with optional `_status` (statuses: `created`, `confirmed`, `rejected`, `cancelled`, `submitted`, `completed`, `reversed`, `declined`) and optional `external_id`.
- `Events.AIRTIME_CREATED` added to the renderer enum and wired through `renderEvent`.
- `renderAirtimeCreatedEvent` buckets the status into three messages:
  - `created` / `confirmed` / `submitted` -> `Sending {amount} {currency} of airtime`
  - `completed` -> `Transferred {amount} {currency} of airtime`
  - `rejected` / `cancelled` / `declined` / `reversed` -> `Airtime transfer failed`
  - Missing `_status` defaults to the sending bucket (rows are born in `created` state).
- Existing `airtime_transferred` rendering is left untouched so older history events keep working.

## Test plan

- [x] New unit test `test/temba-airtime-event-renderer.test.ts` covers each bucket plus the missing-`_status` default.
- [x] `pnpm build` clean.
- [x] `pnpm test:fast --files test/temba-contact-chat.test.ts` still green.