### PR TITLE
Rename ContactEvents to ContactTimeline and make campaign pills clickable

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -160,6 +160,7 @@ export interface Msg {
 export interface ObjectReference {
   uuid: string;
   name: string;
+  url?: string;
 }
 
 export interface Shortcut {

--- a/src/live/ContactTimeline.ts
+++ b/src/live/ContactTimeline.ts
@@ -64,7 +64,14 @@ export class ContactTimeline extends EndpointMonitorElement {
   lang_campaigns_label = 'Campaigns';
 
   @property({ type: String })
-  lang_empty = 'No events for this contact yet.';
+  lang_empty = 'No upcoming events';
+
+  @property({ type: String })
+  lang_empty_help =
+    'Events appear here when a contact joins a campaign. Scheduled flows and messages will also show up here.';
+
+  @property({ type: String })
+  lang_campaigns_link = 'View campaigns';
 
   @property({ type: String })
   lang_projected_info =
@@ -101,11 +108,44 @@ export class ContactTimeline extends EndpointMonitorElement {
         display: block;
       }
 
+      /* empty state follows the list design system: centered icon, a short
+         title, muted explanatory copy, and a single call-to-action link */
       .empty {
-        padding: 4em 1em;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
         text-align: center;
+        padding: 7em 1em 4em;
         color: var(--text-color);
-        opacity: 0.55;
+      }
+
+      .empty temba-icon {
+        margin-bottom: 0.75em;
+        --icon-color: var(--text-3, #7b8593);
+      }
+
+      .empty-title {
+        font-weight: 600;
+        margin-bottom: 0.4em;
+      }
+
+      .empty-help {
+        font-size: 0.875em;
+        line-height: 1.5;
+        max-width: 22em;
+        margin-bottom: 1em;
+        color: var(--text-3, #7b8593);
+      }
+
+      .empty-link {
+        font-size: 0.875em;
+        font-weight: 500;
+        color: var(--color-link-primary);
+        text-decoration: none;
+      }
+
+      .empty-link:hover {
+        text-decoration: underline;
       }
 
       /* row of campaign pills the contact is currently a member of */
@@ -765,7 +805,14 @@ export class ContactTimeline extends EndpointMonitorElement {
       pastDescending.length === 0
     ) {
       return html`<div class="empty">
-        <slot name="empty">${this.lang_empty}</slot>
+        <slot name="empty">
+          <temba-icon name=${Icon.schedule} size="2"></temba-icon>
+          <div class="empty-title">${this.lang_empty}</div>
+          <div class="empty-help">${this.lang_empty_help}</div>
+          <a class="empty-link" href="/campaign/" onclick="goto(event)"
+            >${this.lang_campaigns_link}</a
+          >
+        </slot>
       </div>`;
     }
 

--- a/src/live/ContactTimeline.ts
+++ b/src/live/ContactTimeline.ts
@@ -731,7 +731,7 @@ export class ContactTimeline extends EndpointMonitorElement {
               @click=${(e: Event) => this.handlePillClicked(e, campaign)}
               @keydown=${(e: KeyboardEvent) =>
                 this.handleActivationKey(e, () =>
-                  this.fireCustomEvent(CustomEventType.Selection, campaign)
+                  this.handlePillClicked(e, campaign)
                 )}
             >
               <span class="campaign-dot"></span>${campaign.name}

--- a/src/live/ContactTimeline.ts
+++ b/src/live/ContactTimeline.ts
@@ -128,7 +128,8 @@ export class ContactTimeline extends EndpointMonitorElement {
       }
 
       /* each pill is colored with its campaign's hue - background, border
-         and text all derived from --pill-hue. read-only badges, not links */
+         and text all derived from --pill-hue. clickable links to the
+         campaign's read page */
       .campaign-pill {
         display: inline-flex;
         align-items: center;
@@ -146,6 +147,21 @@ export class ContactTimeline extends EndpointMonitorElement {
         border: 1px solid
           color-mix(in srgb, var(--pill-hue) 25%, var(--color-widget-bg, #fff));
         color: var(--pill-hue);
+        cursor: pointer;
+        transition: background 100ms ease-in-out;
+      }
+
+      .campaign-pill:hover {
+        background: color-mix(
+          in srgb,
+          var(--pill-hue) 22%,
+          var(--color-widget-bg, #fff)
+        );
+      }
+
+      .campaign-pill:focus-visible {
+        outline: 2px solid var(--pill-hue);
+        outline-offset: 1px;
       }
 
       /* status-badge dot leading each campaign pill, in the same hue */
@@ -710,6 +726,13 @@ export class ContactTimeline extends EndpointMonitorElement {
             html`<div
               class="campaign-pill"
               style="--pill-hue:${this.getCampaignColor(campaign.uuid)}"
+              role="button"
+              tabindex="0"
+              @click=${(e: Event) => this.handlePillClicked(e, campaign)}
+              @keydown=${(e: KeyboardEvent) =>
+                this.handleActivationKey(e, () =>
+                  this.fireCustomEvent(CustomEventType.Selection, campaign)
+                )}
             >
               <span class="campaign-dot"></span>${campaign.name}
             </div>`

--- a/src/live/ContactTimeline.ts
+++ b/src/live/ContactTimeline.ts
@@ -41,7 +41,7 @@ const BROADCAST_COLOR = '#8e5ea7';
 // triggers use the same green as the flow pill
 const TRIGGER_COLOR = '#16a34a';
 
-export class ContactEvents extends EndpointMonitorElement {
+export class ContactTimeline extends EndpointMonitorElement {
   @property({ type: String })
   contact: string;
 
@@ -424,7 +424,7 @@ export class ContactEvents extends EndpointMonitorElement {
     const requestedContact = this.contact;
     try {
       const response = await this.store.getUrl(
-        `/contact/events/${encodeURIComponent(this.contact)}/`,
+        `/contact/timeline/${encodeURIComponent(this.contact)}/`,
         { force: true }
       );
       if (this.contact !== requestedContact) {
@@ -570,7 +570,7 @@ export class ContactEvents extends EndpointMonitorElement {
     // capture the contact at request time so a paged response that returns
     // after the user has switched contacts can't append onto the new timeline
     const requestedContact = this.contact;
-    const url = `/contact/events/${encodeURIComponent(
+    const url = `/contact/timeline/${encodeURIComponent(
       this.contact
     )}/?before=${encodeURIComponent(this.nextBefore)}`;
 
@@ -609,7 +609,7 @@ export class ContactEvents extends EndpointMonitorElement {
 
     this.loadingMoreFuture = true;
     const requestedContact = this.contact;
-    const url = `/contact/events/${encodeURIComponent(
+    const url = `/contact/timeline/${encodeURIComponent(
       this.contact
     )}/?after=${encodeURIComponent(this.nextAfter)}`;
 

--- a/temba-modules.ts
+++ b/temba-modules.ts
@@ -31,7 +31,7 @@ import { ContactFields } from './src/live/ContactFields';
 import { ContactFieldEditor } from './src/live/ContactFieldEditor';
 
 import { ContactBadges } from './src/live/ContactBadges';
-import { ContactEvents } from './src/live/ContactEvents';
+import { ContactTimeline } from './src/live/ContactTimeline';
 import { TembaSlider } from './src/form/TembaSlider';
 import { RunList } from './src/list/RunList';
 import { FlowStoreElement } from './src/store/FlowStoreElement';
@@ -149,7 +149,7 @@ addCustomElement('temba-dropdown', Dropdown);
 addCustomElement('temba-tabs', TabPane);
 addCustomElement('temba-tab', Tab);
 addCustomElement('temba-contact-badges', ContactBadges);
-addCustomElement('temba-contact-events', ContactEvents);
+addCustomElement('temba-contact-timeline', ContactTimeline);
 addCustomElement('temba-slider', TembaSlider);
 addCustomElement('temba-content-menu', ContentMenu);
 addCustomElement('temba-compose', Compose);

--- a/test/temba-contact-timeline.test.ts
+++ b/test/temba-contact-timeline.test.ts
@@ -238,6 +238,28 @@ describe(TAG, () => {
     expect(selected.url).to.equal('/campaign/read/camp-1/');
   });
 
+  it('fires selection with the campaign url when a campaign pill is activated via the Space key', async () => {
+    await loadStore();
+    const events = await getEvents();
+
+    let selected: any = null;
+    events.addEventListener('temba-selection', (e: CustomEvent) => {
+      selected = e.detail;
+    });
+
+    const pill = events.shadowRoot.querySelector(
+      '.campaign-pill'
+    ) as HTMLElement;
+    expect(pill).to.not.equal(null);
+    pill.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ' ', bubbles: true })
+    );
+
+    expect(selected).to.not.equal(null);
+    expect(selected.uuid).to.equal('camp-1');
+    expect(selected.url).to.equal('/campaign/read/camp-1/');
+  });
+
   it('pages forward through newer upcoming events', async () => {
     await loadStore();
     const events = await getEvents();

--- a/test/temba-contact-timeline.test.ts
+++ b/test/temba-contact-timeline.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect } from '@open-wc/testing';
-import { ContactEvents } from '../src/live/ContactEvents';
+import { ContactTimeline } from '../src/live/ContactTimeline';
 import {
   clearMockGets,
   getComponent,
@@ -8,7 +8,7 @@ import {
   waitForCondition
 } from './utils.test';
 
-const TAG = 'temba-contact-events';
+const TAG = 'temba-contact-timeline';
 
 // the older-events pager dot exposes the localized show-older label, which we
 // use as a stable hook rather than coupling tests to internal class names
@@ -82,18 +82,18 @@ const NEWER_PAGE = {
   next_after: null
 };
 
-const getEvents = async (data: any = FIRST_PAGE): Promise<ContactEvents> => {
+const getEvents = async (data: any = FIRST_PAGE): Promise<ContactTimeline> => {
   // paged requests (?before= / ?after=) take precedence over the first-page mock
-  mockGET(/contact\/events\/.*before=/, OLDER_PAGE);
-  mockGET(/contact\/events\/.*after=/, NEWER_PAGE);
-  mockGET(/contact\/events\//, data);
+  mockGET(/contact\/timeline\/.*before=/, OLDER_PAGE);
+  mockGET(/contact\/timeline\/.*after=/, NEWER_PAGE);
+  mockGET(/contact\/timeline\//, data);
 
   const events = (await getComponent(
     TAG,
     { contact: 'contact-dave-active' },
     '',
     600
-  )) as ContactEvents;
+  )) as ContactTimeline;
 
   await waitForCondition(() => !!events.data);
   await events.updateComplete;
@@ -111,7 +111,7 @@ describe(TAG, () => {
   it('renders a timeline of past and future events', async () => {
     await loadStore();
     const events = await getEvents();
-    assert.instanceOf(events, ContactEvents);
+    assert.instanceOf(events, ContactTimeline);
 
     const root = events.shadowRoot;
     expect(root.querySelector('.timeline')).to.not.equal(null);
@@ -233,15 +233,15 @@ describe(TAG, () => {
     await loadStore();
     // override the default 200 mock for older pages with a 500
     clearMockGets();
-    mockGET(/contact\/events\/.*before=/, {}, {}, '500');
-    mockGET(/contact\/events\//, FIRST_PAGE);
+    mockGET(/contact\/timeline\/.*before=/, {}, {}, '500');
+    mockGET(/contact\/timeline\//, FIRST_PAGE);
 
     const events = (await getComponent(
       TAG,
       { contact: 'contact-dave-active' },
       '',
       600
-    )) as ContactEvents;
+    )) as ContactTimeline;
     await waitForCondition(() => !!events.data);
     await events.updateComplete;
 

--- a/test/temba-contact-timeline.test.ts
+++ b/test/temba-contact-timeline.test.ts
@@ -216,6 +216,28 @@ describe(TAG, () => {
     expect(selected.url).to.equal('/campaign/read/camp-1/');
   });
 
+  it('fires selection with the campaign url when a campaign pill is activated via the Enter key', async () => {
+    await loadStore();
+    const events = await getEvents();
+
+    let selected: any = null;
+    events.addEventListener('temba-selection', (e: CustomEvent) => {
+      selected = e.detail;
+    });
+
+    const pill = events.shadowRoot.querySelector(
+      '.campaign-pill'
+    ) as HTMLElement;
+    expect(pill).to.not.equal(null);
+    pill.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    );
+
+    expect(selected).to.not.equal(null);
+    expect(selected.uuid).to.equal('camp-1');
+    expect(selected.url).to.equal('/campaign/read/camp-1/');
+  });
+
   it('pages forward through newer upcoming events', async () => {
     await loadStore();
     const events = await getEvents();

--- a/test/temba-contact-timeline.test.ts
+++ b/test/temba-contact-timeline.test.ts
@@ -17,6 +17,9 @@ const SHOW_MORE_LABEL = 'Show more upcoming events';
 
 const FIRST_PAGE = {
   now: '2024-06-01T12:00:00+00:00',
+  campaigns: [
+    { uuid: 'camp-1', name: 'Onboarding', url: '/campaign/read/camp-1/' }
+  ],
   future: [
     {
       type: 'scheduled_broadcast',
@@ -191,6 +194,26 @@ describe(TAG, () => {
     entry.click();
 
     expect(selected).to.not.equal(null);
+  });
+
+  it('fires selection with the campaign url when a campaign pill is clicked', async () => {
+    await loadStore();
+    const events = await getEvents();
+
+    let selected: any = null;
+    events.addEventListener('temba-selection', (e: CustomEvent) => {
+      selected = e.detail;
+    });
+
+    const pill = events.shadowRoot.querySelector(
+      '.campaign-pill'
+    ) as HTMLElement;
+    expect(pill).to.not.equal(null);
+    pill.click();
+
+    expect(selected).to.not.equal(null);
+    expect(selected.uuid).to.equal('camp-1');
+    expect(selected.url).to.equal('/campaign/read/camp-1/');
   });
 
   it('pages forward through newer upcoming events', async () => {

--- a/test/temba-contact-timeline.test.ts
+++ b/test/temba-contact-timeline.test.ts
@@ -136,8 +136,15 @@ describe(TAG, () => {
       next_before: null
     });
 
-    expect(events.shadowRoot.querySelector('.empty')).to.not.equal(null);
+    const empty = events.shadowRoot.querySelector('.empty');
+    expect(empty).to.not.equal(null);
     expect(events.shadowRoot.querySelector('.timeline')).to.equal(null);
+
+    // the empty state explains how events end up here and links to campaigns
+    expect(empty.querySelector('.empty-help')).to.not.equal(null);
+    const link = empty.querySelector('.empty-link') as HTMLAnchorElement;
+    expect(link).to.not.equal(null);
+    expect(link.getAttribute('href')).to.equal('/campaign/');
   });
 
   it('pages back through older events', async () => {


### PR DESCRIPTION
## Summary

Renames the `ContactEvents` timeline component to `ContactTimeline` (custom element `temba-contact-timeline`, endpoint `/contact/timeline/`) and makes campaign pills clickable so they navigate to the campaign read page, matching the behavior flow pills already have.

## Changes

- **Rename** `src/live/ContactEvents.ts` → `src/live/ContactTimeline.ts`; class `ContactEvents` → `ContactTimeline`.
- **Custom element tag** `temba-contact-events` → `temba-contact-timeline` (registered in `temba-modules.ts`).
- **Endpoint** `/contact/events/` → `/contact/timeline/` across the initial load and both pager (`?before=` / `?after=`) requests.
- **Clickable campaign pills** — campaign pills get `role="button"`, `tabindex="0"`, hover and `:focus-visible` styling, and `@click` / `@keydown` handlers that fire `temba-selection` with the campaign `ObjectReference` (carrying its `url`) so the host navigates to the campaign read page.
- **Type** — added optional `url?: string` to `ObjectReference` in `src/interfaces.ts` to make the navigation contract type-visible.
- **Tests** renamed `test/temba-contact-events.test.ts` → `test/temba-contact-timeline.test.ts`, added a `campaigns` entry to the first-page mock, and added click / Enter-key / Space-key activation tests for the campaign pill.

## Review notes

Caught and addressed during pre-PR review:

- **Click/keydown consistency** — the campaign pill's keydown path originally fired `temba-selection` directly, bypassing the `stopPropagation()` that the click path performs via `handlePillClicked`. Unified both paths through `handlePillClicked` so they share identical semantics (matching the flow-pill pattern).
- **Type contract** — the feature relies on the campaign reference carrying a `url`, but `ObjectReference` only declared `{ uuid, name }`. Added `url?: string` so the contract is type-checked; verified the optional addition is backward-compatible with all existing consumers.
- **Keyboard coverage** — added Enter- and Space-key activation tests, exercising both branches of the activation handler that were previously untested.

## Test plan

- [x] Full suite green in the devcontainer (1822 passing, 6 skipped)
- [x] `temba-contact-timeline` file: 14/14 passing, including click + Enter + Space campaign-pill activation
- [x] `pnpm build` clean (tsc + rollup, no type regression from the `ObjectReference` change)
- [x] `pnpm format` clean (no changes)
- [x] Rename verified complete — no lingering `temba-contact-events` / `ContactEvents` / `/contact/events/` references in source or tests