### PR TITLE
Route message list navigation through the SPA

### DIFF
--- a/src/list/ContentList.ts
+++ b/src/list/ContentList.ts
@@ -1524,7 +1524,16 @@ export class ContentList<T = any> extends RapidElement {
     this.fireCustomEvent(CustomEventType.RowClick, { item });
     const href = this.getRowHref(item);
     if (href && this.isSafeHref(href)) {
-      window.location.href = href;
+      // Meta/ctrl-click opens a new tab, matching ordinary links.
+      if (event.metaKey || event.ctrlKey) {
+        window.open(href, '_blank');
+        return;
+      }
+      // Fire Redirected rather than assigning window.location so the
+      // host SPA frame swaps content in place instead of doing a full
+      // page reload — the frame listens for this event on document and
+      // routes it through its in-app loader.
+      this.fireCustomEvent(CustomEventType.Redirected, { url: href });
     }
   }
 

--- a/src/list/MsgList.ts
+++ b/src/list/MsgList.ts
@@ -134,6 +134,14 @@ export class MsgList extends ContentList<Msg> {
     ];
   }
 
+  /** Rows navigate to the message's contact. Returning the href here
+   * also marks the row `clickable`, so it carries the pointer cursor on
+   * hover. */
+  protected getRowHref(item: Msg): string | null {
+    const uuid = item.contact?.uuid;
+    return uuid ? `/contact/read/${uuid}/` : null;
+  }
+
   protected renderCell(
     item: Msg,
     column: ContentListColumn
@@ -220,20 +228,37 @@ export class MsgList extends ContentList<Msg> {
   }
 
   /** Flow + label pills for a row, pushed to the trailing edge of
-   * the message cell, or '' when the row carries none. */
+   * the message cell, or '' when the row carries none. The flow pill
+   * opens its editor and each label pill opens that label's filtered
+   * message view — matching the rapidpro msg list. `clickable` gives
+   * the hover affordance; `goto` routes the click through the SPA and
+   * stops propagation so the row's own contact navigation doesn't also
+   * fire. */
   private renderPills(item: Msg): TemplateResult | string {
     const labels = item.labels || [];
     if (!item.flow && !labels.length) return '';
     return html`
       <div class="cell-pills">
         ${item.flow
-          ? html`<temba-label type="flow" icon=${Icon.flow}
+          ? html`<temba-label
+              type="flow"
+              icon=${Icon.flow}
+              href="/flow/editor/${item.flow.uuid}/"
+              onclick="goto(event)"
+              clickable
               >${item.flow.name}</temba-label
             >`
           : null}
         ${labels.map(
           (l) => html`
-            <temba-label type="label" icon=${Icon.label}>${l.name}</temba-label>
+            <temba-label
+              type="label"
+              icon=${Icon.label}
+              href="/msg/filter/${l.uuid}/"
+              onclick="goto(event)"
+              clickable
+              >${l.name}</temba-label
+            >
           `
         )}
       </div>

--- a/src/live/ContactTimeline.ts
+++ b/src/live/ContactTimeline.ts
@@ -809,7 +809,7 @@ export class ContactTimeline extends EndpointMonitorElement {
           <temba-icon name=${Icon.schedule} size="2"></temba-icon>
           <div class="empty-title">${this.lang_empty}</div>
           <div class="empty-help">${this.lang_empty_help}</div>
-          <a class="empty-link" href="/campaign/" onclick="goto(event)"
+          <a class="empty-link" href="/campaign/" onclick="goto(event, this)"
             >${this.lang_campaigns_link}</a
           >
         </slot>

--- a/test/temba-content-list.test.ts
+++ b/test/temba-content-list.test.ts
@@ -1,4 +1,5 @@
 import { assert, expect } from '@open-wc/testing';
+import { stub } from 'sinon';
 import { CustomEventType } from '../src/interfaces';
 import { ContentList } from '../src/list/ContentList';
 import { ContactList } from '../src/list/ContactList';
@@ -85,6 +86,76 @@ describe('temba-content-list', () => {
     action.click();
 
     expect(bulkDetail).to.deep.equal({ action: 'delete', ids: ['u-1'] });
+  });
+
+  it('builds a contact-read href for message rows', async () => {
+    const list = (await getComponent('temba-msg-list', {}, '', 700)) as MsgList;
+    expect((list as any).getRowHref({ contact: { uuid: 'c-123' } })).to.equal(
+      '/contact/read/c-123/'
+    );
+    // No uuid (or no contact at all) leaves the row non-navigating.
+    expect((list as any).getRowHref({ contact: {} })).to.equal(null);
+    expect((list as any).getRowHref({})).to.equal(null);
+  });
+
+  it('fires temba-redirected on row click when the row has an href', async () => {
+    const list = (await getList({
+      endpoint: '/test-assets/content-list/items.json'
+    })) as ContentList;
+    list.columns = [{ key: 'name' }];
+    // Make rows navigate; this also marks them `.clickable`.
+    (list as any).getRowHref = (item: any) => `/contact/read/${item.uuid}/`;
+    (list as any).requestUpdate();
+    await list.updateComplete;
+
+    let redirectUrl: string | null = null;
+    list.addEventListener(CustomEventType.Redirected, (e: Event) => {
+      redirectUrl = (e as CustomEvent).detail.url;
+    });
+
+    const row = list.shadowRoot!.querySelector(
+      'tr.row.clickable'
+    ) as HTMLElement;
+    assert.exists(row, 'first row should be clickable');
+    row.click();
+
+    // Routes through the SPA via the Redirected event rather than a
+    // full-page window.location assignment.
+    expect(redirectUrl).to.equal('/contact/read/u-1/');
+  });
+
+  it('opens a new tab on meta-click without firing temba-redirected', async () => {
+    const list = (await getList({
+      endpoint: '/test-assets/content-list/items.json'
+    })) as ContentList;
+    list.columns = [{ key: 'name' }];
+    (list as any).getRowHref = (item: any) => `/contact/read/${item.uuid}/`;
+    (list as any).requestUpdate();
+    await list.updateComplete;
+
+    let redirected = false;
+    list.addEventListener(CustomEventType.Redirected, () => {
+      redirected = true;
+    });
+
+    const openStub = stub(window, 'open');
+    try {
+      const row = list.shadowRoot!.querySelector(
+        'tr.row.clickable'
+      ) as HTMLElement;
+      row.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          composed: true,
+          metaKey: true
+        })
+      );
+      expect(openStub.calledOnceWithExactly('/contact/read/u-1/', '_blank')).to
+        .be.true;
+      expect(redirected).to.be.false;
+    } finally {
+      openStub.restore();
+    }
   });
 
   it('renders the messages list (screenshot)', async () => {


### PR DESCRIPTION
## Summary

The new message list (`MsgList`) rows weren't navigating correctly and its flow/label pills were inert. This makes rows and pills navigate within the SPA (in-place content swap) instead of triggering full-page reloads, and gives them the hover affordances users expect.

## Changes

**`src/list/ContentList.ts`** — row-click navigation
- Replaced `window.location.href = href` (full-page reload) with firing `CustomEventType.Redirected`, which the rapidpro frame listens for on `document` and routes through its in-place `spaGet` loader.
- Meta/ctrl-click now opens the row in a new tab (`window.open`), matching ordinary link behavior — the old code supported neither.
- A row only navigates when `getRowHref` returns a (same-origin, `isSafeHref`-validated) URL, which also marks the `<tr>` `clickable` for the pointer cursor.

**`src/list/MsgList.ts`** — message rows + pills
- Added `getRowHref` so message rows navigate to the contact (`/contact/read/<uuid>/`) and show the pointer cursor on hover. Returns `null` when no contact uuid is present.
- Made the flow/label pills clickable links matching the rapidpro `msg_list.html`: flow → `/flow/editor/<uuid>/`, label → `/msg/filter/<uuid>/`. Uses the `temba-label` + `href` + `onclick="goto(event)"` + `clickable` idiom already used by `ContactBadges`/`ContactDetails`. `goto` routes through the SPA and stops propagation, so clicking a pill doesn't also trigger the row's contact navigation.

**`src/live/ContactTimeline.ts`** — empty-state link
- The "View campaigns" link in the Next Up empty state used `onclick="goto(event)"`, which for a real `<a>` element hits a branch that does `document.location.href = ...` (full reload), because `<a>.href` is a truthy property. Passing the element (`goto(event, this)`) makes `event.target == ele`, skipping that branch and falling through to `spaGet`, matching the working call site in `ContactChat`.

**`test/temba-content-list.test.ts`** — coverage for the new navigation
- `getRowHref` builds the contact-read URL and returns `null` without a uuid.
- A row click fires `temba-redirected` with the expected URL.
- A meta-click opens a new tab via `window.open` and does not fire `temba-redirected`.

## Review notes

A pre-PR review (expert-code-reviewer) verified the change end-to-end against the consuming frame and returned `ready` with no correctness issues. The one actionable finding — no test coverage for the new navigation paths — was addressed by adding the three tests above. Two low/suggestion notes were left as-is by design: navigation relies on the frame listener (consistent with how `Modax` already works), and ctrl-vs-meta new-tab uniformity belongs in the frame's `goto` helper rather than here.

Why the other `goto(event)` call sites were left untouched: `ContactBadges`/`ContactDetails` use the same one-arg form but on `temba-label` elements, which have no `.href` JS property — so `goto` correctly skips the reload branch and falls through to `spaGet`. Only the plain `<a>` in `ContactTimeline` was affected.

## Test plan

- [x] `pnpm test` — full suite green (1825 passed, 0 failed, 6 skipped)
- [x] New unit/interaction tests for row-click SPA navigation and `getRowHref`
- [x] Messages-list screenshot test unchanged (the `clickable` attribute only adds `cursor: pointer`)
- [x] `pnpm format` and `pnpm build` clean