### PR TITLE
Enable expression completion for the open ticket note field

### DIFF
--- a/src/flow/nodes/split_by_ticket.ts
+++ b/src/flow/nodes/split_by_ticket.ts
@@ -41,6 +41,7 @@ export const split_by_ticket: NodeConfig = {
       type: 'textarea',
       label: 'Note',
       required: false,
+      evaluated: true,
       placeholder: 'Enter a note for the ticket (optional)',
       minHeight: 100
     }

--- a/test/nodes/split_by_ticket.test.ts
+++ b/test/nodes/split_by_ticket.test.ts
@@ -16,6 +16,10 @@ describe('split_by_ticket node config', () => {
       expect(split_by_ticket.type).to.equal('split_by_ticket');
       expect(split_by_ticket.name).to.equal('Open Ticket');
     });
+
+    it('enables expression completion on the note field', () => {
+      expect((split_by_ticket.form!.note as any).evaluated).to.equal(true);
+    });
   });
 
   describe('round-trip transformation', () => {


### PR DESCRIPTION
## Summary

The "Note" field on the open ticket action (`split_by_ticket` node) was a plain textarea with no expression support. This enables `@`-expression completion (e.g. `@contact.name`) in that field, matching the behavior of other evaluated message fields.

## Changes

- **`src/flow/nodes/split_by_ticket.ts`** — add `evaluated: true` to the `note` field config. `FieldRenderer` renders an `evaluated` textarea as `temba-rich-edit` (with a `textarea` session) instead of a plain `temba-textinput`, which wires up the completion popup. This is the same flag used by `send_email.body` and `say_msg.text`.
- **`test/nodes/split_by_ticket.test.ts`** — add an assertion that the note field has `evaluated: true`, to lock in the intent and guard against silent regression.

## Review notes

Pre-PR review (expert-code-reviewer) verdict: ready. Substantive points checked:
- Confirmed `evaluated` is a valid `BaseFieldConfig` flag and that `FieldRenderer.renderTextarea` branches on it to render `temba-rich-edit` — no endpoint or extra config required.
- Confirmed the note still round-trips as a plain string through `toFormData`/`fromFormData`; `temba-rich-edit` exposes a string `value` identical to `temba-textinput`, so expressions are stored verbatim for the backend to evaluate. No serialization change.
- Added the suggested config-level test assertion (consistent with how `say_msg`/`send_email` are tested — no full render test needed).

## Test plan

- [x] `pnpm test` — full suite green (1826 passed, 0 failed, 6 skipped)
- [x] New test asserts `note.evaluated === true`
- [x] `pnpm format` — no changes
- [x] `pnpm build` — succeeds