### PR TITLE
Serve temba-components editor.json via the dev server

### DIFF
--- a/rollup.components.mjs
+++ b/rollup.components.mjs
@@ -47,6 +47,7 @@ export default {
         replace({
             preventAssignment: true,
             'process.env.NODE_ENV': JSON.stringify('development'),
+            '__TEMBA_DEV_SERVER__': JSON.stringify(false),
             '__TEMBA_COMPONENTS_VERSION__': JSON.stringify(TEMBA_COMPONENTS_VERSION)
           }),
 

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -41,15 +41,20 @@ export const getStore = () => {
   return document.querySelector('temba-store') as Store;
 };
 
+declare const __TEMBA_DEV_SERVER__: boolean;
+
 /**
- * True when running against the temba-components dev server. The dev server
- * (and the rollup IIFE build) replace `process.env.NODE_ENV` with
- * 'development' at build time; the try/catch keeps this safe when the code is
- * loaded unbundled in a browser, where `process` is undefined.
+ * True only when running against the temba-components dev server, which
+ * replaces `__TEMBA_DEV_SERVER__` with `true` at serve time. The production
+ * rollup build and the test runner replace it with `false`; for any other
+ * consumer the token is undefined and the try/catch falls back to `false`.
+ * We deliberately do not key off `process.env.NODE_ENV` — the published IIFE
+ * bundle (rollup.components.mjs) hardcodes that to 'development', so it can't
+ * distinguish the dev server from a production consumer.
  */
 const isDevServer = (): boolean => {
   try {
-    return process.env.NODE_ENV === 'development';
+    return __TEMBA_DEV_SERVER__ === true;
   } catch {
     return false;
   }

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -41,6 +41,20 @@ export const getStore = () => {
   return document.querySelector('temba-store') as Store;
 };
 
+/**
+ * True when running against the temba-components dev server. The dev server
+ * (and the rollup IIFE build) replace `process.env.NODE_ENV` with
+ * 'development' at build time; the try/catch keeps this safe when the code is
+ * loaded unbundled in a browser, where `process` is undefined.
+ */
+const isDevServer = (): boolean => {
+  try {
+    return process.env.NODE_ENV === 'development';
+  } catch {
+    return false;
+  }
+};
+
 export class Store extends RapidElement {
   public static get styles() {
     return css`
@@ -172,7 +186,7 @@ export class Store extends RapidElement {
     const fetches = [];
     if (this.completionEndpoint) {
       fetches.push(
-        getUrl(this.completionEndpoint).then((response) => {
+        getUrl(this.getCompletionEndpoint()).then((response) => {
           this.schema = response.json['context'] as CompletionSchema;
           this.fnOptions = response.json['functions'] as CompletionOption[];
         })
@@ -336,6 +350,27 @@ export class Store extends RapidElement {
         setLocale(target);
       }
     }
+  }
+
+  /**
+   * Resolves the completion endpoint to fetch. When running against the
+   * temba-components dev server we override the configured endpoint so the
+   * editor serves our own editor.json (static/mr/docs/en-us/editor.json)
+   * rather than the host application's mailroom completions. The dev-server
+   * origin is derived from import.meta.url so this works even when the
+   * components are loaded cross-origin (e.g. rapidpro on :8001 with the
+   * components dev server on :3011).
+   */
+  private getCompletionEndpoint(): string {
+    if (isDevServer()) {
+      try {
+        const origin = new URL(import.meta.url).origin;
+        return `${origin}/api/v2/completion.json`;
+      } catch {
+        // import.meta.url unavailable; fall back to the configured endpoint
+      }
+    }
+    return this.completionEndpoint;
   }
 
   public getCompletionSchema(): CompletionSchema {

--- a/web-dev-server.config.mjs
+++ b/web-dev-server.config.mjs
@@ -295,8 +295,18 @@ export default {
     // Permissive CORS so this dev server can be loaded as a cross-origin
     // module source by a rapidpro instance running on a different localhost
     // port (e.g. Nautilus/run-pair.sh launching rapidpro:8001 + components:3011).
+    // The Store fetches completion.json with custom headers (X-CSRFToken,
+    // X-Temba-Workspace, X-Requested-With), which makes it a non-simple
+    // cross-origin request, so we must also answer the preflight (OPTIONS)
+    // with the allowed methods/headers or the browser blocks it.
     (ctx, next) => {
       ctx.set('Access-Control-Allow-Origin', '*');
+      ctx.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+      ctx.set('Access-Control-Allow-Headers', '*');
+      if (ctx.method === 'OPTIONS') {
+        ctx.status = 204;
+        return;
+      }
       return next();
     },
   ],

--- a/web-dev-server.config.mjs
+++ b/web-dev-server.config.mjs
@@ -314,6 +314,7 @@ export default {
     replacePlugin({
       preventAssignment: true,
       'process.env.NODE_ENV': JSON.stringify('development'),
+      '__TEMBA_DEV_SERVER__': JSON.stringify(true),
       '__TEMBA_COMPONENTS_VERSION__': JSON.stringify(TEMBA_COMPONENTS_VERSION),
       'process.env.MINIO_ENDPOINT': JSON.stringify('http://minio:9000'),
       'process.env.MINIO_PUBLIC_ENDPOINT': JSON.stringify('http://localhost:9000'),

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -454,6 +454,7 @@ export default {
     replacePlugin({
       preventAssignment: true,
       'process.env.NODE_ENV': JSON.stringify('test'),
+      __TEMBA_DEV_SERVER__: JSON.stringify(false),
       __TEMBA_COMPONENTS_VERSION__: JSON.stringify(TEMBA_COMPONENTS_VERSION)
     }),
     {


### PR DESCRIPTION
## Summary

While developing against the temba-components dev server, the `Store` component now overrides the host application's configured `completion` endpoint so the editor serves the temba-components own `editor.json` (`static/mr/docs/en-us/editor.json`) rather than the host's mailroom completions. This lets you iterate on completion schema changes in temba-components without round-tripping through rapidpro.

## Changes

- **`src/store/Store.ts`**
  - Added `getCompletionEndpoint()`, used when fetching completions in `reset()`. On the dev server it returns `<dev-server-origin>/api/v2/completion.json`, deriving the origin from `import.meta.url` so it works cross-origin (e.g. rapidpro on `:8001` loading the components dev server on `:3011` via run-pair). Outside the dev server it returns the configured endpoint unchanged.
  - Added `isDevServer()`, gated on a dedicated build-replaced `__TEMBA_DEV_SERVER__` token (mirrors the existing `__TEMBA_COMPONENTS_VERSION__` pattern in `src/version.ts`).
- **`web-dev-server.config.mjs`**
  - Replaces `__TEMBA_DEV_SERVER__` with `true`.
  - Extends the permissive CORS middleware to answer the `OPTIONS` preflight (`Access-Control-Allow-Methods` / `Access-Control-Allow-Headers`, `204` short-circuit). The Store's `getUrl` always sends custom headers (`X-CSRFToken`, `X-Temba-Workspace`, `X-Requested-With`), making the cross-origin completion fetch a non-simple request that requires a preflight response.
- **`rollup.components.mjs`** / **`web-test-runner.config.mjs`** — Replace `__TEMBA_DEV_SERVER__` with `false` (production build and tests).

## Review notes

Caught and fixed during pre-PR review:

- **Critical:** the first implementation keyed dev-detection on `process.env.NODE_ENV === 'development'`. The published package ships only the rollup IIFE bundle (`dist/temba-components.js`), and that build hardcodes `process.env.NODE_ENV` to `'development'` — so the override would have fired in rapidpro **production** and pointed completions at a non-existent URL. Replaced with the dedicated `__TEMBA_DEV_SERVER__` token that is only `true` on the dev server; verified the production bundle resolves `isDevServer()` to constant-`false`.
- Confirmed the CORS preflight handling is correct: `getUrl` uses default `same-origin` credentials, so the `Allow-Origin: *` + `Allow-Headers: *` combination is valid (no credentialed-wildcard conflict).

## Test plan

- [x] Full suite green in the devcontainer (1825 passed, 6 pre-existing skips)
- [x] `temba-store` tests pass with the new token defined as `false` in the test runner
- [x] Verified the production IIFE bundle fully replaces `__TEMBA_DEV_SERVER__` (no literal token remains) so the dev override branch is unreachable in production
- [x] `pnpm build` and `pnpm format` clean