### PR TITLE
Validate flow-editor field lengths and flow-type availability

### DIFF
--- a/src/flow/NodeEditor.ts
+++ b/src/flow/NodeEditor.ts
@@ -1129,11 +1129,16 @@ export class NodeEditor extends RapidElement {
             }
           }
 
-          // Check required fields (skip in localization mode since all fields are optional)
+          // Check required fields (skip in localization mode since all fields are optional).
+          // A whitespace-only string counts as empty here - otherwise it slips past this
+          // check and is emitted (e.g. trimmed to "") into the definition, which the backend
+          // then rejects (e.g. a dial wait with an empty phone).
           if (
             !this.isTranslating &&
             (fieldConfig as any).required &&
-            (!value || (Array.isArray(value) && value.length === 0))
+            (!value ||
+              (typeof value === 'string' && value.trim() === '') ||
+              (Array.isArray(value) && value.length === 0))
           ) {
             errors[fieldName] = `${
               (fieldConfig as any).label || fieldName
@@ -1151,17 +1156,32 @@ export class NodeEditor extends RapidElement {
             } must be at least ${(fieldConfig as any).minLength} characters`;
           }
 
-          // Check maxLength for text fields
-          if (
-            typeof value === 'string' &&
-            (fieldConfig as any).maxLength &&
-            value.length > (fieldConfig as any).maxLength
-          ) {
-            errors[fieldName] = `${
-              (fieldConfig as any).label || fieldName
-            } must be no more than ${
-              (fieldConfig as any).maxLength
-            } characters`;
+          // Check maxLength for text fields, as well as for the values of select/tag
+          // items (e.g. result names, quick replies) which are stored as arrays of
+          // option objects (or plain strings) rather than a single string. Without the
+          // array/object handling, an over-long value here is emitted into the definition
+          // and rejected by the backend (goflow caps result names at 64 and quick replies
+          // at 1000 chars).
+          const maxLength = (fieldConfig as any).maxLength;
+          if (maxLength) {
+            const itemLength = (item: any): number => {
+              if (typeof item === 'string') return item.length;
+              if (item && typeof item === 'object') {
+                const text = item.value ?? item.name;
+                return typeof text === 'string' ? text.length : 0;
+              }
+              return 0;
+            };
+
+            const exceedsMax = Array.isArray(value)
+              ? value.some((item) => itemLength(item) > maxLength)
+              : itemLength(value) > maxLength;
+
+            if (exceedsMax) {
+              errors[fieldName] = `${
+                (fieldConfig as any).label || fieldName
+              } must be no more than ${maxLength} characters`;
+            }
           }
         });
       }

--- a/src/flow/actions/add_input_labels.ts
+++ b/src/flow/actions/add_input_labels.ts
@@ -6,7 +6,10 @@ import { renderNamedObjects } from '../utils';
 export const add_input_labels: ActionConfig = {
   name: 'Add Input Labels',
   group: ACTION_GROUPS.save,
-  flowTypes: [FlowTypes.VOICE, FlowTypes.MESSAGE, FlowTypes.BACKGROUND],
+  // Not allowed in background flows: goflow treats add_input_labels as an interactive
+  // action (messaging, messaging_offline, voice only), so offering it in a
+  // messaging_background flow produces a definition the backend rejects.
+  flowTypes: [FlowTypes.VOICE, FlowTypes.MESSAGE],
   render: (_node: Node, action: AddInputLabels) => {
     return html`<div>${renderNamedObjects(action.labels, 'label')}</div>`;
   },

--- a/src/flow/actions/send_msg.ts
+++ b/src/flow/actions/send_msg.ts
@@ -81,6 +81,7 @@ export const send_msg: ActionConfig = {
       searchable: true,
       placeholder: 'Add quick replies...',
       maxItems: 10,
+      maxLength: 1000,
       evaluated: true
     },
     template: {

--- a/src/flow/actions/set_run_result.ts
+++ b/src/flow/actions/set_run_result.ts
@@ -21,6 +21,7 @@ export const set_run_result: ActionConfig = {
       label: 'Result Name',
       helpText: 'Select an existing result name or type a new one',
       required: true,
+      maxLength: 64,
       placeholder: 'Select or enter result name...',
       createArbitraryOption: (input, options) => {
         const exists = options.some(

--- a/test/temba-node-editor.test.ts
+++ b/test/temba-node-editor.test.ts
@@ -520,6 +520,95 @@ describe('temba-node-editor', () => {
     expect(shadowRoot).to.not.be.null;
   });
 
+  it('enforces goflow length limits on select/tag item values', async () => {
+    // goflow caps quick replies at 1000 chars (send_msg)
+    let el = (await fixture(html`
+      <temba-node-editor
+        .action=${{
+          uuid: 'len-1',
+          type: 'send_msg',
+          text: 'Hi',
+          quick_replies: []
+        }}
+        .isOpen=${true}
+      ></temba-node-editor>
+    `)) as NodeEditorElement;
+    await el.updateComplete;
+
+    // a normal quick reply passes
+    (el as any).formData = {
+      uuid: 'len-1',
+      text: 'Hi',
+      quick_replies: [{ value: 'Yes', name: 'Yes' }]
+    };
+    expect((el as any).validateForm().valid).to.be.true;
+
+    // one longer than 1000 chars is rejected
+    const longReply = 'x'.repeat(1001);
+    (el as any).formData = {
+      uuid: 'len-1',
+      text: 'Hi',
+      quick_replies: [{ value: longReply, name: longReply }]
+    };
+    let result = (el as any).validateForm();
+    expect(result.valid).to.be.false;
+    expect(result.errors.quick_replies).to.exist;
+
+    // goflow caps result names at 64 chars (set_run_result)
+    el = (await fixture(html`
+      <temba-node-editor
+        .action=${{
+          uuid: 'len-2',
+          type: 'set_run_result',
+          name: 'Age',
+          value: '@input',
+          category: ''
+        }}
+        .isOpen=${true}
+      ></temba-node-editor>
+    `)) as NodeEditorElement;
+    await el.updateComplete;
+
+    const longName = 'n'.repeat(65);
+    (el as any).formData = {
+      uuid: 'len-2',
+      name: [{ value: longName, name: longName }],
+      value: '@input',
+      category: ''
+    };
+    result = (el as any).validateForm();
+    expect(result.valid).to.be.false;
+    expect(result.errors.name).to.exist;
+  });
+
+  it('treats a whitespace-only required field as empty', async () => {
+    // a required field containing only whitespace must fail validation - otherwise
+    // it slips through and is emitted (e.g. trimmed to "") and rejected by the backend
+    const el = (await fixture(html`
+      <temba-node-editor
+        .action=${{
+          uuid: 'ws-1',
+          type: 'send_email',
+          addresses: ['help@nyaruka.com'],
+          subject: 'Hello',
+          body: 'Body'
+        }}
+        .isOpen=${true}
+      ></temba-node-editor>
+    `)) as NodeEditorElement;
+    await el.updateComplete;
+
+    (el as any).formData = {
+      uuid: 'ws-1',
+      addresses: [{ value: 'help@nyaruka.com', name: 'help@nyaruka.com' }],
+      subject: '   ',
+      body: 'Body'
+    };
+    const result = (el as any).validateForm();
+    expect(result.valid).to.be.false;
+    expect(result.errors.subject).to.exist;
+  });
+
   it('displays bubble count for accordion value counts', async () => {
     const action = {
       uuid: 'test-action-uuid',

--- a/test/temba-node-type-selector.test.ts
+++ b/test/temba-node-type-selector.test.ts
@@ -118,6 +118,27 @@ describe('temba-node-type-selector', () => {
     expect(titles).to.include('Split by Contact Field');
   });
 
+  it('does not offer Add Input Labels in background flows', async () => {
+    const selector = await createSelector();
+
+    const titlesFor = async (flowType: string) => {
+      selector.flowType = flowType as any;
+      await selector.updateComplete;
+      selector.show('all', { x: 100, y: 100 });
+      await selector.updateComplete;
+      return Array.from(
+        selector.shadowRoot?.querySelectorAll('.node-item-title') || []
+      ).map((item) => item.textContent?.trim());
+    };
+
+    // available in messaging flows
+    expect(await titlesFor('message')).to.include('Add Input Labels');
+
+    // not available in background flows: goflow treats add_input_labels as an
+    // interactive action that a messaging_background flow rejects
+    expect(await titlesFor('background')).to.not.include('Add Input Labels');
+  });
+
   it('shows Call AI in action categories (not a separate branching section)', async () => {
     const selector = await createSelector();
     selector.flowType = 'message';


### PR DESCRIPTION
## Summary

The flow editor can generate flow definitions that the backend (goflow, via mailroom) rejects on save — blocking the user with a generic "Your flow failed validation" error. This tightens the editor's form validation to match goflow's rules so those definitions can't be produced in the first place.

## Changes

**Form validation — `src/flow/NodeEditor.ts`**
- The `required` check now treats a whitespace-only string as empty. Previously a required field (e.g. a dial wait's `phone`) could pass validation as `"   "` and then be emitted as `""`, which goflow rejects.
- The `maxLength` check now also covers `select`/tag field values, which are stored as arrays of option objects (or plain strings) rather than a single string. Previously `maxLength` was only enforced on `typeof value === 'string'`.

**Field limits (to match goflow)**
- `set_run_result.ts`: result name capped at 64 chars (goflow `result_name` max).
- `send_msg.ts`: quick replies capped at 1000 chars each (goflow per-reply max).

**Flow-type availability**
- `add_input_labels.ts`: no longer offered in background flows. goflow treats `add_input_labels` as an interactive action not allowed in `messaging_background`. Offline flows are no longer supported by the editor, so its `BACKGROUND` type now only maps to `messaging_background`.

## Review notes

A pre-PR review verified the diff against goflow v0.276.5 and returned a `ready` verdict (no medium-or-higher findings). It confirmed:
- the new array/object `maxLength` logic handles every field shape actually used, with no false positives on existing text fields (`category` 36, `result_name` 64) and no missed shapes on the array fields;
- the whitespace-`required` change is safe across all required fields (none treat whitespace as meaningful; the one space-valued option field is a non-required select, untouched);
- `add_input_labels` is the only interactive action, so the flow-type fix is complete — no analogous mismatch remains.

Two low-severity notes were intentionally left as-is: `itemLength` assumes `value`/`name` keys (no current `maxLength` field uses a custom `valueKey`/`nameKey`), and the length check runs on untrimmed input (correct here — quick replies and result names are emitted untrimmed, so this mirrors what goflow sees).

## Test plan

- [x] Added unit tests for select/tag length limits (quick reply > 1000, result name > 64) and whitespace-only required field — `test/temba-node-editor.test.ts`
- [x] Added selector test: `add_input_labels` present in message flows, absent in background — `test/temba-node-type-selector.test.ts`
- [x] Full suite green in the devcontainer: 1829 passed, 0 failed, 6 skipped
- [x] `pnpm format` and `pnpm build` clean