### PR TITLE
Send and show typing indicators in contact chat

### DIFF
--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -1245,6 +1245,9 @@ export class Chat extends RapidElement {
     const today = new Date();
     const msgIds = group.messages;
 
+    // whether the typing indicator renders as the latest bubble of this group
+    const appendTyping = idx === 0 && this.typingJoinsNewestGroup();
+
     const mostRecentId = msgIds[msgIds.length - 1];
     const currentMsg = this.msgMap.get(mostRecentId);
 
@@ -1351,7 +1354,8 @@ export class Chat extends RapidElement {
                   (statusClass === 'failed' || statusClass === 'errored'));
               const unsendableClass = hasError ? 'error' : '';
               const deletedClass = msgEvent._deleted ? 'deleted' : '';
-              const latestClass = index === msgIds.length - 1 ? 'latest' : '';
+              const latestClass =
+                index === msgIds.length - 1 && !appendTyping ? 'latest' : '';
               const eventClass = msg._rendered ? 'is-event' : '';
               const noteClass = msg.type === 'ticket_note_added' ? 'note' : '';
               const matchClass =
@@ -1368,6 +1372,7 @@ export class Chat extends RapidElement {
               </div>`;
             }
           )}
+          ${appendTyping ? this.renderTypingBubble() : null}
         </div>
         ${showAvatar
           ? html`<div class="avatar" style="align-self:flex-end">
@@ -1392,21 +1397,40 @@ export class Chat extends RapidElement {
     return { html: resultHtml, timestamp: newLastShownTimestamp };
   }
 
-  // renders an animated bubble indicating the contact is typing, styled to
-  // match a message group from the contact
+  // renders the row containing the animated typing bubble
+  private renderTypingBubble(): TemplateResult {
+    return html`<div class="row message latest">
+      <div class="bubble-wrap">
+        <div class="bubble">
+          <div class="typing-dots"><span></span><span></span><span></span></div>
+        </div>
+      </div>
+    </div>`;
+  }
+
+  // whether the typing indicator should render as part of the newest message group rather
+  // than as its own group - the same rules used to group the contact's messages
+  private typingJoinsNewestGroup(): boolean {
+    if (!this.typing || this.messageGroups.length === 0) {
+      return false;
+    }
+    const group = this.messageGroups[0];
+    const lastMsg = this.msgMap.get(group.messages[group.messages.length - 1]);
+    if (!lastMsg || lastMsg.type !== 'msg_received') {
+      return false;
+    }
+    return (
+      Math.abs(Date.now() - lastMsg.created_on.getTime()) < BATCH_TIME_WINDOW
+    );
+  }
+
+  // renders an animated bubble indicating the contact is typing, as its own group styled
+  // to match a message group from the contact
   private renderTyping(): TemplateResult {
     const showAvatar = this.avatars && this.agent;
     return html`<div class="block ${this.agent ? 'outgoing' : 'incoming'}">
       <div class="group-messages" style="flex-grow:1">
-        <div class="row message latest">
-          <div class="bubble-wrap">
-            <div class="bubble">
-              <div class="typing-dots">
-                <span></span><span></span><span></span>
-              </div>
-            </div>
-          </div>
-        </div>
+        ${this.renderTypingBubble()}
       </div>
       ${showAvatar
         ? html`<div class="avatar" style="align-self:flex-end">
@@ -1576,7 +1600,9 @@ export class Chat extends RapidElement {
         ${this.hideTopScroll ? 'scroll-at-top' : ''}"
     >
       <div class="scroll" @scroll=${this.handleScroll}>
-        ${this.typing ? this.renderTyping() : null}
+        ${this.typing && !this.typingJoinsNewestGroup()
+          ? this.renderTyping()
+          : null}
         ${this.messageGroups
           ? (() => {
               let lastTimestamp: Date | null = null;

--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -904,6 +904,7 @@ export class Chat extends RapidElement {
         this.fetching = false;
         // first add messages to the map
         const newMessages = [];
+        let newIncoming = false;
         for (const m of messages) {
           // filter out metadata events - they aren't rendered but cached for later reference
           if (m.type === 'msg_deleted' || m.type === 'msg_status_changed') {
@@ -916,6 +917,7 @@ export class Chat extends RapidElement {
 
           if (this.addMessage(m)) {
             newMessages.push(m.uuid);
+            newIncoming = newIncoming || m.type === 'msg_received';
           }
         }
 
@@ -932,6 +934,12 @@ export class Chat extends RapidElement {
 
         const grouped = this.groupMessages(newMessages);
         this.insertGroups(grouped, append);
+
+        // a new message from the contact takes the typing bubble's place - clearing typing in
+        // the same render means the bubble appears to fill in with the message
+        if (append && newIncoming) {
+          this.typing = false;
+        }
 
         // show notification if new messages are appended and user is scrolled away from bottom
         // but not during search (searchHighlight is set)

--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -313,6 +313,42 @@ export class Chat extends RapidElement {
         color: rgba(255, 255, 255, 0.7);
       }
 
+      .typing-dots {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 0;
+      }
+
+      .typing-dots span {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: rgba(0, 0, 0, 0.35);
+        animation: typing-blink 1.2s infinite both;
+      }
+
+      .typing-dots span:nth-child(2) {
+        animation-delay: 0.2s;
+      }
+
+      .typing-dots span:nth-child(3) {
+        animation-delay: 0.4s;
+      }
+
+      @keyframes typing-blink {
+        0%,
+        80%,
+        100% {
+          opacity: 0.25;
+          transform: translateY(0);
+        }
+        40% {
+          opacity: 1;
+          transform: translateY(-2px);
+        }
+      }
+
       .note .bubble {
         background: #fffac3;
         border: 1px solid #e8d169;
@@ -828,6 +864,10 @@ export class Chat extends RapidElement {
 
   @property({ type: Boolean })
   showTimestamps = true;
+
+  // whether the contact is currently typing, shown as an animated bubble
+  @property({ type: Boolean })
+  typing = false;
 
   @property({ type: String, attribute: false })
   searchHighlight: string = null;
@@ -1352,6 +1392,35 @@ export class Chat extends RapidElement {
     return { html: resultHtml, timestamp: newLastShownTimestamp };
   }
 
+  // renders an animated bubble indicating the contact is typing, styled to
+  // match a message group from the contact
+  private renderTyping(): TemplateResult {
+    const showAvatar = this.avatars && this.agent;
+    return html`<div class="block ${this.agent ? 'outgoing' : 'incoming'}">
+      <div class="group-messages" style="flex-grow:1">
+        <div class="row message latest">
+          <div class="bubble-wrap">
+            <div class="bubble">
+              <div class="typing-dots">
+                <span></span><span></span><span></span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      ${showAvatar
+        ? html`<div class="avatar" style="align-self:flex-end">
+            <temba-user
+              uuid=${this.contactUuid ?? nothing}
+              name=${this.contactName ?? nothing}
+              ?system=${!this.contactUuid && !this.contactName}
+            >
+            </temba-user>
+          </div>`
+        : null}
+    </div>`;
+  }
+
   private renderNote(
     event: TicketEvent,
     name: string | null,
@@ -1507,6 +1576,7 @@ export class Chat extends RapidElement {
         ${this.hideTopScroll ? 'scroll-at-top' : ''}"
     >
       <div class="scroll" @scroll=${this.handleScroll}>
+        ${this.typing ? this.renderTyping() : null}
         ${this.messageGroups
           ? (() => {
               let lastTimestamp: Date | null = null;

--- a/src/events.ts
+++ b/src/events.ts
@@ -117,4 +117,5 @@ export type CallStartedEvent = ContactEvent;
 export interface ContactHistoryPage {
   events: ContactEvent[];
   next: string | null;
+  typing?: boolean;
 }

--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -1101,7 +1101,14 @@ export class ContactChat extends ContactStoreElement {
         if (fetchContact === this.currentContact.uuid) {
           const hasNewEvents = messages.length > 0;
           chat.addMessages(messages, null, true);
-          chat.typing = !!page.typing;
+          // typing turns on immediately, but when new events are arriving leave clearing
+          // it to the chat, so that an incoming message replaces the typing bubble in the
+          // same render rather than the bubble disappearing first
+          if (page.typing) {
+            chat.typing = true;
+          } else if (!hasNewEvents) {
+            chat.typing = false;
+          }
           this.polling = false;
           // keep polling quickly while the contact is typing
           this.scheduleRefresh(hasNewEvents || !!page.typing);

--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -45,6 +45,9 @@ export const MIN_CHAT_REFRESH = 500;
 export const BODY_SNIPPET_LENGTH = 250;
 */
 
+// how often we send typing indicators while the user is composing
+export const TYPING_THROTTLE = 4000;
+
 // re-export for backwards compatibility
 export { renderTicketAction, renderTicketAssigneeChanged };
 
@@ -529,6 +532,9 @@ export class ContactChat extends ContactStoreElement {
   beforeUUID: string = null; // for scrolling back through history
   afterUUID: string = null; // for polling new messages
   refreshId = null;
+
+  // last time we sent a typing indicator for the user
+  lastTypingSent = 0;
   polling = false;
   pollingInterval = 2000; // start at 2 seconds
   lastFetchTime: number = null;
@@ -924,6 +930,26 @@ export class ContactChat extends ContactStoreElement {
     compose.triggerSend();
   }
 
+  private handleComposeChanged(evt: CustomEvent) {
+    const text = evt.detail?.und?.text;
+    if (!this.currentContact || !text) {
+      return;
+    }
+
+    // let the contact know we're typing, at most once per throttle window
+    const now = Date.now();
+    if (now - this.lastTypingSent < TYPING_THROTTLE) {
+      return;
+    }
+    this.lastTypingSent = now;
+
+    postJSON(`/contact/chat/${this.currentContact.uuid}/`, {
+      typing: true
+    }).catch(() => {
+      // typing indicators are best effort
+    });
+  }
+
   private handleSend(evt: CustomEvent) {
     this.errorMessage = null;
     const composeEle = evt.currentTarget as Compose;
@@ -1075,8 +1101,10 @@ export class ContactChat extends ContactStoreElement {
         if (fetchContact === this.currentContact.uuid) {
           const hasNewEvents = messages.length > 0;
           chat.addMessages(messages, null, true);
+          chat.typing = !!page.typing;
           this.polling = false;
-          this.scheduleRefresh(hasNewEvents);
+          // keep polling quickly while the contact is typing
+          this.scheduleRefresh(hasNewEvents || !!page.typing);
         } else {
           this.polling = false;
         }
@@ -1238,6 +1266,7 @@ export class ContactChat extends ContactStoreElement {
           shortcuts
           min-height="75"
           @temba-submitted=${this.handleSend.bind(this)}
+          @temba-content-changed=${this.handleComposeChanged.bind(this)}
         >
         </temba-compose>
         ${this.errorMessage

--- a/test/temba-chat.test.ts
+++ b/test/temba-chat.test.ts
@@ -124,4 +124,42 @@ describe('temba-chat typing indicator', () => {
     const blocks = chat.shadowRoot.querySelectorAll('.block');
     assert.equal(blocks.length, 2);
   });
+
+  it('is cleared by an incoming message but not an outgoing one', async () => {
+    const chat = await createChat(
+      'contactname="Jane Doe" contactuuid="contact-1"'
+    );
+    chat.loadMessages([received('msg-1', 'hello there')]);
+    await chat.updateComplete;
+
+    chat.typing = true;
+    await chat.updateComplete;
+
+    // an incoming message takes the typing bubble's place
+    chat.addMessages(
+      [received('msg-2', 'here is my question')],
+      new Date(Date.now() - 10000),
+      true
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    await chat.updateComplete;
+
+    assert.isFalse(chat.typing);
+    assert.isNull(chat.shadowRoot.querySelector('.typing-dots'));
+
+    // but an outgoing message leaves it showing
+    chat.typing = true;
+    await chat.updateComplete;
+
+    chat.addMessages(
+      [created('msg-3', 'good question')],
+      new Date(Date.now() - 10000),
+      true
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    await chat.updateComplete;
+
+    assert.isTrue(chat.typing);
+    assert.isNotNull(chat.shadowRoot.querySelector('.typing-dots'));
+  });
 });

--- a/test/temba-chat.test.ts
+++ b/test/temba-chat.test.ts
@@ -64,6 +64,14 @@ describe('temba-chat contact avatars', () => {
   });
 });
 
+const created = (uuid: string, text: string): ContactEvent =>
+  ({
+    uuid,
+    type: 'msg_created',
+    created_on: new Date(),
+    msg: { text }
+  }) as ContactEvent;
+
 describe('temba-chat typing indicator', () => {
   it('shows an animated typing bubble while the contact is typing', async () => {
     const chat = await createChat(
@@ -80,5 +88,40 @@ describe('temba-chat typing indicator', () => {
     chat.typing = false;
     await chat.updateComplete;
     assert.isNull(chat.shadowRoot.querySelector('.typing-dots'));
+  });
+
+  it('joins the newest message group when it is from the contact', async () => {
+    const chat = await createChat(
+      'contactname="Jane Doe" contactuuid="contact-1"'
+    );
+    chat.loadMessages([received('msg-1', 'hello there')]);
+    await chat.updateComplete;
+
+    chat.typing = true;
+    await chat.updateComplete;
+
+    // typing bubble renders inside the contact's group, not as its own block
+    const blocks = chat.shadowRoot.querySelectorAll('.block');
+    assert.equal(blocks.length, 1);
+    assert.isNotNull(blocks[0].querySelector('.typing-dots'));
+
+    // and the typing bubble takes over as the latest bubble in the group
+    const latest = blocks[0].querySelectorAll('.row.latest');
+    assert.equal(latest.length, 1);
+    assert.isNotNull(latest[0].querySelector('.typing-dots'));
+  });
+
+  it('renders as its own group when the newest message is outgoing', async () => {
+    const chat = await createChat(
+      'contactname="Jane Doe" contactuuid="contact-1"'
+    );
+    chat.loadMessages([created('msg-1', 'how can we help?')]);
+    await chat.updateComplete;
+
+    chat.typing = true;
+    await chat.updateComplete;
+
+    const blocks = chat.shadowRoot.querySelectorAll('.block');
+    assert.equal(blocks.length, 2);
   });
 });

--- a/test/temba-chat.test.ts
+++ b/test/temba-chat.test.ts
@@ -63,3 +63,22 @@ describe('temba-chat contact avatars', () => {
     assert.isNotNull(user.bgimage);
   });
 });
+
+describe('temba-chat typing indicator', () => {
+  it('shows an animated typing bubble while the contact is typing', async () => {
+    const chat = await createChat(
+      'contactname="Jane Doe" contactuuid="contact-1"'
+    );
+    chat.loadMessages([received('msg-1', 'hello there')]);
+    await chat.updateComplete;
+    assert.isNull(chat.shadowRoot.querySelector('.typing-dots'));
+
+    chat.typing = true;
+    await chat.updateComplete;
+    assert.isNotNull(chat.shadowRoot.querySelector('.typing-dots'));
+
+    chat.typing = false;
+    await chat.updateComplete;
+    assert.isNull(chat.shadowRoot.querySelector('.typing-dots'));
+  });
+});

--- a/test/temba-contact-chat.test.ts
+++ b/test/temba-contact-chat.test.ts
@@ -239,6 +239,53 @@ describe('temba-contact-chat', () => {
     );
   });
 
+  it('sends throttled typing indicators while composing', async () => {
+    await loadStore();
+    const chat: ContactChat = await getContactChat({
+      contact: 'contact-dave-active'
+    });
+    mockPOST(/contact\/chat\/contact-dave-active\//, {});
+
+    const compose = chat.shadowRoot.querySelector('temba-compose') as Compose;
+    const fetchStub = window.fetch as SinonStub;
+
+    const typingPosts = () =>
+      fetchStub.getCalls().filter((call) => {
+        return (
+          `${call.args[0]}`.includes('/contact/chat/contact-dave-active/') &&
+          call.args[1]?.body === JSON.stringify({ typing: true })
+        );
+      });
+
+    const typeSomething = (text: string) => {
+      compose.dispatchEvent(
+        new CustomEvent(CustomEventType.ContentChanged, {
+          detail: { und: { text } }
+        })
+      );
+    };
+
+    // move past the initial throttle window (fake timers start at zero)
+    clock.tick(5000);
+
+    typeSomething('hello');
+    expect(typingPosts().length).to.equal(1);
+
+    // more typing inside the throttle window doesn't send another
+    typeSomething('hello wor');
+    expect(typingPosts().length).to.equal(1);
+
+    // but once the throttle window passes it does
+    clock.tick(5000);
+    typeSomething('hello world');
+    expect(typingPosts().length).to.equal(2);
+
+    // clearing the compose doesn't send typing
+    clock.tick(5000);
+    typeSomething('');
+    expect(typingPosts().length).to.equal(2);
+  });
+
   it('shows failure message with retry', async () => {
     // we are a StoreElement, so load a store first
     await loadStore();


### PR DESCRIPTION
* `temba-contact-chat` sends a throttled `{"typing": true}` POST to the chat endpoint while the user is composing (at most every 4s, matching courier's 10s marker)
* Chat polling responses now include a `typing` flag which renders as an animated dots bubble in `temba-chat` and keeps polling at the fast interval
* The typing bubble collapses into the contact's newest message group using the same author/time-window rules as message grouping, taking over the `latest` corner styling
* When the contact's message arrives, the chat clears typing in the same render that inserts the message, so the bubble fills in with the message instead of flickering away first (an outgoing message leaves it showing)
