### PR TITLE
Fix empty contact fields tab from definition/data load race

### DIFF
--- a/src/live/ContactFields.ts
+++ b/src/live/ContactFields.ts
@@ -94,9 +94,32 @@ export class ContactFields extends ContactStoreElement {
   @property({ type: Boolean })
   disabled = false;
 
+  // tracks whether the store's contact field definitions have loaded. these
+  // load independently of the contact data this element fetches, so we can't
+  // render field rows until they're present (see render). this is reactive so
+  // that flipping it re-renders once the definitions arrive.
+  @property({ type: Boolean, attribute: false })
+  fieldsReady = false;
+
   connectedCallback(): void {
     super.connectedCallback();
     this.handleFieldChanged = this.handleFieldChanged.bind(this);
+
+    // field definitions are usually already loaded by the time this element
+    // connects, but during a cold load they may still be in flight
+    this.fieldsReady =
+      !!this.store &&
+      (this.store.ready ||
+        (this.store.getKeyedAssets()['fields'] || []).length > 0);
+  }
+
+  protected storeUpdated(event: CustomEvent) {
+    super.storeUpdated(event);
+    // the store fires a StoreUpdated for the fields endpoint once the field
+    // definitions have loaded; that's our signal that it's safe to render
+    if (this.store && event.detail.url === this.store.fieldsEndpoint) {
+      this.fieldsReady = true;
+    }
   }
 
   private isAgent(): boolean {
@@ -148,9 +171,17 @@ export class ContactFields extends ContactStoreElement {
   }
 
   public render(): TemplateResult {
-    if (this.data) {
-      const fieldsToShow = Object.entries(this.data.fields).sort(
-        (a: [string, string], b: [string, string]) => {
+    // we need both the contact data and the field definitions (loaded during
+    // store init) before we can render. these load independently, so the
+    // contact data can arrive first; rendering then would crash on missing
+    // field definitions and leave the tab empty (see getContactField below).
+    if (this.data && this.fieldsReady) {
+      // guard against keys with no matching field definition (mid-load races
+      // or fields that have since been deleted) so a single missing
+      // definition can't throw and blank out the entire tab
+      const fieldsToShow = Object.entries(this.data.fields)
+        .filter(([key]: [string, string]) => !!this.store.getContactField(key))
+        .sort((a: [string, string], b: [string, string]) => {
           const [ak] = a;
           const [bk] = b;
           const fieldA = this.store.getContactField(ak);
@@ -212,8 +243,7 @@ export class ContactFields extends ContactStoreElement {
           }
 
           return ak.localeCompare(bk);
-        }
-      );
+        });
 
       if (fieldsToShow.length == 0) {
         return html`<slot name="empty"></slot>`;

--- a/test/temba-contact-fields.test.ts
+++ b/test/temba-contact-fields.test.ts
@@ -56,4 +56,59 @@ describe(TAG, () => {
 
     // await assertScreenshot('contacts/fields-updated', getClip(fields));
   });
+
+  // regression: the contact data and the store's field definitions load
+  // independently. if the contact data arrives first (more likely under
+  // Firefox's request scheduling) we must not render against missing field
+  // definitions, which previously threw and left the tab blank.
+  it('does not render or crash before field definitions load', async () => {
+    await loadStore();
+    const fields: ContactFields = await getFields({
+      contact: 'contact-dave-active'
+    });
+
+    // simulate the race: contact data present, but definitions not yet loaded
+    fields.fieldsReady = false;
+    await fields.updateComplete;
+
+    // nothing should render and, crucially, render must not throw
+    expect(fields.shadowRoot.querySelectorAll('temba-contact-field').length).to.equal(
+      0
+    );
+
+    // once the definitions arrive, the fields populate
+    fields.fieldsReady = true;
+    await fields.updateComplete;
+    expect(
+      fields.shadowRoot.querySelectorAll('temba-contact-field').length
+    ).to.be.greaterThan(0);
+  });
+
+  // regression: a contact may carry a field key whose definition no longer
+  // exists (e.g. a deleted field). a single missing definition must not throw
+  // and blank out the entire tab.
+  it('ignores contact field keys with no matching definition', async () => {
+    await loadStore();
+    const fields: ContactFields = await getFields({
+      contact: 'contact-dave-active'
+    });
+
+    const known = fields.shadowRoot.querySelectorAll(
+      'temba-contact-field'
+    ).length;
+    expect(known).to.be.greaterThan(0);
+
+    // inject a field key that has no definition in the store
+    fields.data = {
+      ...fields.data,
+      fields: { ...fields.data.fields, nonexistent_field_xyz: 'orphan value' }
+    };
+    await fields.updateComplete;
+
+    // render must not throw and the orphan key must be dropped, leaving the
+    // known fields intact
+    expect(
+      fields.shadowRoot.querySelectorAll('temba-contact-field').length
+    ).to.equal(known);
+  });
 });

--- a/test/temba-contact-fields.test.ts
+++ b/test/temba-contact-fields.test.ts
@@ -72,9 +72,9 @@ describe(TAG, () => {
     await fields.updateComplete;
 
     // nothing should render and, crucially, render must not throw
-    expect(fields.shadowRoot.querySelectorAll('temba-contact-field').length).to.equal(
-      0
-    );
+    expect(
+      fields.shadowRoot.querySelectorAll('temba-contact-field').length
+    ).to.equal(0);
 
     // once the definitions arrive, the fields populate
     fields.fieldsReady = true;


### PR DESCRIPTION
## Summary

Fixes the intermittent empty "fields" tab on the contact read page. The bug was a race between two independent async loads, and surfaced more often in Firefox.

## Root cause

The fields tab needs two things that load via separate, unordered async paths:

1. **Contact data** (the field *values*) — fetched on demand when `<temba-contact-fields>` receives its `contact` attribute.
2. **Field definitions** (the field *metadata*: type, label, featured, priority) — loaded once at store init via `Store.refreshFields()` into `store.fields`.

`ContactFields.render()` only guarded on `if (this.data)`, then called `this.store.getContactField(key)` for every field key and immediately read `.type` / `.featured`. When contact data arrived **before** definitions loaded, `getContactField` returned `undefined`, the property access threw, the exception escaped Lit's render, and the whole tab rendered empty. Firefox's HTTP request scheduling makes the losing ordering more likely — it's a genuine race, not a browser bug.

## Changes

- **`src/live/ContactFields.ts`**
  - Added a reactive `fieldsReady` flag. Initialized in `connectedCallback` from current store state (`store.ready` OR definitions already present in `getKeyedAssets()['fields']`), and flipped to `true` in an overridden `storeUpdated()` when the store fires a `StoreUpdated` for `store.fieldsEndpoint`. `render()` now gates on `this.data && this.fieldsReady`.
  - Gating on `fieldsReady` rather than `store.ready` directly is deliberate: `ready` lives on the separate store element, so it would not trigger a re-render of `ContactFields` and the tab could stick empty permanently. `fieldsReady` is local reactive state and the fields `StoreUpdated` event reliably re-renders the component once definitions arrive.
  - Filters out field keys with no matching definition before sorting/mapping, so a stale or deleted field key can never throw and blank the tab.
- **`test/temba-contact-fields.test.ts`** — two regression tests.

## Review notes

Pre-PR review (expert-code-reviewer) verified race completeness across all load orderings: `fieldsReady` cannot remain false in any ordering (the connect-time init covers the fields-loaded-but-store-not-globally-ready window, and the `StoreUpdated` listener is registered synchronously before `refreshFields` resolves). The `storeUpdated` override calls `super` so the existing data-update path is preserved. Only low-severity/suggestion findings remained (use of `@property` vs `@state`, lookup repetition) — left as-is to match existing file conventions and keep the change minimal. Verdict: ready.

## Test plan

- [x] New regression test: does not render or crash before field definitions load (asserts no throw + empty render, then populates once `fieldsReady` flips)
- [x] New regression test: ignores contact field keys with no matching definition (orphan key dropped, known fields intact)
- [x] Full suite passes: 1855 passed, 0 failed, 6 skipped
- [x] `pnpm format` and `pnpm build` clean