### PR TITLE
Support legacy webhooks by preserving result_name placement

### DIFF
--- a/src/flow/nodes/split_by_webhook.ts
+++ b/src/flow/nodes/split_by_webhook.ts
@@ -200,7 +200,10 @@ export const split_by_webhook: NodeConfig = {
         callWebhookAction?.headers ||
         getDefaultHeadersRecord(callWebhookAction?.method || 'GET'),
       body: callWebhookAction?.body || '',
-      result_name: node.router?.result_name || ''
+      // Legacy webhooks store result_name on the action; modern ones store it
+      // on the router. Prefer the action so legacy nodes round-trip correctly.
+      result_name:
+        callWebhookAction?.result_name || node.router?.result_name || ''
     };
   },
   fromFormData: (formData: FormData, originalNode: Node): Node => {
@@ -213,8 +216,16 @@ export const split_by_webhook: NodeConfig = {
     // Find existing call_webhook action to preserve its UUID
     const existingCallWebhookAction = originalNode.actions?.find(
       (action) => action.type === 'call_webhook'
-    );
+    ) as CallWebhook | undefined;
     const callWebhookUuid = existingCallWebhookAction?.uuid || generateUUID();
+
+    // Legacy webhooks keep the result_name on the action rather than the
+    // router. Detect them by the presence of result_name on the existing
+    // action so they continue to round-trip in their original format instead
+    // of being silently migrated (which would change how results are
+    // referenced downstream of the flow).
+    const isLegacyResultName = !!existingCallWebhookAction?.result_name;
+    const trimmedResultName = formData.result_name?.trim() || '';
 
     // Create call_webhook action
     const callWebhookAction: CallWebhook = {
@@ -225,6 +236,11 @@ export const split_by_webhook: NodeConfig = {
       headers: formData.headers || [],
       body: formData.body || ''
     };
+
+    // Preserve the legacy placement: result_name stays on the action.
+    if (isLegacyResultName && trimmedResultName !== '') {
+      callWebhookAction.result_name = trimmedResultName;
+    }
 
     // Create categories and exits for Success and Failure
     const existingCategories = originalNode.router?.categories || [];
@@ -247,9 +263,11 @@ export const split_by_webhook: NodeConfig = {
       ...router
     };
 
-    // Only set result_name if provided
-    if (formData.result_name && formData.result_name.trim() !== '') {
-      finalRouter.result_name = formData.result_name.trim();
+    // Modern webhooks store result_name on the router. For legacy webhooks the
+    // result_name lives on the action (set above), so we leave it off the
+    // router to avoid storing it in both places.
+    if (!isLegacyResultName && trimmedResultName !== '') {
+      finalRouter.result_name = trimmedResultName;
     }
 
     // Return the complete node

--- a/test/nodes/split_by_webhook.test.ts
+++ b/test/nodes/split_by_webhook.test.ts
@@ -185,4 +185,145 @@ describe('split_by_webhook node config', () => {
       expect(resultNode.actions![0].uuid).to.equal('existing-action-uuid');
     });
   });
+
+  describe('legacy webhook result_name support', () => {
+    // Legacy webhooks (from the old flow editor) store the result_name on the
+    // call_webhook action. Modern webhooks store it on the router. These must
+    // be supported in parallel — editing a legacy webhook must keep it legacy
+    // because the placement changes how the result is referenced downstream.
+
+    const legacyNode: Node = {
+      uuid: 'd02536d0-7e86-47ab-8c60-fcf2678abc2b',
+      actions: [
+        {
+          type: 'call_webhook',
+          uuid: '9aa018e7-4934-457a-b582-63b164c562f7',
+          method: 'GET',
+          url: 'http://localhost/?cmd=country',
+          result_name: 'Country Webhook'
+        } as CallWebhook
+      ],
+      router: {
+        type: 'switch',
+        operand: '@results.country_webhook.category',
+        categories: [],
+        cases: []
+      } as any,
+      exits: []
+    };
+
+    const modernNode: Node = {
+      uuid: 'd02536d0-7e86-47ab-8c60-fcf2678abc2b',
+      actions: [
+        {
+          type: 'call_webhook',
+          uuid: '9aa018e7-4934-457a-b582-63b164c562f7',
+          method: 'GET',
+          url: 'http://localhost/?cmd=country'
+        } as CallWebhook
+      ],
+      router: {
+        type: 'switch',
+        operand: '@webhook.status',
+        result_name: 'Country Webhook',
+        categories: [],
+        cases: []
+      } as any,
+      exits: []
+    };
+
+    it('reads result_name from the action for legacy webhooks', () => {
+      const formData = split_by_webhook.toFormData!(legacyNode);
+      expect(formData.result_name).to.equal('Country Webhook');
+    });
+
+    it('reads result_name from the router for modern webhooks', () => {
+      const formData = split_by_webhook.toFormData!(modernNode);
+      expect(formData.result_name).to.equal('Country Webhook');
+    });
+
+    it('keeps result_name on the action when editing a legacy webhook', () => {
+      const formData = {
+        uuid: legacyNode.uuid,
+        method: [{ value: 'GET', name: 'GET' }],
+        url: 'http://localhost/?cmd=country',
+        headers: [],
+        body: '',
+        result_name: 'Country Webhook'
+      };
+
+      const resultNode = split_by_webhook.fromFormData!(formData, legacyNode);
+
+      const action = resultNode.actions![0] as CallWebhook;
+      expect(action.result_name).to.equal('Country Webhook');
+      // Should NOT also be duplicated onto the router
+      expect(resultNode.router!.result_name).to.be.undefined;
+    });
+
+    it('keeps result_name on the router when editing a modern webhook', () => {
+      const formData = {
+        uuid: modernNode.uuid,
+        method: [{ value: 'GET', name: 'GET' }],
+        url: 'http://localhost/?cmd=country',
+        headers: [],
+        body: '',
+        result_name: 'Country Webhook'
+      };
+
+      const resultNode = split_by_webhook.fromFormData!(formData, modernNode);
+
+      expect(resultNode.router!.result_name).to.equal('Country Webhook');
+      const action = resultNode.actions![0] as CallWebhook;
+      expect(action.result_name).to.be.undefined;
+    });
+
+    it('stores result_name on the router for brand new webhooks', () => {
+      const newNode: Node = {
+        uuid: 'new-node',
+        actions: [],
+        exits: []
+      };
+
+      const formData = {
+        uuid: 'new-node',
+        method: [{ value: 'GET', name: 'GET' }],
+        url: 'https://example.com/api',
+        headers: [],
+        body: '',
+        result_name: 'My Result'
+      };
+
+      const resultNode = split_by_webhook.fromFormData!(formData, newNode);
+
+      expect(resultNode.router!.result_name).to.equal('My Result');
+      const action = resultNode.actions![0] as CallWebhook;
+      expect(action.result_name).to.be.undefined;
+    });
+
+    it('round-trips a legacy webhook without migrating it to the modern format', () => {
+      const formData = split_by_webhook.toFormData!(legacyNode);
+      const resultNode = split_by_webhook.fromFormData!(formData, legacyNode);
+
+      const action = resultNode.actions![0] as CallWebhook;
+      expect(action.result_name).to.equal('Country Webhook');
+      expect(resultNode.router!.result_name).to.be.undefined;
+    });
+
+    it('drops the action result_name when a legacy webhook clears it', () => {
+      const formData = {
+        uuid: legacyNode.uuid,
+        method: [{ value: 'GET', name: 'GET' }],
+        url: 'http://localhost/?cmd=country',
+        headers: [],
+        body: '',
+        result_name: ''
+      };
+
+      const resultNode = split_by_webhook.fromFormData!(formData, legacyNode);
+
+      const action = resultNode.actions![0] as CallWebhook;
+      expect(action.result_name).to.be.undefined;
+      expect(resultNode.router!.result_name).to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Supports **legacy webhooks** in the flow editor so they keep their original on-disk structure when edited, instead of being silently migrated to the modern format. There is no realistic way to migrate existing flows, and the structural difference changes how the webhook's result is referenced downstream, so both formats must be supported in parallel.

## Analysis of the old flow editor

The original [floweditor webhook router](https://github.com/nyaruka/floweditor/tree/main/src/components/flow/routers/webhook) grandfathered legacy webhooks. Reading `helpers.ts`:

- **Read (`nodeToState`)** pulled the result name from *either* place:
  ```ts
  state.resultName = { value: action.result_name || router.result_name || '' };
  ```
- **Write (`stateToNode`)** kept the result name wherever it originally lived:
  ```ts
  // if the action had the result name, keep the result on the action rather than the router
  if (originalAction && originalAction.result_name) {
    newAction.result_name = state.resultName.value;
  }
  return createServiceCallSplitNode(
    newAction,
    settings.originalNode,
    '@webhook.status',
    Operators.has_number_between,
    ['200', '299'],
    newAction.result_name ? '' : state.resultName.value // put result on router only if not on action
  );
  ```

The key finding: the **only** thing the old editor grandfathered was the **placement of the result name** — on the `call_webhook` **action** (legacy) vs. on the **router** (modern). Even for legacy nodes, the old editor still wrote a modern `@webhook.status` / `has_number_between` router. The placement is what matters because:

- **Legacy** (`result_name` on the action): goflow categorizes the webhook on the action and the result is referenced as `@results.<name>.*`.
- **Modern** (`result_name` on the router): the router on `@webhook.status` owns the result.

Migrating one to the other would break existing `@results.<name>...` references elsewhere in a flow, which is why these are kept in parallel rather than converted.

## What was employed here and why

`src/flow/nodes/split_by_webhook.ts` previously read/wrote `result_name` **only** on the router, so opening and saving a legacy webhook would drop the action's `result_name` and move it to the router — exactly the migration we need to avoid. The fix mirrors the old editor's approach:

- **Read path (`toFormData`)** — reads `result_name` from `callWebhookAction?.result_name || node.router?.result_name`, so legacy nodes populate the form field.
- **Write path (`fromFormData`)** — detects legacy nodes by `result_name` being present on the existing action and, when legacy, writes `result_name` back onto the **action** (and leaves it off the router, avoiding duplication). Modern/new nodes keep `result_name` on the router as before.
- The operand stays `@webhook.status` with `has_number_between ['200','299']` in both cases, matching the old editor's behavior — only the result-name placement is grandfathered.

## Tests

Added a `legacy webhook result_name support` block to `test/nodes/split_by_webhook.test.ts` (7 tests) so this keeps working going forward:

- reads `result_name` from the action (legacy) and from the router (modern)
- keeps `result_name` on the action when editing a legacy webhook (and not duplicated on the router)
- keeps `result_name` on the router when editing a modern webhook
- stores `result_name` on the router for brand-new webhooks
- round-trips a legacy webhook without migrating it to the modern format
- drops the action's `result_name` when a legacy webhook clears the field

All webhook node tests pass (16/16); `pnpm build` is clean.
