### PR TITLE
Deliver contact chat events over realtime sockets instead of polling

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@jsplumb/browser-ui": "^6.2.10",
     "@lit/localize": "^0.12.2",
     "@open-wc/lit-helpers": "^0.7.0",
+    "centrifuge": "^5.7.0",
     "chart.js": "^4.5.1",
     "chartjs-adapter-luxon": "^1.3.1",
     "chartjs-plugin-datalabels": "^2.2.0",
@@ -68,6 +69,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.3.0",
     "@types/leaflet": "1.4.4",
+    "@types/mocha": "^10.0.0",
     "@types/node": "22.13.0",
     "@types/remarkable": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^7.5.0",
@@ -107,7 +109,6 @@
     "sinon": "^21.0.0",
     "svgstore": "^3.0.1",
     "tslib": "2.8.1",
-    "@types/mocha": "^10.0.0",
     "typescript": "5.9.3",
     "yargs": "^17.7.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@open-wc/lit-helpers':
         specifier: ^0.7.0
         version: 0.7.0(lit@3.3.2)
+      centrifuge:
+        specifier: ^5.7.0
+        version: 5.7.0
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
@@ -677,6 +680,33 @@ packages:
 
   '@parse5/tools@0.3.0':
     resolution: {integrity: sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@puppeteer/browsers@1.4.6':
     resolution: {integrity: sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==}
@@ -1525,6 +1555,9 @@ packages:
 
   centra@2.7.0:
     resolution: {integrity: sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==}
+
+  centrifuge@5.7.0:
+    resolution: {integrity: sha512-Ptx7ELyVc7/KgzpadVlISTtdTWsuzumze5/vo9sH4RsvtFulJJMhmKr/cNDg6se1eKKbS6ZywIBl4eSZxqY3fw==}
 
   chai-a11y-axe@1.5.0:
     resolution: {integrity: sha512-V/Vg/zJDr9aIkaHJ2KQu7lGTQQm5ZOH4u1k5iTMvIXuSVlSuUo0jcSpSqf9wUn9zl6oQXa4e4E0cqH18KOgKlQ==}
@@ -2797,6 +2830,9 @@ packages:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
     engines: {node: '>=10'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
@@ -3191,6 +3227,10 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-agent@6.3.0:
     resolution: {integrity: sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==}
@@ -4461,6 +4501,26 @@ snapshots:
     dependencies:
       parse5: 7.3.0
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
   '@puppeteer/browsers@1.4.6(typescript@5.9.3)':
     dependencies:
       debug: 4.3.4
@@ -5438,6 +5498,11 @@ snapshots:
       follow-redirects: 1.15.11
     transitivePeerDependencies:
       - debug
+
+  centrifuge@5.7.0:
+    dependencies:
+      events: 3.3.0
+      protobufjs: 7.6.4
 
   chai-a11y-axe@1.5.0:
     dependencies:
@@ -6939,6 +7004,8 @@ snapshots:
       slice-ansi: 4.0.0
       wrap-ansi: 6.2.0
 
+  long@5.3.2: {}
+
   lru-cache@7.18.3: {}
 
   lru-cache@8.0.5: {}
@@ -7306,6 +7373,20 @@ snapshots:
   process@0.11.10: {}
 
   progress@2.0.3: {}
+
+  protobufjs@7.6.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.13.0
+      long: 5.3.2
 
   proxy-agent@6.3.0:
     dependencies:

--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -838,6 +838,10 @@ export class Chat extends RapidElement {
   private msgMap = new Map<string, ContactEvent>();
   private metadataCache = new Map<string, ContactEvent>();
 
+  // bumped on reset so deferred addMessages work from before a reset is
+  // discarded rather than re-merged into the fresh view
+  private resetGeneration = 0;
+
   public firstUpdated(
     changed: PropertyValueMap<any> | Map<PropertyKey, unknown>
   ): void {
@@ -858,10 +862,16 @@ export class Chat extends RapidElement {
       startTime = new Date();
     }
 
+    const generation = this.resetGeneration;
     const elapsed = new Date().getTime() - startTime.getTime();
     window.setTimeout(
       () => {
         this.fetching = false;
+
+        // the chat was reset while we were waiting, our messages are stale
+        if (generation !== this.resetGeneration) {
+          return;
+        }
         // first add messages to the map
         const newMessages = [];
         for (const m of messages) {
@@ -905,6 +915,10 @@ export class Chat extends RapidElement {
         }
 
         window.setTimeout(() => {
+          if (generation !== this.resetGeneration) {
+            return;
+          }
+
           // when appending (new messages at bottom), adjust scroll to maintain visible content
           // with column-reverse, new content at bottom increases scrollHeight
           if (append && (isScrolledAway || maintainScroll)) {
@@ -1486,6 +1500,7 @@ export class Chat extends RapidElement {
   }
 
   public reset() {
+    this.resetGeneration++;
     this.msgMap.clear();
     this.messageGroups = [];
     this.hideBottomScroll = true;

--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -1502,6 +1502,7 @@ export class Chat extends RapidElement {
   public reset() {
     this.resetGeneration++;
     this.msgMap.clear();
+    this.metadataCache.clear();
     this.messageGroups = [];
     this.hideBottomScroll = true;
     this.hideTopScroll = true;

--- a/src/display/TembaUser.ts
+++ b/src/display/TembaUser.ts
@@ -116,6 +116,13 @@ export class TembaUser extends RapidElement {
     if (changed.has('avatar')) {
       if (this.avatar) {
         this.bgimage = `url('${this.avatar}') center / contain no-repeat`;
+      } else {
+        // clearing the avatar must also clear the image, otherwise a reused
+        // element keeps showing the previous user's avatar - fall back to the
+        // system default or the initials/contact-icon branch
+        this.bgimage = this.system
+          ? `url('${DEFAULT_AVATAR}') center / contain no-repeat`
+          : null;
       }
     }
   }

--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -522,9 +522,8 @@ export class ContactChat extends ContactStoreElement {
   beforeUUID: string = null; // for scrolling back through history
   afterUUID: string = null; // newest event seen, for catch-up fetches
 
-  // live socket subscriptions for the current contact (and ticket)
-  private subscriptions: SocketSubscription[] = [];
-  private subscribedChannels: string[] = [];
+  // live socket subscriptions by channel for the current contact (and ticket)
+  private subscriptions = new Map<string, SocketSubscription>();
   private fetchingMissed = false;
 
   constructor() {
@@ -590,8 +589,7 @@ export class ContactChat extends ContactStoreElement {
 
   private unsubscribeAll() {
     this.subscriptions.forEach((sub) => sub.unsubscribe());
-    this.subscriptions = [];
-    this.subscribedChannels = [];
+    this.subscriptions.clear();
   }
 
   /**
@@ -599,33 +597,43 @@ export class ContactChat extends ContactStoreElement {
    * ticket. New events arrive as they happen on "history:<contact-uuid>";
    * ticket detail events (notes, assignment, topic) only arrive on
    * "history:<contact-uuid>:<ticket-uuid>" so we subscribe to both when
-   * viewing a ticket.
+   * viewing a ticket. Only the channels that actually changed are touched,
+   * so switching tickets on the same contact leaves the contact channel
+   * continuously subscribed with no gap in delivery.
    */
   private updateSubscriptions() {
-    const channels = [];
+    const channels = new Set<string>();
     if (this.isConnected && this.currentContact) {
-      channels.push(`history:${this.currentContact.uuid}`);
+      channels.add(`history:${this.currentContact.uuid}`);
       if (this.currentTicket) {
-        channels.push(
+        channels.add(
           `history:${this.currentContact.uuid}:${this.currentTicket.uuid}`
         );
       }
     }
 
-    if (channels.join(',') === this.subscribedChannels.join(',')) {
-      return;
-    }
+    // drop subscriptions we no longer need
+    this.subscriptions.forEach((sub, channel) => {
+      if (!channels.has(channel)) {
+        sub.unsubscribe();
+        this.subscriptions.delete(channel);
+      }
+    });
 
-    this.unsubscribeAll();
-    this.subscribedChannels = channels;
-    this.subscriptions = channels.map((channel) =>
-      subscribeToSocket(
-        channel,
-        (data: any) => this.handleSocketEvent(data),
-        // on every (re)subscribe fetch anything we might have missed
-        () => this.fetchMissedEvents()
-      )
-    );
+    // add any new ones
+    channels.forEach((channel) => {
+      if (!this.subscriptions.has(channel)) {
+        this.subscriptions.set(
+          channel,
+          subscribeToSocket(
+            channel,
+            (data: any) => this.handleSocketEvent(data),
+            // on every (re)subscribe fetch anything we might have missed
+            () => this.fetchMissedEvents()
+          )
+        );
+      }
+    });
   }
 
   private handleSocketEvent(event: any) {
@@ -1098,24 +1106,26 @@ export class ContactChat extends ContactStoreElement {
       }
 
       const fetchContact = this.currentContact.uuid;
+      const fetchTicket = this.currentTicket?.uuid;
 
-      fetchContactHistory(
-        endpoint,
-        this.currentTicket?.uuid,
-        null,
-        this.afterUUID
-      ).then((page: ContactHistoryPage) => {
-        this.fetchingMissed = false;
+      fetchContactHistory(endpoint, fetchTicket, null, this.afterUUID).then(
+        (page: ContactHistoryPage) => {
+          this.fetchingMissed = false;
 
-        // things may have changed while we were fetching
-        if (this.searchMode || fetchContact !== this.currentContact?.uuid) {
-          return;
+          // things may have changed while we were fetching
+          if (
+            this.searchMode ||
+            fetchContact !== this.currentContact?.uuid ||
+            fetchTicket !== this.currentTicket?.uuid
+          ) {
+            return;
+          }
+
+          const messages = this.createMessages(page);
+          messages.reverse();
+          chat.addMessages(messages, null, true);
         }
-
-        const messages = this.createMessages(page);
-        messages.reverse();
-        chat.addMessages(messages, null, true);
-      });
+      );
     }
   }
 

--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -36,14 +36,7 @@ import {
   renderTicketAction,
   renderTicketAssigneeChanged
 } from '../events/eventRenderers';
-
-/*
-export const SCROLL_THRESHOLD = 100;
-export const SIMULATED_WEB_SLOWNESS = 0;
-export const MAX_CHAT_REFRESH = 10000;
-export const MIN_CHAT_REFRESH = 500;
-export const BODY_SNIPPET_LENGTH = 250;
-*/
+import { subscribeToSocket, SocketSubscription } from './SocketService';
 
 // re-export for backwards compatibility
 export { renderTicketAction, renderTicketAssigneeChanged };
@@ -527,11 +520,12 @@ export class ContactChat extends ContactStoreElement {
 
   ticket = null;
   beforeUUID: string = null; // for scrolling back through history
-  afterUUID: string = null; // for polling new messages
-  refreshId = null;
-  polling = false;
-  pollingInterval = 2000; // start at 2 seconds
-  lastFetchTime: number = null;
+  afterUUID: string = null; // newest event seen, for catch-up fetches
+
+  // live socket subscriptions for the current contact (and ticket)
+  private subscriptions: SocketSubscription[] = [];
+  private subscribedChannels: string[] = [];
+  private fetchingMissed = false;
 
   constructor() {
     super();
@@ -562,28 +556,22 @@ export class ContactChat extends ContactStoreElement {
   public connectedCallback() {
     super.connectedCallback();
     this.chat = this.shadowRoot.querySelector('temba-chat');
+    this.updateSubscriptions();
   }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
-    if (this.refreshId) {
-      clearInterval(this.refreshId);
-    }
+    this.unsubscribeAll();
   }
 
   public updated(changedProperties: Map<string, any>) {
     super.updated(changedProperties);
 
-    // if we don't have an endpoint infer one
     if (
-      changedProperties.has('data') ||
-      changedProperties.has('currentContact')
+      changedProperties.has('currentContact') ||
+      changedProperties.has('currentTicket')
     ) {
-      // unschedule any previous refreshes
-      if (this.refreshId) {
-        clearTimeout(this.refreshId);
-        this.refreshId = null;
-      }
+      this.updateSubscriptions();
     }
 
     if (changedProperties.has('currentContact') && this.currentContact) {
@@ -594,9 +582,62 @@ export class ContactChat extends ContactStoreElement {
       ) {
         this.reset();
       } else {
-        setTimeout(() => this.checkForNewMessages(), 500);
+        this.fetchMissedEvents();
       }
       this.fetchPreviousMessages();
+    }
+  }
+
+  private unsubscribeAll() {
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+    this.subscriptions = [];
+    this.subscribedChannels = [];
+  }
+
+  /**
+   * Keeps our socket subscriptions in sync with the current contact and
+   * ticket. New events arrive as they happen on "history:<contact-uuid>";
+   * ticket detail events (notes, assignment, topic) only arrive on
+   * "history:<contact-uuid>:<ticket-uuid>" so we subscribe to both when
+   * viewing a ticket.
+   */
+  private updateSubscriptions() {
+    const channels = [];
+    if (this.isConnected && this.currentContact) {
+      channels.push(`history:${this.currentContact.uuid}`);
+      if (this.currentTicket) {
+        channels.push(
+          `history:${this.currentContact.uuid}:${this.currentTicket.uuid}`
+        );
+      }
+    }
+
+    if (channels.join(',') === this.subscribedChannels.join(',')) {
+      return;
+    }
+
+    this.unsubscribeAll();
+    this.subscribedChannels = channels;
+    this.subscriptions = channels.map((channel) =>
+      subscribeToSocket(
+        channel,
+        (data: any) => this.handleSocketEvent(data),
+        // on every (re)subscribe fetch anything we might have missed
+        () => this.fetchMissedEvents()
+      )
+    );
+  }
+
+  private handleSocketEvent(event: any) {
+    // while searching we're viewing an arbitrary point in history, new
+    // events will be picked up by the refetch when search closes
+    if (!this.chat || this.searchMode || !this.currentContact) {
+      return;
+    }
+
+    const messages = this.createMessages({ events: [event], next: null });
+    if (messages.length > 0) {
+      this.chat.addMessages(messages, null, true);
     }
   }
 
@@ -607,10 +648,7 @@ export class ContactChat extends ContactStoreElement {
     this.ticket = null;
     this.beforeUUID = null;
     this.afterUUID = null;
-    this.refreshId = null;
-    this.polling = false;
-    this.pollingInterval = 2000;
-    this.lastFetchTime = null;
+    this.fetchingMissed = false;
 
     const compose = this.shadowRoot.querySelector('temba-compose') as Compose;
     if (compose) {
@@ -628,11 +666,6 @@ export class ContactChat extends ContactStoreElement {
       this.searchIndex = -1;
       this.searchLoading = false;
       this.searchNoResults = false;
-      // stop polling while searching
-      if (this.refreshId) {
-        clearTimeout(this.refreshId);
-        this.refreshId = null;
-      }
       window.setTimeout(() => {
         const input = this.shadowRoot.querySelector('.search-input') as any;
         if (input) {
@@ -953,10 +986,8 @@ export class ContactChat extends ContactStoreElement {
         if (response.status < 400) {
           const event = response.json.event;
           event.created_on = new Date(event.created_on);
+          this.resolveUserAvatar(event);
           this.chat.addMessages([event], null, true);
-          // reset polling interval to 2 seconds after sending a message
-          this.pollingInterval = 2000;
-          this.checkForNewMessages();
           composeEle.reset();
           this.fireCustomEvent(CustomEventType.MessageSent, {
             msg: payload,
@@ -978,25 +1009,6 @@ export class ContactChat extends ContactStoreElement {
     return null;
   }
 
-  private scheduleRefresh(hasNewEvents = false) {
-    if (this.refreshId) {
-      clearTimeout(this.refreshId);
-      this.refreshId = null;
-    }
-
-    // reset to 2 seconds if we received new events
-    if (hasNewEvents) {
-      this.pollingInterval = 2000;
-    } else {
-      // increase interval by 1 second up to max of 15 seconds
-      this.pollingInterval = Math.min(this.pollingInterval + 1000, 15000);
-    }
-
-    this.refreshId = setTimeout(() => {
-      this.checkForNewMessages();
-    }, this.pollingInterval);
-  }
-
   public prerender(event: ContactEvent) {
     // use the unified renderEvent function with isSimulation = false
     const rendered = renderEvent(event, false);
@@ -1009,10 +1021,27 @@ export class ContactChat extends ContactStoreElement {
     }
   }
 
+  /**
+   * Keeps the store's avatar cache fresh from server-hydrated user refs and
+   * fills in refs that arrive without one - events published over sockets
+   * carry only a user's uuid and name.
+   */
+  private resolveUserAvatar(event: any) {
+    const user = event._user;
+    if (user && user.uuid && this.store) {
+      if (user.avatar) {
+        this.store.setUserAvatar(user.uuid, user.avatar);
+      } else {
+        user.avatar = this.store.getUserAvatar(user.uuid);
+      }
+    }
+  }
+
   private createMessages(page: ContactHistoryPage): ContactEvent[] {
     if (page.events) {
       const messages: ContactEvent[] = [];
       page.events.forEach((event) => {
+        this.resolveUserAvatar(event);
         // track the UUID of the newest event for polling
         if (
           !this.afterUUID ||
@@ -1047,18 +1076,24 @@ export class ContactChat extends ContactStoreElement {
     return [];
   }
 
-  private checkForNewMessages() {
+  /**
+   * Fetches any events newer than the last one we've seen. New events
+   * normally arrive over the socket, so this is only needed to cover gaps -
+   * events published between our initial history fetch and the subscription
+   * becoming active, or while a dropped connection was reconnecting.
+   */
+  private fetchMissedEvents() {
     // we are already working on it or in search mode
-    if (this.polling || this.searchMode) {
+    if (this.fetchingMissed || this.searchMode) {
       return;
     }
 
     const chat = this.chat;
     if (this.currentContact && this.afterUUID) {
-      this.polling = true;
-      this.lastFetchTime = Date.now();
+      this.fetchingMissed = true;
       const endpoint = this.getEndpoint();
       if (!endpoint) {
+        this.fetchingMissed = false;
         return;
       }
 
@@ -1070,16 +1105,16 @@ export class ContactChat extends ContactStoreElement {
         null,
         this.afterUUID
       ).then((page: ContactHistoryPage) => {
+        this.fetchingMissed = false;
+
+        // things may have changed while we were fetching
+        if (this.searchMode || fetchContact !== this.currentContact?.uuid) {
+          return;
+        }
+
         const messages = this.createMessages(page);
         messages.reverse();
-        if (fetchContact === this.currentContact.uuid) {
-          const hasNewEvents = messages.length > 0;
-          chat.addMessages(messages, null, true);
-          this.polling = false;
-          this.scheduleRefresh(hasNewEvents);
-        } else {
-          this.polling = false;
-        }
+        chat.addMessages(messages, null, true);
       });
     }
   }
@@ -1130,9 +1165,6 @@ export class ContactChat extends ContactStoreElement {
         }
 
         chat.addMessages(messages);
-        if (!this.searchMode) {
-          this.scheduleRefresh();
-        }
       });
     }
   }

--- a/src/live/SocketService.ts
+++ b/src/live/SocketService.ts
@@ -1,0 +1,84 @@
+import { Centrifuge } from 'centrifuge';
+
+/**
+ * Thin wrapper around our realtime messaging socket (centrifugo). The server
+ * lives behind the same origin at /ws/connect and authenticates connections
+ * with the browser's session cookie (via a server-side connect proxy), so no
+ * token handling is needed here. Components subscribe to channels like
+ * "history:<contact-uuid>" and receive each published event as raw JSON.
+ */
+
+export interface SocketSubscription {
+  unsubscribe(): void;
+}
+
+export type PublicationHandler = (data: any) => void;
+
+export interface SocketProvider {
+  subscribe(
+    channel: string,
+    onPublication: PublicationHandler,
+    onSubscribed?: () => void
+  ): SocketSubscription;
+}
+
+let socket: Centrifuge = null;
+
+const getSocket = (): Centrifuge => {
+  if (!socket) {
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    socket = new Centrifuge(`${protocol}://${window.location.host}/ws/connect`);
+    socket.connect();
+  }
+  return socket;
+};
+
+/**
+ * Default provider backed by a single shared centrifugo connection, created
+ * lazily on first subscribe and kept open for the life of the page. Assumes
+ * one subscriber per channel at a time, which holds for our components.
+ */
+class CentrifugoProvider implements SocketProvider {
+  public subscribe(
+    channel: string,
+    onPublication: PublicationHandler,
+    onSubscribed?: () => void
+  ): SocketSubscription {
+    const socket = getSocket();
+    const sub =
+      socket.getSubscription(channel) || socket.newSubscription(channel);
+
+    sub.on('publication', (ctx) => onPublication(ctx.data));
+    if (onSubscribed) {
+      // fires on every (re)subscribe, including after reconnects, so
+      // subscribers can catch up on anything missed while offline
+      sub.on('subscribed', () => onSubscribed());
+    }
+    sub.subscribe();
+
+    return {
+      unsubscribe: () => {
+        sub.unsubscribe();
+        sub.removeAllListeners();
+        socket.removeSubscription(sub);
+      }
+    };
+  }
+}
+
+let provider: SocketProvider = new CentrifugoProvider();
+
+export const subscribeToSocket = (
+  channel: string,
+  onPublication: PublicationHandler,
+  onSubscribed?: () => void
+): SocketSubscription => {
+  return provider.subscribe(channel, onPublication, onSubscribed);
+};
+
+// for tests to swap in a mock provider, returns the previous provider
+export const setSocketProvider = (newProvider: SocketProvider) => {
+  const previous = provider;
+  provider = newProvider;
+  return previous;
+};

--- a/src/live/SocketService.ts
+++ b/src/live/SocketService.ts
@@ -1,11 +1,25 @@
-import { Centrifuge } from 'centrifuge';
+import { Centrifuge, Subscription, SubscriptionState } from 'centrifuge';
 
 /**
- * Thin wrapper around our realtime messaging socket (centrifugo). The server
- * lives behind the same origin at /ws/connect and authenticates connections
- * with the browser's session cookie (via a server-side connect proxy), so no
- * token handling is needed here. Components subscribe to channels like
- * "history:<contact-uuid>" and receive each published event as raw JSON.
+ * Access to our realtime messaging socket (centrifugo). The server lives
+ * behind the same origin at /ws/connect and authenticates connections with
+ * the browser's session cookie (via a server-side connect proxy), so no
+ * token handling is needed here.
+ *
+ * The connection is owned by a SocketManager which is page-scoped - it hangs
+ * off `window` rather than any component, so it survives components mounting
+ * and unmounting, and vanilla js on the containing page can share the same
+ * connection:
+ *
+ *   const sub = window.sockets.subscribe('notifications:<org>:<user>', (event) => {
+ *     ...
+ *   });
+ *   sub.unsubscribe();
+ *
+ * Any number of subscribers (components or page js) can watch the same
+ * channel - the underlying centrifugo subscription is created on first use
+ * and torn down when the last subscriber leaves. The connection itself stays
+ * open for the life of the page. Each published event arrives as raw JSON.
  */
 
 export interface SocketSubscription {
@@ -22,58 +36,118 @@ export interface SocketProvider {
   ): SocketSubscription;
 }
 
-let socket: Centrifuge = null;
+interface ChannelEntry {
+  sub: Subscription;
+  count: number;
+}
 
-const getSocket = (): Centrifuge => {
-  if (!socket) {
-    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-    socket = new Centrifuge(`${protocol}://${window.location.host}/ws/connect`);
-    socket.connect();
+export class SocketManager implements SocketProvider {
+  private socket: Centrifuge = null;
+  private channels = new Map<string, ChannelEntry>();
+  private createSocket: () => Centrifuge;
+
+  constructor(createSocket?: () => Centrifuge) {
+    this.createSocket =
+      createSocket ||
+      (() => {
+        const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+        const socket = new Centrifuge(
+          `${protocol}://${window.location.host}/ws/connect`
+        );
+        socket.connect();
+        return socket;
+      });
   }
-  return socket;
-};
 
-/**
- * Default provider backed by a single shared centrifugo connection, created
- * lazily on first subscribe and kept open for the life of the page. Assumes
- * one subscriber per channel at a time, which holds for our components.
- */
-class CentrifugoProvider implements SocketProvider {
   public subscribe(
     channel: string,
     onPublication: PublicationHandler,
     onSubscribed?: () => void
   ): SocketSubscription {
-    const socket = getSocket();
-    const sub =
-      socket.getSubscription(channel) || socket.newSubscription(channel);
+    if (!this.socket) {
+      this.socket = this.createSocket();
+    }
 
-    sub.on('publication', (ctx) => onPublication(ctx.data));
+    let entry = this.channels.get(channel);
+    if (!entry) {
+      entry = {
+        sub:
+          this.socket.getSubscription(channel) ||
+          this.socket.newSubscription(channel),
+        count: 0
+      };
+      this.channels.set(channel, entry);
+      entry.sub.subscribe();
+    }
+    entry.count++;
+
+    const sub = entry.sub;
+    const pubHandler = (ctx: { data: any }) => onPublication(ctx.data);
+    sub.on('publication', pubHandler);
+
+    let subHandler: () => void = null;
     if (onSubscribed) {
       // fires on every (re)subscribe, including after reconnects, so
       // subscribers can catch up on anything missed while offline
-      sub.on('subscribed', () => onSubscribed());
-    }
-    sub.subscribe();
+      subHandler = () => onSubscribed();
+      sub.on('subscribed', subHandler);
 
+      // late joiners on an already-live channel won't see a subscribed
+      // event, so give them their initial one
+      if (sub.state === SubscriptionState.Subscribed) {
+        window.setTimeout(() => subHandler && subHandler(), 0);
+      }
+    }
+
+    let active = true;
     return {
       unsubscribe: () => {
-        sub.unsubscribe();
-        sub.removeAllListeners();
-        socket.removeSubscription(sub);
+        if (!active) {
+          return;
+        }
+        active = false;
+
+        sub.off('publication', pubHandler);
+        if (subHandler) {
+          sub.off('subscribed', subHandler);
+          subHandler = null;
+        }
+
+        entry.count--;
+        if (entry.count === 0) {
+          this.channels.delete(channel);
+          sub.unsubscribe();
+          this.socket.removeSubscription(sub);
+        }
       }
     };
   }
 }
 
-let provider: SocketProvider = new CentrifugoProvider();
+// the page-scoped manager, shared with vanilla js as window.sockets and
+// reused if another copy of this module already created it
+const getManager = (): SocketManager => {
+  const w = window as any;
+  if (!w.sockets) {
+    w.sockets = new SocketManager();
+  }
+  return w.sockets;
+};
+getManager();
+
+// when set, components subscribe through this instead of the page manager
+let provider: SocketProvider = null;
 
 export const subscribeToSocket = (
   channel: string,
   onPublication: PublicationHandler,
   onSubscribed?: () => void
 ): SocketSubscription => {
-  return provider.subscribe(channel, onPublication, onSubscribed);
+  return (provider || getManager()).subscribe(
+    channel,
+    onPublication,
+    onSubscribed
+  );
 };
 
 // for tests to swap in a mock provider, returns the previous provider

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -12,8 +12,10 @@
       'scf1453991c986b25': `Tab para completar, enter para seleccionar`,
 's73b4d70c02f4b4e0': `No options`,
 'sbc913d7dc0f33877': `to add`,
+'s81f17cfc89a04338': `Interrupt flow`,
 's8f02e3a18ffc083a': `Are not currently in a flow`,
 's638236250662c6b3': `Have sent a message in the last`,
 's4788ee206c4570c7': `Have not started this flow in the last 90 days`,
+'sea4f08110bb8f15d': `Remove`,
     };
   

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -12,8 +12,10 @@
       's73b4d70c02f4b4e0': `No options`,
 'scf1453991c986b25': `Tab to complete, enter to select`,
 'sbc913d7dc0f33877': `to add`,
+'s81f17cfc89a04338': `Interrupt flow`,
 's8f02e3a18ffc083a': `Are not currently in a flow`,
 's638236250662c6b3': `Have sent a message in the last`,
 's4788ee206c4570c7': `Have not started this flow in the last 90 days`,
+'sea4f08110bb8f15d': `Remove`,
     };
   

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -12,8 +12,10 @@
       's73b4d70c02f4b4e0': `No options`,
 'scf1453991c986b25': `Tab to complete, enter to select`,
 'sbc913d7dc0f33877': `to add`,
+'s81f17cfc89a04338': `Interrupt flow`,
 's8f02e3a18ffc083a': `Are not currently in a flow`,
 's638236250662c6b3': `Have sent a message in the last`,
 's4788ee206c4570c7': `Have not started this flow in the last 90 days`,
+'sea4f08110bb8f15d': `Remove`,
     };
   

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -158,6 +158,22 @@ export class Store extends RapidElement {
   }
 
   private cache: any;
+
+  // user avatar urls by user uuid, seeded from server-hydrated user
+  // references so ones that arrive without an avatar (e.g. events published
+  // over sockets) can be filled in from users we've already seen
+  private userAvatars = new Map<string, string>();
+
+  public setUserAvatar(uuid: string, avatar: string) {
+    if (uuid && avatar) {
+      this.userAvatars.set(uuid, avatar);
+    }
+  }
+
+  public getUserAvatar(uuid: string): string {
+    return this.userAvatars.get(uuid);
+  }
+
   public getLocale() {
     return this.locale[0];
   }
@@ -561,6 +577,7 @@ export class Store extends RapidElement {
             const results = response.json.results;
             if (results && results.length === 1) {
               const user = results[0];
+              this.setUserAvatar(user.uuid, user.avatar);
 
               items.forEach((item) => {
                 // replace each key with a matching user

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -161,8 +161,9 @@ export class Store extends RapidElement {
 
   // user avatar urls by user uuid, seeded from server-hydrated user
   // references so ones that arrive without an avatar (e.g. events published
-  // over sockets) can be filled in from users we've already seen
-  private userAvatars = new Map<string, string>();
+  // over sockets) can be filled in from users we've already seen. LRU-bounded
+  // so long-lived tabs don't accumulate every user ever seen.
+  private userAvatars = lru<string>(500);
 
   public setUserAvatar(uuid: string, avatar: string) {
     if (uuid && avatar) {

--- a/test/temba-contact-chat.test.ts
+++ b/test/temba-contact-chat.test.ts
@@ -528,6 +528,42 @@ describe('temba-contact-chat', () => {
     expect(chat.afterUUID).to.equal(before);
   });
 
+  it('keeps the contact channel subscribed across ticket changes', async () => {
+    await loadStore();
+    const chat: ContactChat = await getContactChat({
+      contact: 'contact-dave-active'
+    });
+
+    const contactChannel = `history:${chat.currentContact.uuid}`;
+    expect(mockSocket.activeChannels()).to.deep.equal([contactChannel]);
+    const contactSub = mockSocket.subs[0];
+
+    const makeTicket = (uuid: string) =>
+      ({
+        uuid,
+        topic: { uuid: 'topic-1', name: 'General' },
+        assignee: null,
+        closed_on: null
+      }) as any;
+
+    chat.currentTicket = makeTicket('ticket-1');
+    await chat.updateComplete;
+    expect(mockSocket.activeChannels()).to.deep.equal([
+      contactChannel,
+      `${contactChannel}:ticket-1`
+    ]);
+
+    chat.currentTicket = makeTicket('ticket-2');
+    await chat.updateComplete;
+    expect(mockSocket.activeChannels()).to.deep.equal([
+      contactChannel,
+      `${contactChannel}:ticket-2`
+    ]);
+
+    // the contact subscription was never torn down along the way
+    expect(contactSub.unsubscribed).to.be.false;
+  });
+
   it('fills in missing user avatars from the store cache', async () => {
     await loadStore();
     const chat: ContactChat = await getContactChat({

--- a/test/temba-contact-chat.test.ts
+++ b/test/temba-contact-chat.test.ts
@@ -1,6 +1,12 @@
 import { SinonStub, useFakeTimers } from 'sinon';
 import { Compose } from '../src/form/Compose';
 import { ContactChat } from '../src/live/ContactChat';
+import {
+  PublicationHandler,
+  setSocketProvider,
+  SocketProvider,
+  SocketSubscription
+} from '../src/live/SocketService';
 import { Attachment, CustomEventType } from '../src/interfaces';
 import {
   assertScreenshot,
@@ -20,6 +26,61 @@ import {
 import { expect, oneEvent } from '@open-wc/testing';
 
 let clock: any;
+
+interface MockSubscription {
+  channel: string;
+  onPublication: PublicationHandler;
+  onSubscribed?: () => void;
+  unsubscribed: boolean;
+}
+
+class MockSocketProvider implements SocketProvider {
+  public subs: MockSubscription[] = [];
+
+  public subscribe(
+    channel: string,
+    onPublication: PublicationHandler,
+    onSubscribed?: () => void
+  ): SocketSubscription {
+    const sub: MockSubscription = {
+      channel,
+      onPublication,
+      onSubscribed,
+      unsubscribed: false
+    };
+    this.subs.push(sub);
+
+    // confirm the subscription asynchronously like a real socket would
+    if (onSubscribed) {
+      setTimeout(() => {
+        if (!sub.unsubscribed) {
+          sub.onSubscribed();
+        }
+      }, 0);
+    }
+
+    return {
+      unsubscribe: () => {
+        sub.unsubscribed = true;
+      }
+    };
+  }
+
+  public publish(channel: string, data: any) {
+    this.subs
+      .filter((sub) => sub.channel === channel && !sub.unsubscribed)
+      .forEach((sub) => sub.onPublication(data));
+  }
+
+  public activeChannels(): string[] {
+    return this.subs
+      .filter((sub) => !sub.unsubscribed)
+      .map((sub) => sub.channel);
+  }
+}
+
+let mockSocket: MockSocketProvider;
+let previousSocketProvider: SocketProvider;
 
 const TAG = 'temba-contact-chat';
 const getContactChat = async (attrs: any = {}) => {
@@ -70,11 +131,15 @@ describe('temba-contact-chat', () => {
 
     mockAPI();
     clock = useFakeTimers();
+
+    mockSocket = new MockSocketProvider();
+    previousSocketProvider = setSocketProvider(mockSocket);
   });
 
   afterEach(function () {
     clock.restore();
     mockedNow.restore();
+    setSocketProvider(previousSocketProvider);
   });
 
   // temporarily disabled as it's too flaky in CI
@@ -387,5 +452,125 @@ describe('temba-contact-chat', () => {
     expect(chat.searchNoResults).to.be.true;
 
     await assertScreenshot('contacts/chat-search-no-results', getClip(chat));
+  });
+
+  it('subscribes to the contact history channel', async () => {
+    await loadStore();
+    const chat: ContactChat = await getContactChat({
+      contact: 'contact-dave-active'
+    });
+
+    expect(mockSocket.activeChannels()).to.deep.equal([
+      `history:${chat.currentContact.uuid}`
+    ]);
+  });
+
+  it('renders events published on the socket', async () => {
+    await loadStore();
+    const chat: ContactChat = await getContactChat({
+      contact: 'contact-dave-active'
+    });
+
+    const eventUUID = '01998888-0000-7000-8000-000000000001';
+    mockSocket.publish(`history:${chat.currentContact.uuid}`, {
+      uuid: eventUUID,
+      type: 'msg_received',
+      created_on: '2025-09-25T12:00:00.000000+00:00',
+      msg: {
+        urn: 'tel:+250788123123',
+        text: 'hello over the socket',
+        channel: { uuid: '8a81e9e0-10a0-4319-9b00-ce723cfa8303', name: 'SMS' }
+      }
+    });
+
+    // flush the render timeouts in addMessages
+    for (let i = 0; i < 10; i++) {
+      await waitFor(50);
+      clock.tick(50);
+      await chat.updateComplete;
+    }
+
+    // the event was ingested and is now our newest seen event
+    expect(chat.afterUUID).to.equal(eventUUID);
+
+    // and it rendered in the chat
+    const tembaChat = chat.shadowRoot.querySelector('temba-chat');
+    const row = tembaChat.shadowRoot.querySelector(
+      `.row[data-uuid="${eventUUID}"]`
+    );
+    expect(row).to.exist;
+  });
+
+  it('ignores socket events while searching', async () => {
+    await loadStore();
+    const chat: ContactChat = await getContactChat({
+      contact: 'contact-dave-active',
+      showSearch: true
+    });
+
+    // enter search mode
+    const searchToggle = chat.shadowRoot.querySelector(
+      '.search-toggle'
+    ) as HTMLElement;
+    searchToggle.click();
+    await waitFor(100);
+    clock.tick(100);
+    await chat.updateComplete;
+
+    const before = chat.afterUUID;
+    mockSocket.publish(`history:${chat.currentContact.uuid}`, {
+      uuid: '01998888-0000-7000-8000-000000000002',
+      type: 'msg_received',
+      created_on: '2025-09-25T12:00:00.000000+00:00',
+      msg: { text: 'should be ignored' }
+    });
+
+    expect(chat.afterUUID).to.equal(before);
+  });
+
+  it('fills in missing user avatars from the store cache', async () => {
+    await loadStore();
+    const chat: ContactChat = await getContactChat({
+      contact: 'contact-dave-active'
+    });
+
+    const channel = `history:${chat.currentContact.uuid}`;
+    const userUUID = 'aaaa1111-0000-4000-8000-000000000001';
+
+    // a hydrated event seeds the avatar cache
+    mockSocket.publish(channel, {
+      uuid: '01998888-0000-7000-8000-000000000003',
+      type: 'ticket_note_added',
+      created_on: '2025-09-25T12:00:00.000000+00:00',
+      note: 'first note',
+      _user: {
+        uuid: userUUID,
+        name: 'Ann Admin',
+        avatar: '/media/avatars/ann.jpg'
+      }
+    });
+
+    // an unhydrated ref for the same user gets the cached avatar
+    const unhydrated = {
+      uuid: '01998888-0000-7000-8000-000000000004',
+      type: 'ticket_note_added',
+      created_on: '2025-09-25T12:01:00.000000+00:00',
+      note: 'second note',
+      _user: { uuid: userUUID, name: 'Ann Admin' }
+    };
+    mockSocket.publish(channel, unhydrated);
+
+    expect(unhydrated._user['avatar']).to.equal('/media/avatars/ann.jpg');
+  });
+
+  it('unsubscribes when removed from the page', async () => {
+    await loadStore();
+    const chat: ContactChat = await getContactChat({
+      contact: 'contact-dave-active'
+    });
+
+    expect(mockSocket.activeChannels().length).to.equal(1);
+    chat.remove();
+    expect(mockSocket.activeChannels().length).to.equal(0);
   });
 });

--- a/test/temba-socket.test.ts
+++ b/test/temba-socket.test.ts
@@ -1,0 +1,152 @@
+import { assert } from '@open-wc/testing';
+import { SocketManager } from '../src/live/SocketService';
+
+class FakeSub {
+  public handlers: { [event: string]: ((ctx: any) => void)[] } = {};
+  public state = 'unsubscribed';
+  public subscribeCalls = 0;
+  public unsubscribeCalls = 0;
+
+  public on(event: string, fn: (ctx: any) => void) {
+    this.handlers[event] = this.handlers[event] || [];
+    this.handlers[event].push(fn);
+    return this;
+  }
+
+  public off(event: string, fn: (ctx: any) => void) {
+    this.handlers[event] = (this.handlers[event] || []).filter(
+      (handler) => handler !== fn
+    );
+    return this;
+  }
+
+  public subscribe() {
+    this.subscribeCalls++;
+    this.state = 'subscribed';
+  }
+
+  public unsubscribe() {
+    this.unsubscribeCalls++;
+    this.state = 'unsubscribed';
+  }
+
+  public emit(event: string, ctx: any) {
+    (this.handlers[event] || []).forEach((handler) => handler(ctx));
+  }
+}
+
+class FakeCentrifuge {
+  public subs = new Map<string, FakeSub>();
+  public removed: FakeSub[] = [];
+
+  public getSubscription(channel: string) {
+    return this.subs.get(channel) || null;
+  }
+
+  public newSubscription(channel: string) {
+    const sub = new FakeSub();
+    this.subs.set(channel, sub);
+    return sub;
+  }
+
+  public removeSubscription(sub: FakeSub) {
+    this.removed.push(sub);
+    this.subs.forEach((existing, channel) => {
+      if (existing === sub) {
+        this.subs.delete(channel);
+      }
+    });
+  }
+}
+
+const createManager = () => {
+  const fake = new FakeCentrifuge();
+  let connections = 0;
+  const manager = new SocketManager(() => {
+    connections++;
+    return fake as any;
+  });
+  return { fake, manager, connections: () => connections };
+};
+
+describe('SocketManager', () => {
+  it('shares one connection and subscription across subscribers', () => {
+    const { fake, manager, connections } = createManager();
+
+    const seenA = [];
+    const seenB = [];
+    manager.subscribe('history:abc', (data) => seenA.push(data));
+    manager.subscribe('history:abc', (data) => seenB.push(data));
+    manager.subscribe('history:other', () => {});
+
+    assert.equal(connections(), 1);
+    assert.equal(fake.subs.size, 2);
+
+    const sub = fake.subs.get('history:abc');
+    assert.equal(sub.subscribeCalls, 1);
+
+    sub.emit('publication', { data: { type: 'msg_created' } });
+    assert.deepEqual(seenA, [{ type: 'msg_created' }]);
+    assert.deepEqual(seenB, [{ type: 'msg_created' }]);
+  });
+
+  it('tears down the subscription when the last subscriber leaves', () => {
+    const { fake, manager } = createManager();
+
+    const first = manager.subscribe('history:abc', () => {});
+    const second = manager.subscribe('history:abc', () => {});
+    const sub = fake.subs.get('history:abc');
+
+    first.unsubscribe();
+    // safe to call twice, still counted once
+    first.unsubscribe();
+    assert.equal(sub.unsubscribeCalls, 0);
+
+    second.unsubscribe();
+    assert.equal(sub.unsubscribeCalls, 1);
+    assert.deepEqual(fake.removed, [sub]);
+  });
+
+  it('stops delivering to unsubscribed handlers', () => {
+    const { fake, manager } = createManager();
+
+    const seenA = [];
+    const seenB = [];
+    const first = manager.subscribe('history:abc', (data) => seenA.push(data));
+    manager.subscribe('history:abc', (data) => seenB.push(data));
+
+    first.unsubscribe();
+    fake.subs.get('history:abc').emit('publication', { data: 'hello' });
+
+    assert.deepEqual(seenA, []);
+    assert.deepEqual(seenB, ['hello']);
+  });
+
+  it('notifies late joiners on an already-live channel', (done) => {
+    const { fake, manager } = createManager();
+
+    manager.subscribe('history:abc', () => {});
+    assert.equal(fake.subs.get('history:abc').state, 'subscribed');
+
+    manager.subscribe(
+      'history:abc',
+      () => {},
+      () => done()
+    );
+  });
+
+  it('resubscribes a channel after full teardown', () => {
+    const { fake, manager } = createManager();
+
+    const first = manager.subscribe('history:abc', () => {});
+    first.unsubscribe();
+
+    const seen = [];
+    manager.subscribe('history:abc', (data) => seen.push(data));
+    const sub = fake.subs.get('history:abc');
+    assert.equal(sub.subscribeCalls, 1);
+
+    sub.emit('publication', { data: 'again' });
+    assert.deepEqual(seen, ['again']);
+  });
+});

--- a/test/temba-user.test.ts
+++ b/test/temba-user.test.ts
@@ -30,6 +30,34 @@ describe('temba-user', () => {
     assert.include(user.bgimage, "url('/img/a.png')");
   });
 
+  it('clears bgimage when avatar is removed', async () => {
+    // lit reuses elements across renders, so an element that showed one
+    // user's avatar must fall back to initials when reused for a user
+    // without one
+    const user = await createUser(
+      '<temba-user name="Jane" avatar="/img/a.png"></temba-user>'
+    );
+    assert.include(user.bgimage, "url('/img/a.png')");
+
+    user.avatar = null;
+    user.name = 'Bob Contact';
+    await user.updateComplete;
+    assert.isNull(user.bgimage);
+    assert.equal(user.initials, 'BC');
+  });
+
+  it('restores default avatar when avatar is removed from system user', async () => {
+    const user = await createUser(
+      '<temba-user name="Bot" system avatar="/img/a.png"></temba-user>'
+    );
+    assert.include(user.bgimage, "url('/img/a.png')");
+
+    user.avatar = null;
+    await user.updateComplete;
+    assert.isNotNull(user.bgimage);
+    assert.notInclude(user.bgimage, '/img/a.png');
+  });
+
   it('uses default avatar when system is true', async () => {
     const user = await createUser(
       '<temba-user name="Bot" system></temba-user>'

--- a/xliff/es.xlf
+++ b/xliff/es.xlf
@@ -21,6 +21,12 @@
 <trans-unit id="sbc913d7dc0f33877">
   <source>to add</source>
 </trans-unit>
+<trans-unit id="sea4f08110bb8f15d">
+  <source>Remove</source>
+</trans-unit>
+<trans-unit id="s81f17cfc89a04338">
+  <source>Interrupt flow</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/xliff/fr.xlf
+++ b/xliff/fr.xlf
@@ -20,6 +20,12 @@
 <trans-unit id="sbc913d7dc0f33877">
   <source>to add</source>
 </trans-unit>
+<trans-unit id="sea4f08110bb8f15d">
+  <source>Remove</source>
+</trans-unit>
+<trans-unit id="s81f17cfc89a04338">
+  <source>Interrupt flow</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/xliff/pt.xlf
+++ b/xliff/pt.xlf
@@ -20,6 +20,12 @@
 <trans-unit id="sbc913d7dc0f33877">
   <source>to add</source>
 </trans-unit>
+<trans-unit id="sea4f08110bb8f15d">
+  <source>Remove</source>
+</trans-unit>
+<trans-unit id="s81f17cfc89a04338">
+  <source>Interrupt flow</source>
+</trans-unit>
 </body>
 </file>
 </xliff>


### PR DESCRIPTION
The contact chat currently polls `/contact/chat/<uuid>/` on an adaptive 2s–15s interval for new events. Now that mailroom publishes contact history events to realtime sockets (centrifugo), the chat subscribes and renders events as they happen.

## Changes

* New `SocketManager` owning a shared centrifuge-js connection to same-origin `/ws/connect`. Auth is the session cookie via the server-side connect/subscribe proxies, so no token handling. The manager is page-scoped — it hangs off `window.sockets` rather than any component, so the connection survives components mounting and unmounting, and vanilla js on the containing page can subscribe to channels over the same connection (`window.sockets.subscribe(channel, handler)`). Channels are refcounted: any number of subscribers share one underlying subscription, torn down when the last leaves. A `setSocketProvider()` hook lets tests inject a mock.
* `ContactChat` subscribes to `history:<contact-uuid>` for the current contact, plus `history:<contact-uuid>:<ticket-uuid>` when viewing a ticket (ticket detail events only arrive there). Publications flow through the existing `createMessages` → `addMessages` path so rendering, uuid dedup, grouping, and the new-message indicator are unchanged.
* The polling loop (`scheduleRefresh`/`checkForNewMessages`) is replaced by a one-shot catch-up fetch (`after=<newest-seen>`) that runs on every (re)subscribe, covering the gap between the initial history load and the subscription activating, and anything missed while a dropped connection was reconnecting. Scroll-back pagination and chat search still use HTTP.
* Publications are ignored while chat search is open; closing search already resets and refetches.
* `Chat.reset()` now bumps a generation counter and pending deferred `addMessages` merges from before the reset are discarded — previously an in-flight merge could land in the freshly-reset view (exposed by search navigation).
* Socket events carry user refs without avatar hydration, so the store now keeps a cache of user avatars by uuid, seeded from any server-hydrated user ref (history fetches, send responses, `resolveUsers`) and used to fill in refs that arrive without one.

## Testing

* New tests cover subscribing, rendering published events, search-mode suppression, unsubscribe on removal, and avatar fill-in from the cache, using a mock socket provider.
* Verified end to end against a dev stack: a session-cookie-authenticated centrifuge client subscribed through the proxies, and a message sent through mailroom arrived as a publication on the contact's history channel and matched the shape the component ingests.
