### PR TITLE
Add split views, reordering and card treatment to tabs

### DIFF
--- a/demo/components/tabs/example.html
+++ b/demo/components/tabs/example.html
@@ -17,6 +17,11 @@
       temba-tab > div {
         padding: 20px;
       }
+
+      /* let the split tabs example use the full window */
+      body {
+        max-width: none;
+      }
     </style>
   </head>
   <body>
@@ -80,6 +85,39 @@
               Historical records and activity logs are shown in this section.
             </p>
           </div>
+        </temba-tab>
+      </temba-tabs>
+    </div>
+
+    <div class="example">
+      <h3>Split Tabs</h3>
+      <p>
+        The first tab declares a maxWidth and following tabs declare a
+        splitWidth. When there is enough room, those tabs are pulled out of the
+        tab strip and shown side by side as a merged view, with resizers
+        between the secondary panes. The strip is orderable, so tabs can be
+        dragged to control which panes are pulled down first — the pinned
+        first tab can't be moved. Resize the window to see tabs merge and pop
+        back out.
+      </p>
+      <temba-tabs orderable style="height:300px; background:#f3f4f6;">
+        <temba-tab name="Chat" icon="message" maxWidth="500" pinned>
+          <div>This pane is capped at 500px when the view is split.</div>
+        </temba-tab>
+        <temba-tab name="Details" icon="info" splitWidth="200">
+          <div>This pane joins the split view when 200px is available.</div>
+        </temba-tab>
+        <temba-tab name="Fields" icon="fields" splitWidth="200">
+          <div>
+            This pane joins next and can be resized with the resizer, its
+            width is remembered.
+          </div>
+        </temba-tab>
+        <temba-tab name="Notes" icon="notes" splitWidth="200">
+          <div>This pane joins when there is room for it too.</div>
+        </temba-tab>
+        <temba-tab name="Static" icon="flow">
+          <div>This tab never joins the split view.</div>
         </temba-tab>
       </temba-tabs>
     </div>

--- a/src/form/DatePicker.ts
+++ b/src/form/DatePicker.ts
@@ -29,7 +29,9 @@ export class DatePicker extends FieldElement {
 
       .input-wrapper {
         padding: var(--temba-textinput-padding);
-        flex-grow: 1;
+        /* dwarfs the tz-wrapper's grow so the input takes the extra
+           space when everything fits on one line */
+        flex-grow: 999;
       }
 
       .tz {
@@ -65,6 +67,8 @@ export class DatePicker extends FieldElement {
         flex-direction: row;
         align-items: center;
         padding: 0.4em 0em;
+        /* when we wrap to our own row, fill it edge to edge */
+        flex-grow: 1;
       }
 
       .container:focus-within {

--- a/src/layout/Tab.ts
+++ b/src/layout/Tab.ts
@@ -1,5 +1,6 @@
 import { css, html, PropertyValueMap, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
+import { CustomEventType } from '../interfaces';
 import { RapidElement } from '../RapidElement';
 import { getClasses } from '../utils';
 
@@ -11,12 +12,66 @@ export class Tab extends RapidElement {
         flex-direction: column;
         min-height: 0;
         pointer-events: none;
+        box-sizing: border-box;
       }
 
       :host(.selected) {
         display: flex;
         flex-grow: 1;
         pointer-events: auto;
+      }
+
+      :host(.split) {
+        display: flex;
+        flex-grow: 0;
+        pointer-events: auto;
+        min-width: 0;
+        overflow: hidden;
+        /* inherited by pane content so long unbreakable strings wrap
+           instead of clipping or scrolling sideways */
+        overflow-wrap: anywhere;
+      }
+
+      /* pane content can never be laid out wider than the pane itself */
+      :host(.split) ::slotted(*) {
+        min-width: 0;
+        max-width: 100%;
+        box-sizing: border-box;
+      }
+
+      /* pulled panes render as cards with their title bar inside, the card
+         colors can be themed per tab via the --tab-card vars. the border is
+         applied inline by the containing temba-tabs since page-level resets
+         (e.g. tailwind preflight) override :host borders */
+      :host(.split.pane-card) {
+        margin: 0.75rem 0 0;
+        background: var(--tab-card-bg, var(--surface, #fff));
+        border-radius: var(--r-sm, 4px);
+        box-shadow: var(
+          --shadow-2,
+          0 1px 1px rgba(15, 22, 36, 0.04),
+          0 4px 12px rgba(15, 22, 36, 0.06)
+        );
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        padding: 0.5rem 0.75rem;
+        background: rgba(0, 0, 0, 0.04);
+        color: var(--text-2);
+        --icon-color: var(--text-2);
+        font-size: 13px;
+        font-weight: var(--w-medium);
+        user-select: none;
+      }
+
+      .header.grab {
+        cursor: grab;
+      }
+
+      .header .name {
+        margin-left: 0.4em;
       }
     `;
   }
@@ -52,12 +107,47 @@ export class Tab extends RapidElement {
   @property({ type: Boolean })
   dirty = false;
 
+  // when this tab is the first in a split view, cap its pane at this width
+  @property({ type: Number })
+  maxWidth = 0;
+
+  // the minimum width this tab needs to be pulled into a split view alongside
+  // the tabs before it, tabs without one are never split
+  @property({ type: Number })
+  splitWidth = 0;
+
+  // whether this tab is currently shown as a pane in a split view, managed by
+  // the containing temba-tabs
+  @property({ type: Boolean })
+  split = false;
+
+  // our position in the split view, managed by the containing temba-tabs
+  @property({ type: Number, attribute: false })
+  splitIndex = -1;
+
+  // pinned tabs keep their position and can't be reordered
+  @property({ type: Boolean })
+  pinned = false;
+
+  // whether our pane header can be grabbed to reorder panes, managed by the
+  // containing temba-tabs
+  @property({ type: Boolean, attribute: false })
+  headerGrab = false;
+
   public updated(
     changes: PropertyValueMap<any> | Map<PropertyKey, unknown>
   ): void {
     super.updated(changes);
     if (changes.has('selected')) {
       this.classList.toggle('selected', this.selected);
+    }
+    if (changes.has('split')) {
+      this.classList.toggle('split', this.split);
+    }
+    if (changes.has('split') || changes.has('splitIndex')) {
+      // the first pane anchors the view and styles itself, the rest are
+      // cards. namespaced to avoid colliding with page-level .card styles
+      this.classList.toggle('pane-card', this.split && this.splitIndex > 0);
     }
   }
 
@@ -77,10 +167,33 @@ export class Tab extends RapidElement {
     }
   }
 
+  private handleHeaderDown(event: MouseEvent) {
+    if (!this.headerGrab) {
+      return;
+    }
+    event.preventDefault();
+    this.fireCustomEvent(CustomEventType.DragStart, {
+      tab: this,
+      clientX: event.clientX,
+      clientY: event.clientY
+    });
+  }
+
   public render(): TemplateResult {
-    return html`<slot
-      @temba-details-changed=${this.handleDetailsChanged}
-      class="${getClasses({ selected: this.selected })}"
-    ></slot> `;
+    // panes pulled into a split view keep their identity with a small header
+    return html`${this.split && this.splitIndex > 0
+        ? html`<div
+            class="${getClasses({ header: true, grab: this.headerGrab })}"
+            @mousedown=${this.handleHeaderDown}
+          >
+            ${this.icon
+              ? html`<temba-icon name=${this.icon}></temba-icon>`
+              : null}
+            <div class="name">${this.name}</div>
+          </div>`
+        : null}<slot
+        @temba-details-changed=${this.handleDetailsChanged}
+        class="${getClasses({ selected: this.selected })}"
+      ></slot> `;
   }
 }

--- a/src/layout/TabPane.ts
+++ b/src/layout/TabPane.ts
@@ -500,6 +500,24 @@ export class TabPane extends RapidElement {
           this.updateSplitting(true);
         }, TabPane.GROW_DELAY);
         this.applySplitStyles(width);
+        // going from no split to a split, cap the anchor at its split width
+        // now so its content doesn't stretch across the full width and then
+        // reflow when the extra panes are pulled in after the width settles.
+        // the reserved space stays empty until the panes arrive.
+        //
+        // only cap the width here — the pane is still a column at this point
+        // (the split/row layout doesn't kick in until the panes actually
+        // arrive), so setting flex:0 0 auto would collapse the anchor to its
+        // content height and leave just the compose box showing. leaving the
+        // selected tab's flex-grow in place keeps it filling the height while
+        // the explicit width holds the reserved space on the cross axis.
+        if (this.splitTabs.length === 0) {
+          const primary = group[0];
+          if (primary && group.includes(this.options[this.index])) {
+            primary.style.removeProperty('flex');
+            primary.style.width = `${primary.maxWidth}px`;
+          }
+        }
         return;
       }
       this.splitTabs = group;

--- a/src/layout/TabPane.ts
+++ b/src/layout/TabPane.ts
@@ -12,6 +12,7 @@ export class TabPane extends RapidElement {
         display: flex;
         flex-direction: column;
         min-height: 0;
+        min-width: 0;
         flex-grow: 1;
       }
 
@@ -62,6 +63,10 @@ export class TabPane extends RapidElement {
         display: none;
       }
 
+      .option.ghost {
+        opacity: 0.4;
+      }
+
       .option .name {
         margin-left: 0.4em;
         max-width: 200px;
@@ -78,6 +83,20 @@ export class TabPane extends RapidElement {
         margin-right: -6px;
         display: inline-flex;
         align-items: center;
+      }
+
+      .option.merged {
+        padding: 0;
+      }
+
+      .option.merged .segment {
+        display: flex;
+        align-items: center;
+        padding: 8px 14px 10px;
+      }
+
+      .option.merged .segment + .segment {
+        border-left: 1px solid var(--border);
       }
 
       @media (max-width: 900px) {
@@ -129,6 +148,46 @@ export class TabPane extends RapidElement {
         flex-grow: 1;
         min-height: 0;
         overflow: hidden;
+        background: var(--tab-pane-bg, transparent);
+      }
+
+      .pane.split {
+        flex-direction: row;
+      }
+
+      .resizer {
+        flex: 0 0 20px;
+        display: flex;
+        justify-content: center;
+        cursor: col-resize;
+        z-index: 1;
+        /* match the vertical inset of the pane cards */
+        padding: 0.75rem 0 0;
+      }
+
+      .resizer .bar {
+        width: 5px;
+        border-radius: 2.5px;
+        background: var(--border);
+        transition: background 100ms linear;
+      }
+
+      .resizer:hover .bar,
+      .resizer.dragging .bar {
+        background: var(--accent-600);
+      }
+
+      .pane.split slot[name='pane-bottom']::slotted(*) {
+        order: 99;
+      }
+
+      .drop-placeholder {
+        box-sizing: border-box;
+        margin: 0.75rem 0 0;
+        border-radius: var(--r-sm, 4px);
+        background: var(--sunken, #f3f4f6);
+        outline: 2px dashed var(--border-strong, #d1d5db);
+        outline-offset: -2px;
       }
 
       .count {
@@ -192,6 +251,10 @@ export class TabPane extends RapidElement {
   @property({ type: Boolean })
   focusedName = false;
 
+  // whether unpinned tabs can be dragged to reorder them
+  @property({ type: Boolean })
+  orderable = false;
+
   @property({ type: Number })
   index = -1;
 
@@ -201,7 +264,67 @@ export class TabPane extends RapidElement {
   @property({ type: Array, attribute: false })
   options: Tab[] = [];
 
+  // tabs currently merged into a split view, always empty or at least two,
+  // the first tab anchors the view and the rest are pulled in as panes
+  @property({ type: Array, attribute: false })
+  splitTabs: Tab[] = [];
+
+  // user preferred order for unpinned tabs, as tab keys
+  @property({ type: Array, attribute: false })
+  ordering: string[] = [];
+
+  @property({ type: Boolean, attribute: false })
+  dragging = false;
+
+  @property({ type: Boolean, attribute: false })
+  orderDragging = false;
+
+  private resizeObserver: ResizeObserver;
+  private dragTab: Tab;
+  private dragStartX: number;
+  private dragStartWidth: number;
+  private dragMaxWidth: number;
+  private orderTab: Tab;
+  private orderStartX: number;
+  private orderStartY: number;
+  private suppressClick = false;
+  @property({ type: Boolean, attribute: false })
+  paneDragging = false;
+
+  private paneDragTab: Tab;
+  private paneDragStartX: number;
+  private paneDragStartY: number;
+  private paneGhostOffsetX: number;
+  private paneGhostOffsetY: number;
+  private splitGrowTimeout: number;
+
+  // the spacing between split panes, resizers live inside these gutters, the
+  // gap before the first pulled pane has no resizer so it's half as wide to
+  // read the same visually
+  private static GUTTER = 20;
+  private static FIRST_GUTTER = 10;
+
+  // how long the width must be stable before we pull more panes into the
+  // split view, so late-loading layout (menus, fonts) can't make panes
+  // flash in and pop back out
+  private static GROW_DELAY = 200;
+
+  constructor() {
+    super();
+    this.handleResizerMove = this.handleResizerMove.bind(this);
+    this.handleResizerUp = this.handleResizerUp.bind(this);
+    this.handleOrderMove = this.handleOrderMove.bind(this);
+    this.handleOrderUp = this.handleOrderUp.bind(this);
+    this.handlePaneDragMove = this.handlePaneDragMove.bind(this);
+    this.handlePaneDragUp = this.handlePaneDragUp.bind(this);
+  }
+
   private handleTabClick(event: MouseEvent): void {
+    if (this.suppressClick) {
+      this.suppressClick = false;
+      return;
+    }
+
     const newIndex = parseInt(
       (event.currentTarget as HTMLDivElement).dataset.index
     );
@@ -231,6 +354,11 @@ export class TabPane extends RapidElement {
     }
   }
 
+  public connectedCallback(): void {
+    super.connectedCallback();
+    this.ordering = this.getStoredOrder();
+  }
+
   public firstUpdated(
     changes: PropertyValueMap<any> | Map<PropertyKey, unknown>
   ): void {
@@ -239,6 +367,25 @@ export class TabPane extends RapidElement {
       'slotchange',
       this.handleSlotChange.bind(this)
     );
+    this.resizeObserver = new ResizeObserver(() => {
+      // defer so we don't change layout inside the observer callback
+      window.requestAnimationFrame(() => this.updateSplitting());
+    });
+    this.resizeObserver.observe(this);
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+    }
+    window.removeEventListener('mousemove', this.handleResizerMove);
+    window.removeEventListener('mouseup', this.handleResizerUp);
+    window.removeEventListener('mousemove', this.handleOrderMove);
+    window.removeEventListener('mouseup', this.handleOrderUp);
+    window.removeEventListener('mousemove', this.handlePaneDragMove);
+    window.removeEventListener('mouseup', this.handlePaneDragUp);
+    window.clearTimeout(this.splitGrowTimeout);
   }
 
   public updated(changedProperties: Map<string, any>) {
@@ -274,6 +421,514 @@ export class TabPane extends RapidElement {
         }
       }
     }
+
+    this.updateSplitting();
+  }
+
+  // whether the split view is currently showing, which requires the selected
+  // tab to be one of the merged tabs
+  public isSplitActive(): boolean {
+    return (
+      this.splitTabs.length > 1 &&
+      this.splitTabs.includes(this.options[this.index])
+    );
+  }
+
+  // tabs in the order they should be displayed, pinned tabs keep their
+  // natural position at the front and the rest follow the user's ordering
+  public getDisplayOrder(): Tab[] {
+    // stored ordering only applies where the user can reorder tabs
+    if (!this.orderable) {
+      return [...this.options];
+    }
+    const pinned = this.options.filter((tab) => tab.pinned);
+    const rest = this.options.filter((tab) => !tab.pinned);
+    rest.sort((a, b) => {
+      const aRank = this.getOrderRank(a);
+      const bRank = this.getOrderRank(b);
+      return aRank - bRank;
+    });
+    return [...pinned, ...rest];
+  }
+
+  private getOrderRank(tab: Tab): number {
+    const rank = this.ordering.indexOf(this.getTabKey(tab));
+    // tabs the user hasn't ordered sort after, in their natural order
+    return rank >= 0 ? rank : this.ordering.length + this.options.indexOf(tab);
+  }
+
+  // determine which tabs merge into a split view at our current width, any
+  // tab with a split width is pulled in, in display order, as long as it fits
+  private updateSplitting(immediate = false): void {
+    if (this.dragging || this.orderDragging) {
+      return;
+    }
+    const width = this.offsetWidth;
+    const display = this.getDisplayOrder().filter((tab) => !tab.hidden);
+    const group: Tab[] = [];
+
+    const primary = display[0];
+    if (primary && primary.maxWidth > 0) {
+      let required = primary.maxWidth;
+      for (const tab of display.slice(1)) {
+        if (!(tab.splitWidth > 0)) {
+          continue;
+        }
+        const gutter =
+          group.length === 0 ? TabPane.FIRST_GUTTER : TabPane.GUTTER;
+        const needed = required + gutter + tab.splitWidth;
+        if (needed > width) {
+          break;
+        }
+        group.push(tab);
+        required = needed;
+      }
+      if (group.length > 0) {
+        group.unshift(primary);
+      }
+    }
+
+    const changed =
+      group.length !== this.splitTabs.length ||
+      group.some((tab, i) => tab !== this.splitTabs[i]);
+    if (changed) {
+      // adding panes waits for the width to settle, removals are immediate
+      // since keeping a pane that no longer fits would overflow
+      if (!immediate && group.length > this.splitTabs.length) {
+        window.clearTimeout(this.splitGrowTimeout);
+        this.splitGrowTimeout = window.setTimeout(() => {
+          this.updateSplitting(true);
+        }, TabPane.GROW_DELAY);
+        this.applySplitStyles(width);
+        return;
+      }
+      this.splitTabs = group;
+    }
+    this.applySplitStyles(width);
+  }
+
+  // size our panes, the first pane is capped at its max width, panes in the
+  // middle use their remembered widths and the last pane fills what's left
+  private applySplitStyles(width: number): void {
+    const active = this.isSplitActive();
+    const group = this.splitTabs;
+    const gutters =
+      group.length > 1
+        ? TabPane.FIRST_GUTTER + (group.length - 2) * TabPane.GUTTER
+        : 0;
+    const secondaryMins = group
+      .slice(1)
+      .reduce((total, tab) => total + tab.splitWidth, 0);
+
+    const placeholder = this.paneDragging
+      ? (this.shadowRoot.querySelector('.drop-placeholder') as HTMLElement)
+      : null;
+
+    for (const tab of this.options) {
+      const groupIndex = active ? group.indexOf(tab) : -1;
+      tab.split = groupIndex >= 0;
+      tab.splitIndex = groupIndex;
+      tab.headerGrab = this.orderable && !tab.pinned;
+
+      // while a card is being dragged it follows the cursor, its layout
+      // slot is occupied by the drop placeholder
+      if (this.paneDragging && tab === this.paneDragTab) {
+        if (placeholder) {
+          if (groupIndex >= 0) {
+            placeholder.style.display = 'block';
+            this.applySlotStyles(
+              placeholder,
+              groupIndex,
+              group,
+              width,
+              gutters,
+              secondaryMins
+            );
+          } else {
+            placeholder.style.display = 'none';
+          }
+        }
+        continue;
+      }
+
+      if (groupIndex < 0) {
+        tab.style.removeProperty('flex');
+        tab.style.removeProperty('width');
+        tab.style.removeProperty('min-width');
+        tab.style.removeProperty('margin-left');
+        tab.style.removeProperty('margin-right');
+        tab.style.removeProperty('order');
+        tab.style.removeProperty('border');
+        continue;
+      }
+
+      // the card border is inline so page-level resets can't strip it
+      if (groupIndex > 0) {
+        tab.style.border =
+          '1px solid var(--tab-card-border, var(--border-strong, #ddd))';
+      } else {
+        tab.style.removeProperty('border');
+      }
+
+      this.applySlotStyles(
+        tab,
+        groupIndex,
+        group,
+        width,
+        gutters,
+        secondaryMins
+      );
+    }
+  }
+
+  // position and size an element for a slot in the split layout, used for
+  // both the panes themselves and the drop placeholder during a drag
+  private applySlotStyles(
+    el: HTMLElement,
+    groupIndex: number,
+    group: Tab[],
+    width: number,
+    gutters: number,
+    secondaryMins: number
+  ): void {
+    const tab = group[groupIndex];
+    el.style.order = `${groupIndex * 2}`;
+
+    // the first secondary pane has no resizer before it, just a gap
+    if (groupIndex === 1) {
+      el.style.marginLeft = `${TabPane.FIRST_GUTTER}px`;
+    } else {
+      el.style.removeProperty('margin-left');
+    }
+
+    el.style.removeProperty('margin-right');
+
+    if (groupIndex === 0) {
+      el.style.flex = '0 0 auto';
+      el.style.width = `${tab.maxWidth}px`;
+    } else if (groupIndex === group.length - 1) {
+      el.style.flex = '1 1 0';
+      el.style.removeProperty('width');
+      el.style.minWidth = `${tab.splitWidth}px`;
+    } else {
+      const available =
+        width - group[0].maxWidth - gutters - (secondaryMins - tab.splitWidth);
+      const paneWidth = Math.min(
+        Math.max(this.getStoredWidth(tab) || tab.splitWidth, tab.splitWidth),
+        available
+      );
+      el.style.flex = '0 0 auto';
+      el.style.width = `${paneWidth}px`;
+    }
+  }
+
+  private getTabKey(tab: Tab): string {
+    return tab.icon || tab.name;
+  }
+
+  private getStorageScope(): string {
+    return this.id ? `-${this.id}` : '';
+  }
+
+  private getStorageKey(tab: Tab): string {
+    return `temba-tabs${this.getStorageScope()}-split-${this.getTabKey(tab)}`;
+  }
+
+  private getStoredWidth(tab: Tab): number {
+    try {
+      const width = parseInt(
+        window.localStorage.getItem(this.getStorageKey(tab))
+      );
+      return isNaN(width) ? 0 : width;
+    } catch (e) {
+      return 0;
+    }
+  }
+
+  private setStoredWidth(tab: Tab, width: number): void {
+    try {
+      window.localStorage.setItem(this.getStorageKey(tab), `${width}`);
+    } catch (e) {
+      // storage isn't available, width just won't be remembered
+    }
+  }
+
+  private getStoredOrder(): string[] {
+    try {
+      const order = JSON.parse(
+        window.localStorage.getItem(`temba-tabs${this.getStorageScope()}-order`)
+      );
+      return Array.isArray(order) ? order : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  private setStoredOrder(): void {
+    try {
+      window.localStorage.setItem(
+        `temba-tabs${this.getStorageScope()}-order`,
+        JSON.stringify(this.ordering)
+      );
+    } catch (e) {
+      // storage isn't available, order just won't be remembered
+    }
+  }
+
+  private handleResizerDown(event: MouseEvent): void {
+    const groupIndex = parseInt(
+      (event.currentTarget as HTMLElement).dataset.index
+    );
+    this.dragTab = this.splitTabs[groupIndex];
+    this.dragStartX = event.clientX;
+    this.dragStartWidth = this.dragTab.offsetWidth;
+
+    // we can grow until the last pane is squeezed to its minimum
+    const last = this.splitTabs[this.splitTabs.length - 1];
+    this.dragMaxWidth =
+      this.dragStartWidth + last.offsetWidth - last.splitWidth;
+
+    document.body.style.userSelect = 'none';
+    window.addEventListener('mousemove', this.handleResizerMove);
+    window.addEventListener('mouseup', this.handleResizerUp);
+    this.dragging = true;
+    event.preventDefault();
+  }
+
+  private handleResizerMove(event: MouseEvent): void {
+    const width = Math.min(
+      Math.max(
+        this.dragStartWidth + event.clientX - this.dragStartX,
+        this.dragTab.splitWidth
+      ),
+      this.dragMaxWidth
+    );
+    this.dragTab.style.width = `${width}px`;
+  }
+
+  private handleResizerUp(): void {
+    document.body.style.userSelect = '';
+    window.removeEventListener('mousemove', this.handleResizerMove);
+    window.removeEventListener('mouseup', this.handleResizerUp);
+    this.dragging = false;
+
+    const width = this.dragTab.offsetWidth;
+    this.setStoredWidth(this.dragTab, width);
+    this.fireCustomEvent(CustomEventType.Resized, {
+      tab: this.dragTab.name,
+      width
+    });
+  }
+
+  private handleOrderDown(event: MouseEvent): void {
+    const tab =
+      this.options[
+        parseInt((event.currentTarget as HTMLElement).dataset.index)
+      ];
+    if (!tab || tab.pinned) {
+      return;
+    }
+    this.orderTab = tab;
+    this.orderStartX = event.clientX;
+    this.orderStartY = event.clientY;
+    window.addEventListener('mousemove', this.handleOrderMove);
+    window.addEventListener('mouseup', this.handleOrderUp);
+  }
+
+  private handleOrderMove(event: MouseEvent): void {
+    if (!this.orderDragging) {
+      if (
+        Math.abs(event.clientX - this.orderStartX) < 5 &&
+        Math.abs(event.clientY - this.orderStartY) < 5
+      ) {
+        return;
+      }
+      this.orderDragging = true;
+      document.body.style.userSelect = 'none';
+    }
+
+    // unpinned tabs in display order, without the one being dragged
+    const flat = this.getDisplayOrder().filter(
+      (tab) => !tab.pinned && tab !== this.orderTab
+    );
+
+    // walk the rendered options, treating each merged segment as its own
+    // stop, counting the unpinned tabs left of the pointer
+    const stops: HTMLElement[] = [];
+    for (const option of Array.from(
+      this.shadowRoot.querySelectorAll('.options .option:not(.hidden)')
+    ) as HTMLElement[]) {
+      if (option.classList.contains('merged')) {
+        stops.push(
+          ...(Array.from(option.querySelectorAll('.segment')) as HTMLElement[])
+        );
+      } else {
+        stops.push(option);
+      }
+    }
+
+    let insert = 0;
+    for (const stop of stops) {
+      const tab = this.options[parseInt(stop.dataset.index)];
+      if (!tab || tab === this.orderTab || tab.pinned) {
+        continue;
+      }
+      const box = stop.getBoundingClientRect();
+      if (event.clientX > box.left + box.width / 2) {
+        insert += 1;
+      }
+    }
+
+    const newOrdering = flat.map((tab) => this.getTabKey(tab));
+    newOrdering.splice(insert, 0, this.getTabKey(this.orderTab));
+    if (JSON.stringify(newOrdering) !== JSON.stringify(this.ordering)) {
+      this.ordering = newOrdering;
+    }
+  }
+
+  // a pane header was grabbed, get ready to drag it to reorder the panes
+  private handlePaneDragStart(event: CustomEvent): void {
+    const tab = event.detail.tab as Tab;
+    if (
+      !tab ||
+      !this.options.includes(tab) ||
+      !this.orderable ||
+      tab.pinned ||
+      !this.isSplitActive()
+    ) {
+      return;
+    }
+    event.stopPropagation();
+    this.paneDragTab = tab;
+    this.paneDragStartX = event.detail.clientX;
+    this.paneDragStartY = event.detail.clientY;
+    window.addEventListener('mousemove', this.handlePaneDragMove);
+    window.addEventListener('mouseup', this.handlePaneDragUp);
+  }
+
+  private handlePaneDragMove(event: MouseEvent): void {
+    if (!this.paneDragging) {
+      if (
+        Math.abs(event.clientX - this.paneDragStartX) < 3 &&
+        Math.abs(event.clientY - this.paneDragStartY) < 3
+      ) {
+        return;
+      }
+
+      // the real card lifts out of the layout and follows the cursor, a
+      // placeholder takes over its slot. the grab offset is anchored to the
+      // original mousedown so the card tracks the true grab point
+      const rect = this.paneDragTab.getBoundingClientRect();
+      this.paneGhostOffsetX = this.paneDragStartX - rect.left;
+      this.paneGhostOffsetY = this.paneDragStartY - rect.top;
+      this.paneDragging = true;
+      document.body.style.userSelect = 'none';
+      document.body.style.cursor = 'grabbing';
+
+      const style = this.paneDragTab.style;
+      style.position = 'fixed';
+      style.left = `${rect.left}px`;
+      style.top = `${rect.top}px`;
+      style.width = `${rect.width}px`;
+      style.height = `${rect.height}px`;
+      style.margin = '0';
+      style.zIndex = '99999';
+      style.pointerEvents = 'none';
+      style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.18)';
+      style.transform = 'scale(1.02)';
+
+      // render the placeholder now so the layout doesn't jump
+      this.performUpdate();
+      this.updateSplitting();
+    }
+
+    this.paneDragTab.style.left = `${event.clientX - this.paneGhostOffsetX}px`;
+    this.paneDragTab.style.top = `${event.clientY - this.paneGhostOffsetY}px`;
+
+    // reorder live as the dragged card itself crosses pane midpoints, using
+    // the card's center rather than the cursor so the grab point within the
+    // title bar doesn't matter
+    const others = this.splitTabs.filter(
+      (tab) => tab !== this.paneDragTab && !tab.pinned
+    );
+    if (!others.length) {
+      return;
+    }
+    const draggedCenter =
+      event.clientX - this.paneGhostOffsetX + this.paneDragTab.offsetWidth / 2;
+    let before: Tab = null;
+    for (const tab of others) {
+      const box = tab.getBoundingClientRect();
+      if (draggedCenter < box.left + box.width / 2) {
+        before = tab;
+        break;
+      }
+    }
+
+    const flat = this.getDisplayOrder().filter(
+      (tab) => !tab.pinned && tab !== this.paneDragTab
+    );
+    const index = before
+      ? flat.indexOf(before)
+      : flat.indexOf(others[others.length - 1]) + 1;
+    flat.splice(index, 0, this.paneDragTab);
+    const newOrdering = flat.map((tab) => this.getTabKey(tab));
+    if (JSON.stringify(newOrdering) !== JSON.stringify(this.ordering)) {
+      this.ordering = newOrdering;
+      this.updateSplitting();
+    }
+  }
+
+  private handlePaneDragUp(): void {
+    window.removeEventListener('mousemove', this.handlePaneDragMove);
+    window.removeEventListener('mouseup', this.handlePaneDragUp);
+    if (this.paneDragging) {
+      this.paneDragging = false;
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+      if (this.paneDragTab) {
+        // drop the card back into its slot
+        const style = this.paneDragTab.style;
+        for (const prop of [
+          'position',
+          'left',
+          'top',
+          'width',
+          'height',
+          'margin',
+          'z-index',
+          'pointer-events',
+          'box-shadow',
+          'transform'
+        ]) {
+          style.removeProperty(prop);
+        }
+      }
+      this.setStoredOrder();
+      this.updateSplitting();
+      this.fireCustomEvent(CustomEventType.OrderChanged, {
+        order: [...this.ordering]
+      });
+    }
+    this.paneDragTab = null;
+  }
+
+  private handleOrderUp(): void {
+    window.removeEventListener('mousemove', this.handleOrderMove);
+    window.removeEventListener('mouseup', this.handleOrderUp);
+    if (this.orderDragging) {
+      this.orderDragging = false;
+      document.body.style.userSelect = '';
+      this.setStoredOrder();
+      this.updateSplitting();
+
+      // swallow the click that follows a drag
+      this.suppressClick = true;
+      window.setTimeout(() => {
+        this.suppressClick = false;
+      }, 0);
+    }
+    this.orderTab = null;
   }
 
   public focusTab(name: string): Tab {
@@ -317,7 +972,30 @@ export class TabPane extends RapidElement {
     this.requestUpdate();
   }
 
+  private renderOptionContent(tab: Tab): TemplateResult {
+    return html`${tab.icon ? html`<temba-icon name=${tab.icon} />` : null}
+      <div class="name">${tab.name} ${tab.dirty ? ` *` : ``}</div>
+      ${tab.hasBadge()
+        ? html`
+            <div class="badge">
+              ${tab.count > 0 && !tab.activity
+                ? html`<div class="count">${tab.count.toLocaleString()}</div>`
+                : null}
+              ${tab.activity && tab.count > 0 && !tab.dirty
+                ? html`<div class="dot"></div>`
+                : null}
+            </div>
+          `
+        : null}
+      ${tab.checked && !tab.alert
+        ? html`<temba-icon class="check" name="check"></temba-icon>`
+        : null}`;
+  }
+
   public render(): TemplateResult {
+    const merged = this.splitTabs.length > 1;
+    const splitActive = this.isSplitActive();
+    const display = this.getDisplayOrder();
     return html`
       <div
         class="${getClasses({
@@ -327,50 +1005,101 @@ export class TabPane extends RapidElement {
           unselect: this.unselect
         })}"
       >
-        ${this.options.map(
-          (tab, index) => html`
+        ${display.map((tab) => {
+          const index = this.options.indexOf(tab);
+          const groupIndex = merged ? this.splitTabs.indexOf(tab) : -1;
+
+          // merged tabs render together as a single option
+          if (groupIndex > 0) {
+            return null;
+          }
+
+          if (groupIndex === 0) {
+            return html`
+              <div
+                @click=${this.handleTabClick}
+                data-index=${index}
+                class="${getClasses({
+                  option: true,
+                  merged: true,
+                  first: display[0] === tab,
+                  selected: splitActive,
+                  alert: this.splitTabs.some((t) => t.alert),
+                  dirty: this.splitTabs.some((t) => t.dirty)
+                })}"
+              >
+                ${this.splitTabs.map(
+                  (t) =>
+                    html`<div
+                      class="${getClasses({
+                        segment: true,
+                        ghost: this.orderDragging && t === this.orderTab
+                      })}"
+                      data-index=${this.options.indexOf(t)}
+                      @mousedown=${this.orderable && !t.pinned
+                        ? this.handleOrderDown
+                        : null}
+                    >
+                      ${this.renderOptionContent(t)}
+                    </div>`
+                )}
+              </div>
+            `;
+          }
+
+          return html`
             <div
               @click=${this.handleTabClick}
+              @mousedown=${this.orderable && !tab.pinned
+                ? this.handleOrderDown
+                : null}
               data-index=${index}
               class="${getClasses({
                 option: true,
-                first: index == 0,
+                first: display[0] === tab,
                 selected: index == this.index,
                 hidden: tab.hidden,
                 alert: tab.alert,
-                dirty: tab.dirty
+                dirty: tab.dirty,
+                ghost: this.orderDragging && tab === this.orderTab
               })}"
             >
-              ${tab.icon ? html`<temba-icon name=${tab.icon} />` : null}
-              <div class="name">${tab.name} ${tab.dirty ? ` *` : ``}</div>
-              ${tab.hasBadge()
-                ? html`
-                    <div class="badge">
-                      ${tab.count > 0 && !tab.activity
-                        ? html`<div class="count">
-                            ${tab.count.toLocaleString()}
-                          </div>`
-                        : null}
-                      ${tab.activity && tab.count > 0 && !tab.dirty
-                        ? html`<div class="dot"></div>`
-                        : null}
-                    </div>
-                  `
-                : null}
-              ${tab.checked && !tab.alert
-                ? html`<temba-icon class="check" name="check"></temba-icon>`
-                : null}
+              ${this.renderOptionContent(tab)}
             </div>
-          `
-        )}
+          `;
+        })}
 
         <div style="flex-grow:1"></div>
         <div style="display:flex; align-items:center">
           <slot name="tab-right"></slot>
         </div>
       </div>
-      <div @temba-details-changed=${this.handleTabDetailsChanged} class="pane">
+      <div
+        @temba-details-changed=${this.handleTabDetailsChanged}
+        @temba-drag-start=${this.handlePaneDragStart}
+        class="${getClasses({ pane: true, split: splitActive })}"
+      >
         <slot></slot>
+        ${splitActive
+          ? this.splitTabs.slice(1, -1).map((tab, i) => {
+              // each resizer sits after the pane it resizes
+              const groupIndex = i + 1;
+              return html`
+                <div
+                  data-index=${groupIndex}
+                  style="order:${groupIndex * 2 + 1}"
+                  class="${getClasses({
+                    resizer: true,
+                    dragging: this.dragging && this.dragTab === tab
+                  })}"
+                  @mousedown=${this.handleResizerDown}
+                >
+                  <div class="bar"></div>
+                </div>
+              `;
+            })
+          : null}
+        ${this.paneDragging ? html`<div class="drop-placeholder"></div>` : null}
         <slot name="pane-bottom"></slot>
       </div>
     `;

--- a/src/list/TembaMenu.ts
+++ b/src/list/TembaMenu.ts
@@ -162,6 +162,21 @@ export class TembaMenu extends ResizeElement {
         display: none;
       }
 
+      /* the loading skeleton reserves the menu footprint, the rail is 36px
+         items with 8px margins and a level is 12em items plus padding */
+      .level-0.loading-rail {
+        min-width: 52px;
+      }
+
+      .level.loading-level {
+        width: 178px;
+      }
+
+      /* when the skeleton root has a remembered width, the level fills it */
+      .root .loading-level {
+        flex-grow: 1;
+      }
+
       .level-0 > .item,
       .level-0 > temba-dropdown > div[slot='toggle'] > .avatar,
       .level-0 > temba-dropdown > div[slot='toggle'] > .item {
@@ -800,6 +815,27 @@ export class TembaMenu extends ResizeElement {
         this.value = null;
       }
     }
+
+    // remember our rendered width so the next load can reserve it exactly
+    if (this.root && this.root.items && !this.isMobile()) {
+      const width = this.offsetWidth;
+      if (width > 0 && width !== this.getStoredWidth()) {
+        try {
+          window.localStorage.setItem('temba-menu-width', `${width}`);
+        } catch (e) {
+          // storage isn't available, the width just won't be remembered
+        }
+      }
+    }
+  }
+
+  private getStoredWidth(): number {
+    try {
+      const width = parseInt(window.localStorage.getItem('temba-menu-width'));
+      return isNaN(width) ? 0 : width;
+    } catch (e) {
+      return 0;
+    }
   }
 
   public reset() {
@@ -1304,6 +1340,21 @@ export class TembaMenu extends ResizeElement {
 
   public render(): TemplateResult {
     if (!this.root || !this.root.items) {
+      // reserve our footprint while the menu loads so the rest of the page
+      // doesn't reflow when it arrives, using our remembered width when we
+      // have one so the reservation is exact
+      if (this.endpoint && !this.isMobile()) {
+        const reserved = this.getStoredWidth();
+        return html`<div
+          class="root"
+          style="${reserved ? `width:${reserved}px` : ''}"
+        >
+          <div class="level level-0 loading-rail">
+            <div class="empty"></div>
+          </div>
+          <div class="level level-1 loading-level"></div>
+        </div>`;
+      }
       return null;
     }
 

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -12,8 +12,10 @@
       'scf1453991c986b25': `Tab para completar, enter para seleccionar`,
 's73b4d70c02f4b4e0': `No options`,
 'sbc913d7dc0f33877': `to add`,
+'s81f17cfc89a04338': `Interrupt flow`,
 's8f02e3a18ffc083a': `Are not currently in a flow`,
 's638236250662c6b3': `Have sent a message in the last`,
 's4788ee206c4570c7': `Have not started this flow in the last 90 days`,
+'sea4f08110bb8f15d': `Remove`,
     };
   

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -12,8 +12,10 @@
       's73b4d70c02f4b4e0': `No options`,
 'scf1453991c986b25': `Tab to complete, enter to select`,
 'sbc913d7dc0f33877': `to add`,
+'s81f17cfc89a04338': `Interrupt flow`,
 's8f02e3a18ffc083a': `Are not currently in a flow`,
 's638236250662c6b3': `Have sent a message in the last`,
 's4788ee206c4570c7': `Have not started this flow in the last 90 days`,
+'sea4f08110bb8f15d': `Remove`,
     };
   

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -12,8 +12,10 @@
       's73b4d70c02f4b4e0': `No options`,
 'scf1453991c986b25': `Tab to complete, enter to select`,
 'sbc913d7dc0f33877': `to add`,
+'s81f17cfc89a04338': `Interrupt flow`,
 's8f02e3a18ffc083a': `Are not currently in a flow`,
 's638236250662c6b3': `Have sent a message in the last`,
 's4788ee206c4570c7': `Have not started this flow in the last 90 days`,
+'sea4f08110bb8f15d': `Remove`,
     };
   

--- a/test/temba-menu.test.ts
+++ b/test/temba-menu.test.ts
@@ -31,6 +31,17 @@ describe('temba-menu', () => {
     expect(list.root).is.undefined;
   });
 
+  it('reserves its width while loading', async () => {
+    // an endpoint that never yields items leaves us in the loading state,
+    // where we hold the footprint of the rail plus one level so the page
+    // doesn't reflow when the menu arrives
+    const menu: TembaMenu = await getMenu({
+      endpoint: '/test-assets/menu/does-not-exist.json'
+    });
+    assert.isNotNull(menu.shadowRoot.querySelector('.loading-level'));
+    assert.isAtLeast(menu.offsetWidth, 200);
+  });
+
   it('renders with endpoint', async () => {
     const menu: TembaMenu = await getMenu({
       endpoint: '/test-assets/menu/menu-root.json'

--- a/test/temba-tabs.test.ts
+++ b/test/temba-tabs.test.ts
@@ -204,6 +204,30 @@ describe('temba-tabs', () => {
     assert.equal(tabs.splitTabs.length, 2);
   });
 
+  it('reserves the anchor width while waiting to split', async () => {
+    const wrapper = (await fixture(
+      `<div style="width:1300px;display:flex;">${SPLIT_TABS}</div>`
+    )) as HTMLDivElement;
+    const tabs = wrapper.querySelector('temba-tabs') as TabPane;
+    await tabs.updateComplete;
+
+    // while we wait for the width to settle we haven't split yet, but the
+    // anchor is already capped so its content doesn't stretch across the
+    // full width and reflow when the panes finally arrive
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(tabs.splitTabs.length, 0);
+    assert.equal(tabs.getTab(0).style.width, '600px');
+    // only the width is capped — the anchor keeps its flex-grow so it still
+    // fills the pane height. capping flex here would collapse it to content
+    // height and leave just the shortest child (e.g. a compose box) visible
+    // until the split finally activates
+    assert.equal(tabs.getTab(0).style.flex, '');
+
+    await settle(tabs);
+    assert.equal(tabs.splitTabs.length, 3);
+    assert.equal(tabs.getTab(0).style.width, '600px');
+  });
+
   it('pops tabs back out when the width shrinks', async () => {
     const tabs = await getTabs(1300);
     assert.equal(tabs.splitTabs.length, 3);

--- a/test/temba-tabs.test.ts
+++ b/test/temba-tabs.test.ts
@@ -1,0 +1,533 @@
+import '../temba-modules';
+import { fixture, assert, oneEvent } from '@open-wc/testing';
+import { TabPane } from '../src/layout/TabPane';
+import { Tab } from '../src/layout/Tab';
+import { CustomEventType } from '../src/interfaces';
+
+const SPLIT_TABS = `
+  <temba-tabs orderable>
+    <temba-tab name="Chat" icon="message" maxWidth="600" pinned>
+      <div>chat</div>
+    </temba-tab>
+    <temba-tab name="Details" icon="info" splitWidth="300">
+      <div>details</div>
+    </temba-tab>
+    <temba-tab name="Fields" icon="fields" splitWidth="300">
+      <div>fields</div>
+    </temba-tab>
+    <temba-tab name="Notes" icon="notes">
+      <div>notes</div>
+    </temba-tab>
+  </temba-tabs>
+`;
+
+const SKIP_TABS = `
+  <temba-tabs>
+    <temba-tab name="Chat" icon="message" maxWidth="600" pinned>
+      <div>chat</div>
+    </temba-tab>
+    <temba-tab name="Details" icon="info" splitWidth="300">
+      <div>details</div>
+    </temba-tab>
+    <temba-tab name="Static" icon="flow">
+      <div>static</div>
+    </temba-tab>
+    <temba-tab name="Fields" icon="fields" splitWidth="300">
+      <div>fields</div>
+    </temba-tab>
+  </temba-tabs>
+`;
+
+const BASIC_TABS = `
+  <temba-tabs>
+    <temba-tab name="First" icon="message">
+      <div>first</div>
+    </temba-tab>
+    <temba-tab name="Second" icon="info">
+      <div>second</div>
+    </temba-tab>
+  </temba-tabs>
+`;
+
+// let layout, the resize observer and the grow delay settle, then re-render
+const settle = async (tabs: TabPane) => {
+  await tabs.updateComplete;
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  await tabs.updateComplete;
+};
+
+// wait for a condition that depends on the resize observer, which can be
+// slow to fire when the test machine is under load
+const until = async (tabs: TabPane, check: () => boolean) => {
+  const start = Date.now();
+  while (!check() && Date.now() - start < 2000) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  await tabs.updateComplete;
+};
+
+const getTabs = async (
+  width: number,
+  markup: string = SPLIT_TABS
+): Promise<TabPane> => {
+  const wrapper = (await fixture(
+    `<div style="width:${width}px;display:flex;">${markup}</div>`
+  )) as HTMLDivElement;
+  const tabs = wrapper.querySelector('temba-tabs') as TabPane;
+  await settle(tabs);
+  return tabs;
+};
+
+describe('temba-tabs', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders tabs and switches on click', async () => {
+    const tabs = await getTabs(500, BASIC_TABS);
+    assert.equal(tabs.options.length, 2);
+    assert.equal(tabs.index, 0);
+    assert.isTrue(tabs.getTab(0).selected);
+
+    const options = tabs.shadowRoot.querySelectorAll('.option');
+    (options[1] as HTMLElement).click();
+    await tabs.updateComplete;
+    assert.equal(tabs.index, 1);
+    assert.isTrue(tabs.getTab(1).selected);
+    assert.isFalse(tabs.getTab(0).selected);
+  });
+
+  it('does not split without room', async () => {
+    const tabs = await getTabs(800);
+    assert.equal(tabs.splitTabs.length, 0);
+    assert.isFalse(tabs.isSplitActive());
+    assert.isNull(tabs.shadowRoot.querySelector('.option.merged'));
+
+    // the anchor is uncapped so we never show empty space
+    assert.equal(tabs.getTab(0).style.width, '');
+  });
+
+  it('pulls the next tab into a split view when it fits', async () => {
+    const tabs = await getTabs(1000);
+    assert.equal(tabs.splitTabs.length, 2);
+    assert.isTrue(tabs.isSplitActive());
+
+    const chat = tabs.getTab(0);
+    const details = tabs.getTab(1);
+    assert.isTrue(chat.split);
+    assert.isTrue(details.split);
+    assert.isFalse(tabs.getTab(2).split);
+
+    // the anchor is capped and the last pane fills the rest
+    assert.equal(chat.style.width, '600px');
+    assert.equal(details.style.flexGrow, '1');
+
+    // merged tabs render as a single option with segments
+    const merged = tabs.shadowRoot.querySelector('.option.merged');
+    assert.isNotNull(merged);
+    assert.equal(merged.querySelectorAll('.segment').length, 2);
+    assert.isTrue(merged.classList.contains('selected'));
+
+    // the non-merged tabs are still their own options
+    assert.equal(
+      tabs.shadowRoot.querySelectorAll('.option:not(.merged)').length,
+      2
+    );
+  });
+
+  it('splits additional tabs in order as the width grows', async () => {
+    const tabs = await getTabs(1300);
+    assert.equal(tabs.splitTabs.length, 3);
+
+    // notes doesn't declare a split width so it stays a tab
+    assert.isFalse(tabs.getTab(3).split);
+
+    // middle pane uses its minimum width, last pane flexes
+    assert.equal(tabs.getTab(1).style.width, '300px');
+    assert.equal(tabs.getTab(2).style.flexGrow, '1');
+
+    // one resizer between the two secondary panes, none next to the anchor
+    assert.equal(tabs.shadowRoot.querySelectorAll('.resizer').length, 1);
+  });
+
+  it('shows pane headers for pulled down tabs', async () => {
+    const tabs = await getTabs(1300);
+    assert.equal(tabs.splitTabs.length, 3);
+    await tabs.getTab(1).updateComplete;
+
+    // the anchor doesn't get a header or card treatment, pulled panes do
+    assert.isNull(tabs.getTab(0).shadowRoot.querySelector('.header'));
+    assert.isFalse(tabs.getTab(0).classList.contains('pane-card'));
+    assert.isTrue(tabs.getTab(1).classList.contains('pane-card'));
+    assert.isTrue(tabs.getTab(2).classList.contains('pane-card'));
+    assert.include(
+      tabs.getTab(1).shadowRoot.querySelector('.header .name').textContent,
+      'Details'
+    );
+    assert.include(
+      tabs.getTab(2).shadowRoot.querySelector('.header .name').textContent,
+      'Fields'
+    );
+  });
+
+  it('skips tabs that are not split enabled', async () => {
+    const tabs = await getTabs(1300, SKIP_TABS);
+
+    // static has no split width, so chat merges with details and fields
+    assert.equal(tabs.splitTabs.length, 3);
+    assert.deepEqual(
+      tabs.splitTabs.map((tab) => tab.name),
+      ['Chat', 'Details', 'Fields']
+    );
+    assert.isFalse(tabs.getTab(2).split);
+
+    // static remains its own option next to the merged one
+    assert.equal(tabs.shadowRoot.querySelectorAll('.option').length, 2);
+  });
+
+  it('waits for the width to settle before adding panes', async () => {
+    const wrapper = (await fixture(
+      `<div style="width:1300px;display:flex;">${SPLIT_TABS}</div>`
+    )) as HTMLDivElement;
+    const tabs = wrapper.querySelector('temba-tabs') as TabPane;
+    await tabs.updateComplete;
+
+    // shortly after load we haven't split yet, we're waiting for the
+    // layout to settle
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(tabs.splitTabs.length, 0);
+
+    // a late layout shift (like the nav menu arriving) shrinks us before
+    // the grow delay elapses, so the extra pane never flashes in
+    wrapper.style.width = '1000px';
+    await until(tabs, () => tabs.splitTabs.length === 2);
+    assert.equal(tabs.splitTabs.length, 2);
+  });
+
+  it('pops tabs back out when the width shrinks', async () => {
+    const tabs = await getTabs(1300);
+    assert.equal(tabs.splitTabs.length, 3);
+
+    const wrapper = tabs.parentElement;
+    wrapper.style.width = '1000px';
+    await until(tabs, () => tabs.splitTabs.length === 2);
+    assert.equal(tabs.splitTabs.length, 2);
+    assert.isFalse(tabs.getTab(2).split);
+
+    wrapper.style.width = '700px';
+    await until(tabs, () => tabs.splitTabs.length === 0);
+    assert.equal(tabs.splitTabs.length, 0);
+    assert.isFalse(tabs.getTab(0).split);
+    assert.equal(tabs.getTab(0).style.width, '');
+    assert.isNull(tabs.shadowRoot.querySelector('.option.merged'));
+  });
+
+  it('shows other tabs alone while the merged view is not selected', async () => {
+    const tabs = await getTabs(1000);
+    assert.isTrue(tabs.isSplitActive());
+
+    tabs.index = 3;
+    await settle(tabs);
+    assert.isFalse(tabs.isSplitActive());
+    assert.isFalse(tabs.getTab(0).split);
+    assert.isTrue(tabs.getTab(3).selected);
+
+    // the merged option is still there, just not selected
+    const merged = tabs.shadowRoot.querySelector('.option.merged');
+    assert.isNotNull(merged);
+    assert.isFalse(merged.classList.contains('selected'));
+
+    // clicking it brings the split view back
+    (merged as HTMLElement).click();
+    await settle(tabs);
+    assert.equal(tabs.index, 0);
+    assert.isTrue(tabs.isSplitActive());
+  });
+
+  it('resizes middle panes with the resizer and remembers the width', async () => {
+    const tabs = await getTabs(1300);
+    const details = tabs.getTab(1);
+    assert.equal(details.style.width, '300px');
+
+    const resizer = tabs.shadowRoot.querySelector('.resizer') as HTMLElement;
+    resizer.dispatchEvent(
+      new MouseEvent('mousedown', { bubbles: true, clientX: 0 })
+    );
+    assert.isTrue(tabs.dragging);
+
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: 50 }));
+    assert.equal(details.style.width, '350px');
+
+    const listener = oneEvent(tabs, CustomEventType.Resized, false);
+    window.dispatchEvent(new MouseEvent('mouseup', { clientX: 50 }));
+    const event = await listener;
+
+    assert.isFalse(tabs.dragging);
+    assert.equal(event.detail.width, 350);
+    assert.equal(window.localStorage.getItem('temba-tabs-split-info'), '350');
+  });
+
+  it('clamps resizer drags to the pane minimums', async () => {
+    const tabs = await getTabs(1300);
+    const details = tabs.getTab(1);
+
+    const resizer = tabs.shadowRoot.querySelector('.resizer') as HTMLElement;
+    resizer.dispatchEvent(
+      new MouseEvent('mousedown', { bubbles: true, clientX: 0 })
+    );
+
+    // can't shrink below our own minimum
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: -500 }));
+    assert.equal(details.style.width, '300px');
+
+    // can't grow past the last pane's minimum
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: 5000 }));
+    const width = parseInt(details.style.width);
+    const fields = tabs.getTab(2) as Tab;
+    assert.isAtLeast(fields.offsetWidth, 299);
+    window.dispatchEvent(new MouseEvent('mouseup', { clientX: 5000 }));
+    assert.isBelow(width, 5000);
+  });
+
+  it('restores remembered widths, clamped to the available space', async () => {
+    window.localStorage.setItem('temba-tabs-split-info', '450');
+    let tabs = await getTabs(1450);
+    assert.equal(tabs.getTab(1).style.width, '450px');
+
+    // a remembered width that no longer fits is clamped so the last
+    // pane keeps its minimum
+    window.localStorage.setItem('temba-tabs-split-info', '10000');
+    tabs = await getTabs(1300);
+    assert.equal(tabs.getTab(1).style.width, '370px');
+  });
+
+  it('skips hidden tabs when merging', async () => {
+    const tabs = await getTabs(1300);
+    tabs.setTabDetails(1, { count: 0, hidden: true });
+    await settle(tabs);
+
+    // details is hidden so chat merges directly with fields
+    assert.equal(tabs.splitTabs.length, 2);
+    assert.isFalse(tabs.getTab(1).split);
+    assert.isTrue(tabs.getTab(2).split);
+  });
+
+  it('reorders tabs by dragging and remembers the order', async () => {
+    const tabs = await getTabs(1000);
+    assert.equal(tabs.splitTabs[1].name, 'Details');
+
+    // drag the fields option to the left of the merged option
+    const fields = tabs.shadowRoot.querySelector(
+      '.option[data-index="2"]'
+    ) as HTMLElement;
+    const merged = tabs.shadowRoot.querySelector(
+      '.option.merged'
+    ) as HTMLElement;
+    const fieldsBox = fields.getBoundingClientRect();
+    const mergedBox = merged.getBoundingClientRect();
+
+    fields.dispatchEvent(
+      new MouseEvent('mousedown', {
+        bubbles: true,
+        clientX: fieldsBox.left + 10,
+        clientY: fieldsBox.top + 5
+      })
+    );
+    window.dispatchEvent(
+      new MouseEvent('mousemove', {
+        clientX: mergedBox.left + 2,
+        clientY: mergedBox.top + 5
+      })
+    );
+    assert.isTrue(tabs.orderDragging);
+    window.dispatchEvent(
+      new MouseEvent('mouseup', {
+        clientX: mergedBox.left + 2,
+        clientY: mergedBox.top + 5
+      })
+    );
+    await settle(tabs);
+
+    // fields is now the first tab pulled into the split view
+    assert.isFalse(tabs.orderDragging);
+    assert.equal(tabs.splitTabs[1].name, 'Fields');
+    assert.equal(tabs.index, 0);
+    assert.equal(
+      window.localStorage.getItem('temba-tabs-order'),
+      '["fields","info","notes"]'
+    );
+  });
+
+  it('ignores stored ordering when not orderable', async () => {
+    // an order saved from another view must not leak into tab panes that
+    // don't allow reordering
+    window.localStorage.setItem(
+      'temba-tabs-order',
+      JSON.stringify(['fields', 'info', 'notes'])
+    );
+    const tabs = await getTabs(1000, SKIP_TABS);
+    assert.equal(tabs.getDisplayOrder()[0].name, 'Chat');
+    assert.equal(tabs.getDisplayOrder()[1].name, 'Details');
+    assert.equal(tabs.splitTabs[1].name, 'Details');
+  });
+
+  it('reorders merged panes by dragging their segments', async () => {
+    const tabs = await getTabs(1300);
+    assert.deepEqual(
+      tabs.splitTabs.map((tab) => tab.name),
+      ['Chat', 'Details', 'Fields']
+    );
+
+    // drag the details segment past the fields segment
+    const segments = tabs.shadowRoot.querySelectorAll(
+      '.option.merged .segment'
+    );
+    const details = segments[1] as HTMLElement;
+    const fields = segments[2] as HTMLElement;
+    const detailsBox = details.getBoundingClientRect();
+    const fieldsBox = fields.getBoundingClientRect();
+
+    details.dispatchEvent(
+      new MouseEvent('mousedown', {
+        bubbles: true,
+        clientX: detailsBox.left + 10,
+        clientY: detailsBox.top + 5
+      })
+    );
+    window.dispatchEvent(
+      new MouseEvent('mousemove', {
+        clientX: fieldsBox.right - 2,
+        clientY: fieldsBox.top + 5
+      })
+    );
+    window.dispatchEvent(
+      new MouseEvent('mouseup', {
+        clientX: fieldsBox.right - 2,
+        clientY: fieldsBox.top + 5
+      })
+    );
+    await settle(tabs);
+
+    assert.deepEqual(
+      tabs.splitTabs.map((tab) => tab.name),
+      ['Chat', 'Fields', 'Details']
+    );
+    assert.equal(
+      window.localStorage.getItem('temba-tabs-order'),
+      '["fields","info","notes"]'
+    );
+  });
+
+  it('reorders panes by dragging their title bars', async () => {
+    const tabs = await getTabs(1300);
+    assert.deepEqual(
+      tabs.splitTabs.map((tab) => tab.name),
+      ['Chat', 'Details', 'Fields']
+    );
+
+    const details = tabs.getTab(1);
+    await details.updateComplete;
+    const header = details.shadowRoot.querySelector('.header') as HTMLElement;
+    assert.isTrue(header.classList.contains('grab'));
+
+    const headerBox = header.getBoundingClientRect();
+    const fieldsBox = tabs.getTab(2).getBoundingClientRect();
+
+    header.dispatchEvent(
+      new MouseEvent('mousedown', {
+        bubbles: true,
+        composed: true,
+        clientX: headerBox.left + 20,
+        clientY: headerBox.top + 5
+      })
+    );
+
+    // a small move starts the drag, lifting the card at its position
+    window.dispatchEvent(
+      new MouseEvent('mousemove', {
+        clientX: headerBox.left + 40,
+        clientY: headerBox.top + 5
+      })
+    );
+
+    // then drag until the card itself crosses the fields pane midpoint,
+    // the whole card follows while a placeholder holds its slot and the
+    // panes reorder live
+    window.dispatchEvent(
+      new MouseEvent('mousemove', {
+        clientX: fieldsBox.right - 10,
+        clientY: headerBox.top + 5
+      })
+    );
+    assert.equal(details.style.position, 'fixed');
+    const placeholder = tabs.shadowRoot.querySelector(
+      '.drop-placeholder'
+    ) as HTMLElement;
+    assert.isNotNull(placeholder);
+    assert.deepEqual(
+      tabs.splitTabs.map((tab) => tab.name),
+      ['Chat', 'Fields', 'Details']
+    );
+
+    // the placeholder holds the dragged card's slot, after fields
+    assert.equal(placeholder.style.order, '4');
+
+    window.dispatchEvent(
+      new MouseEvent('mouseup', {
+        clientX: fieldsBox.right - 10,
+        clientY: headerBox.top + 5
+      })
+    );
+    await settle(tabs);
+    assert.equal(details.style.position, '');
+    assert.isNull(tabs.shadowRoot.querySelector('.drop-placeholder'));
+    assert.equal(
+      window.localStorage.getItem('temba-tabs-order'),
+      '["fields","info","notes"]'
+    );
+  });
+
+  it('never lets pane content clip or scroll horizontally', async () => {
+    const tabs = await getTabs(
+      1000,
+      `
+      <temba-tabs>
+        <temba-tab name="Chat" icon="message" maxWidth="600" pinned>
+          <div>chat</div>
+        </temba-tab>
+        <temba-tab name="Details" icon="info" splitWidth="300">
+          <div class="long">${'x'.repeat(600)}</div>
+          <div class="wide" style="width:800px">wide</div>
+        </temba-tab>
+      </temba-tabs>
+    `
+    );
+    assert.equal(tabs.splitTabs.length, 2);
+    const details = tabs.getTab(1);
+    const paneWidth = details.getBoundingClientRect().width;
+
+    // an unbreakable string wraps instead of overflowing
+    const long = details.querySelector('.long') as HTMLElement;
+    assert.isAtMost(long.scrollWidth, long.clientWidth + 1);
+    assert.isAbove(long.getBoundingClientRect().height, 30);
+
+    // an explicitly wide child is clamped to the pane
+    const wide = details.querySelector('.wide') as HTMLElement;
+    assert.isAtMost(wide.getBoundingClientRect().width, paneWidth + 1);
+  });
+
+  it('restores a remembered tab order', async () => {
+    window.localStorage.setItem(
+      'temba-tabs-order',
+      JSON.stringify(['fields', 'info', 'notes'])
+    );
+    const tabs = await getTabs(1000);
+
+    // fields ranks first so it gets pulled down instead of details
+    assert.equal(tabs.splitTabs.length, 2);
+    assert.equal(tabs.splitTabs[1].name, 'Fields');
+
+    // the pinned chat tab is unaffected by ordering
+    assert.equal(tabs.getDisplayOrder()[0].name, 'Chat');
+  });
+});

--- a/xliff/es.xlf
+++ b/xliff/es.xlf
@@ -21,6 +21,12 @@
 <trans-unit id="sbc913d7dc0f33877">
   <source>to add</source>
 </trans-unit>
+<trans-unit id="sea4f08110bb8f15d">
+  <source>Remove</source>
+</trans-unit>
+<trans-unit id="s81f17cfc89a04338">
+  <source>Interrupt flow</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/xliff/fr.xlf
+++ b/xliff/fr.xlf
@@ -20,6 +20,12 @@
 <trans-unit id="sbc913d7dc0f33877">
   <source>to add</source>
 </trans-unit>
+<trans-unit id="sea4f08110bb8f15d">
+  <source>Remove</source>
+</trans-unit>
+<trans-unit id="s81f17cfc89a04338">
+  <source>Interrupt flow</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/xliff/pt.xlf
+++ b/xliff/pt.xlf
@@ -20,6 +20,12 @@
 <trans-unit id="sbc913d7dc0f33877">
   <source>to add</source>
 </trans-unit>
+<trans-unit id="sea4f08110bb8f15d">
+  <source>Remove</source>
+</trans-unit>
+<trans-unit id="s81f17cfc89a04338">
+  <source>Interrupt flow</source>
+</trans-unit>
 </body>
 </file>
 </xliff>


### PR DESCRIPTION
When a tab pane is wide enough, tabs can now be pulled out of the strip and shown side by side as a merged split view. This is all generic tab functionality driven by attributes.

## Splitting

* A first tab with \`maxWidth\` anchors the view and is capped at that width — the cap is only enforced when at least one more pane fits, so there is never empty space to the right of the anchor.
* Any tab with \`splitWidth\` is a candidate to be pulled down, in display order, as long as it fits. Tabs without one stay in the strip and don't block later candidates.
* Merged tabs render as a single joined option in the strip with a segment per tab. Selecting a non-merged tab shows it alone; clicking the merged option brings the split view back.
* Narrowing the window pops panes back into the strip. Removals are immediate, but additions wait for the width to be stable for 200ms so late-loading layout (nav menu, fonts) can't make a pane flash in and pop back out.

## Panes

* Pulled panes render as cards (surface, border, radius, shadow) with their title bar inside the card. Colors are themeable per tab via \`--tab-card-bg\` / \`--tab-card-border\`. The card border is applied inline since page-level resets (e.g. tailwind preflight) override \`:host\` borders.
* Middle panes are resizable with a grab bar and their widths are remembered in localStorage. The last pane fills the remaining space.
* Pane content can never clip or scroll horizontally: children are clamped to the pane width and long unbreakable strings wrap.

## Reordering

* With \`orderable\` set, tabs can be reordered by dragging strip options, merged segments, or the pane title bars. Pane drags float the real card under the cursor with a dashed placeholder marking the drop slot, and the drop position tracks the card's own edges rather than the cursor. Order persists in localStorage and only applies to orderable tab panes.
* \`pinned\` tabs (e.g. a chat anchor) keep their position and can't be moved.

## Related fixes

* The datepicker's timezone box now fills its row when it wraps in narrow layouts.
* \`temba-menu\` reserves its footprint while loading (using its remembered width when available) so pages don't reflow when it arrives.