### PR TITLE
Match action and node type names in flow search

### DIFF
--- a/src/flow/FlowSearch.ts
+++ b/src/flow/FlowSearch.ts
@@ -316,6 +316,29 @@ function getTypeName(
 }
 
 /**
+ * Build the display fields for a result that matched on its type name
+ * (e.g. "email" matching a "Send Email" action). Shows the first content
+ * text as an unhighlighted preview when available, otherwise highlights
+ * the match within the type name itself. Returns null if the type name
+ * doesn't match the query.
+ */
+function makeTypeNameResult(
+  typeName: string,
+  query: string,
+  contentTexts: string[]
+): Pick<SearchResult, 'fullText' | 'matchStart' | 'matchLength'> | null {
+  const idx = typeName.toLowerCase().indexOf(query);
+  if (idx === -1) {
+    return null;
+  }
+  const preview = contentTexts.find((t) => t.trim());
+  if (preview) {
+    return { fullText: preview, matchStart: 0, matchLength: 0 };
+  }
+  return { fullText: typeName, matchStart: idx, matchLength: query.length };
+}
+
+/**
  * Get the localized name for a category, falling back to the original name.
  */
 function localizeCategoryName(
@@ -640,11 +663,13 @@ export class FlowSearch extends LitElement {
         if (node.actions) {
           for (const action of node.actions) {
             const actionConfig = ACTION_CONFIG[action.type];
+            const typeName = getTypeName(actionConfig, undefined);
             const searchAction = localizeAction(
               action,
               langLocalization?.[action.uuid]
             );
             const texts = getActionSearchTexts(searchAction);
+            let matched = false;
             for (const text of texts) {
               const lowerText = text.toLowerCase();
               const idx = lowerText.indexOf(query);
@@ -652,13 +677,29 @@ export class FlowSearch extends LitElement {
                 results.push({
                   nodeUuid: node.uuid,
                   action,
-                  typeName: getTypeName(actionConfig, undefined),
+                  typeName,
                   color: getColor(actionConfig, undefined),
                   fullText: text,
                   matchStart: idx,
                   matchLength: query.length
                 });
+                matched = true;
                 break; // One match per action is enough
+              }
+            }
+
+            // Fall back to matching the action type name (e.g. "email"
+            // matches all "Send Email" actions)
+            if (!matched) {
+              const typeMatch = makeTypeNameResult(typeName, query, texts);
+              if (typeMatch) {
+                results.push({
+                  nodeUuid: node.uuid,
+                  action,
+                  typeName,
+                  color: getColor(actionConfig, undefined),
+                  ...typeMatch
+                });
               }
             }
           }
@@ -679,6 +720,8 @@ export class FlowSearch extends LitElement {
           }
         }
 
+        const typeName = getTypeName(undefined, nodeConfig);
+        let matched = false;
         for (const text of nodeTexts) {
           const lowerText = text.toLowerCase();
           const idx = lowerText.indexOf(query);
@@ -686,13 +729,29 @@ export class FlowSearch extends LitElement {
             results.push({
               nodeUuid: node.uuid,
               action: null,
-              typeName: getTypeName(undefined, nodeConfig),
+              typeName,
               color: getColor(undefined, nodeConfig),
               fullText: text,
               matchStart: idx,
               matchLength: query.length
             });
+            matched = true;
             break; // One match per node is enough
+          }
+        }
+
+        // Fall back to matching the node type name (e.g. "wait" matches
+        // all "Wait for Response" nodes)
+        if (!matched) {
+          const typeMatch = makeTypeNameResult(typeName, query, nodeTexts);
+          if (typeMatch) {
+            results.push({
+              nodeUuid: node.uuid,
+              action: null,
+              typeName,
+              color: getColor(undefined, nodeConfig),
+              ...typeMatch
+            });
           }
         }
       }
@@ -837,6 +896,11 @@ export class FlowSearch extends LitElement {
 
     // Replace newlines with spaces for single-line display
     const text = result.fullText.replace(/\n/g, ' ');
+
+    // Type-name matches show an unhighlighted content preview
+    if (matchLength === 0) {
+      return html`${text}`;
+    }
 
     // Show leading context before the match, then the match, then trailing.
     // CSS text-overflow:ellipsis clips the trailing text, so we keep the match

--- a/test/temba-flow-search.test.ts
+++ b/test/temba-flow-search.test.ts
@@ -1,0 +1,165 @@
+import { fixture, expect } from '@open-wc/testing';
+import { FlowSearch, SearchResult } from '../src/flow/FlowSearch';
+import { FlowDefinition } from '../src/store/flow-definition';
+
+if (!customElements.get('temba-flow-search')) {
+  customElements.define('temba-flow-search', FlowSearch);
+}
+
+const DEFINITION = {
+  language: 'eng',
+  nodes: [
+    {
+      uuid: 'node-email',
+      actions: [
+        {
+          type: 'send_email',
+          uuid: 'action-email',
+          subject: 'Weekly report',
+          body: 'The report is attached.',
+          addresses: ['ops@example.com']
+        }
+      ],
+      exits: []
+    },
+    {
+      uuid: 'node-msg',
+      actions: [
+        {
+          type: 'send_msg',
+          uuid: 'action-msg',
+          text: 'Check your email inbox'
+        }
+      ],
+      exits: []
+    },
+    {
+      uuid: 'node-wait',
+      router: {
+        type: 'switch',
+        operand: '@input.text',
+        categories: [],
+        cases: []
+      },
+      exits: []
+    }
+  ],
+  _ui: {
+    nodes: {
+      'node-email': { type: 'execute_actions', position: { left: 0, top: 0 } },
+      'node-msg': { type: 'execute_actions', position: { left: 0, top: 100 } },
+      'node-wait': {
+        type: 'wait_for_response',
+        position: { left: 0, top: 200 }
+      }
+    },
+    stickies: {}
+  }
+} as unknown as FlowDefinition;
+
+const search = async (query: string): Promise<SearchResult[]> => {
+  const el = (await fixture(
+    '<temba-flow-search></temba-flow-search>'
+  )) as FlowSearch;
+  el.definition = DEFINITION;
+  el.show();
+  await el.updateComplete;
+
+  const input = el.shadowRoot.querySelector('input') as HTMLInputElement;
+  input.value = query;
+  input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+  await el.updateComplete;
+
+  return (el as any).results as SearchResult[];
+};
+
+describe('temba-flow-search', () => {
+  it('matches action content text', async () => {
+    const results = await search('attached');
+    expect(results.length).to.equal(1);
+    expect(results[0].nodeUuid).to.equal('node-email');
+    expect(results[0].typeName).to.equal('Send Email');
+    expect(results[0].fullText).to.equal('The report is attached.');
+    expect(results[0].matchLength).to.equal('attached'.length);
+  });
+
+  it('matches action type names', async () => {
+    const results = await search('email');
+
+    // The send_msg action matches on content, the send_email action
+    // matches on its type name
+    expect(results.length).to.equal(2);
+
+    const typeMatch = results.find((r) => r.nodeUuid === 'node-email');
+    expect(typeMatch.typeName).to.equal('Send Email');
+    expect(typeMatch.action.uuid).to.equal('action-email');
+    // type-name matches preview the first content text without a highlight
+    expect(typeMatch.fullText).to.equal('Weekly report');
+    expect(typeMatch.matchLength).to.equal(0);
+
+    const contentMatch = results.find((r) => r.nodeUuid === 'node-msg');
+    expect(contentMatch.fullText).to.equal('Check your email inbox');
+    expect(contentMatch.matchLength).to.equal('email'.length);
+  });
+
+  it('does not duplicate results when both content and type match', async () => {
+    const results = await search('send');
+    // Both actions match on type name only ("Send Email", "Send Message")
+    expect(results.length).to.equal(2);
+    expect(results.every((r) => r.matchLength === 0)).to.equal(true);
+  });
+
+  it('matches node type names', async () => {
+    const results = await search('wait for');
+    expect(results.length).to.equal(1);
+    expect(results[0].nodeUuid).to.equal('node-wait');
+    expect(results[0].typeName).to.equal('Wait for Response');
+    expect(results[0].action).to.equal(null);
+    // type-name match previews the node's first content text (its operand)
+    expect(results[0].fullText).to.equal('@input.text');
+    expect(results[0].matchLength).to.equal(0);
+  });
+
+  it('highlights within the type name when there is no content preview', async () => {
+    const definition = {
+      language: 'eng',
+      nodes: [
+        {
+          uuid: 'node-random',
+          router: { type: 'random', categories: [], cases: [] },
+          exits: []
+        }
+      ],
+      _ui: {
+        nodes: {
+          'node-random': {
+            type: 'split_by_random',
+            position: { left: 0, top: 0 }
+          }
+        },
+        stickies: {}
+      }
+    } as unknown as FlowDefinition;
+
+    const el = (await fixture(
+      '<temba-flow-search></temba-flow-search>'
+    )) as FlowSearch;
+    el.definition = definition;
+    el.show();
+    await el.updateComplete;
+
+    const input = el.shadowRoot.querySelector('input') as HTMLInputElement;
+    input.value = 'random';
+    input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    await el.updateComplete;
+
+    const results = (el as any).results as SearchResult[];
+    expect(results.length).to.equal(1);
+    const typeName = results[0].typeName;
+    expect(results[0].fullText).to.equal(typeName);
+    expect(results[0].matchStart).to.equal(
+      typeName.toLowerCase().indexOf('random')
+    );
+    expect(results[0].matchLength).to.equal('random'.length);
+  });
+});


### PR DESCRIPTION
Flow search now matches on action and node type names in addition to content, so searching "email" surfaces every Send Email action, "wait" surfaces the wait nodes, etc.

- After searching an action's content texts, if nothing matched, the query is checked against the action's config name (e.g. "Send Email"). Content matches take priority, so an action never produces duplicate results.
- Split/wait nodes get the same fallback against their node config name (e.g. "Wait for Response").
- A type-name match shows the item's first content text as an unhighlighted preview — the badge already shows the matching type name, and the preview distinguishes multiple results of the same type. If there is no content text, the type name itself is shown with the match highlighted.
- Flow scope only; the message-table search is unchanged.

Adds tests for FlowSearch covering content matches, type-name matches for actions and nodes, deduplication, and the no-preview fallback.