### PR TITLE
Syntax highlight expressions in Next Up message events

### DIFF
--- a/src/live/ContactTimeline.ts
+++ b/src/live/ContactTimeline.ts
@@ -708,7 +708,11 @@ export class ContactTimeline extends EndpointMonitorElement {
     // message events display the message text; flow-bearing events show a
     // clickable flow pill linking to the flow (the "start" action is implied)
     const body = isMessage
-      ? html`<div class="title-text">${event.message}</div>`
+      ? html`<div class="title-text">
+          <temba-expression-highlight
+            >${event.message}</temba-expression-highlight
+          >
+        </div>`
       : event.flow
         ? html`<temba-label
             type="flow"

--- a/test/temba-contact-timeline.test.ts
+++ b/test/temba-contact-timeline.test.ts
@@ -127,6 +127,42 @@ describe(TAG, () => {
     expect(root.querySelectorAll('.dot.now').length).to.equal(1);
   });
 
+  it('syntax highlights expressions in message events', async () => {
+    await loadStore();
+    const events = await getEvents({
+      ...FIRST_PAGE,
+      future: [
+        {
+          type: 'campaign_event',
+          scheduled: '2024-06-10T12:00:00+00:00',
+          campaign: { uuid: 'camp-1', name: 'Onboarding' },
+          message:
+            'Time to refill @fields.patient_medications. Please reach out to your pharmacist.'
+        }
+      ]
+    });
+
+    // message text is rendered through the expression highlighter (past
+    // message events render the same way, so find the future one by text)
+    const highlight = Array.from(
+      events.shadowRoot.querySelectorAll(
+        '.title-text temba-expression-highlight'
+      )
+    ).find((ele) =>
+      ele.textContent.includes('@fields.patient_medications')
+    ) as any;
+    expect(highlight).to.not.equal(undefined);
+    expect(highlight.textContent.trim()).to.equal(
+      'Time to refill @fields.patient_medications. Please reach out to your pharmacist.'
+    );
+
+    // and the expression inside it is tokenized
+    await highlight.updateComplete;
+    const identifier = highlight.shadowRoot.querySelector('.tok-id');
+    expect(identifier).to.not.equal(null);
+    expect(identifier.textContent).to.contain('fields.patient_medications');
+  });
+
   it('renders an empty state when there are no events', async () => {
     await loadStore();
     const events = await getEvents({


### PR DESCRIPTION
Message entries on the contact Next Up timeline can contain expressions (e.g. `@fields.patient_medications`), so render them through `temba-expression-highlight` instead of as plain text. This applies to projected campaign messages as well as scheduled and sent broadcasts, matching the expression styling used elsewhere.

Includes a test covering that message events tokenize and highlight their expressions.