### PR TITLE
Warn before dismissing dialogs with unsaved changes via escape

### DIFF
--- a/src/flow/NodeEditor.ts
+++ b/src/flow/NodeEditor.ts
@@ -20,6 +20,7 @@ import {
   SPLIT_GROUP_METADATA
 } from './types';
 import { CustomEventType } from '../interfaces';
+import { Dialog } from '../layout/Dialog';
 import { generateUUID } from '../utils';
 import {
   formatIssueMessage,
@@ -477,6 +478,11 @@ export class NodeEditor extends RapidElement {
   @state()
   private originalFormData: FormData = {};
 
+  // snapshot of getComparableFormData(), refreshed on any non-user mutation
+  // (init, async resolve) — the baseline for detecting unsaved edits when
+  // dismissing via escape
+  private pristineFormData = '';
+
   @state()
   private errors: { [key: string]: string } = {};
 
@@ -515,22 +521,75 @@ export class NodeEditor extends RapidElement {
   private issuesByAction!: Map<string, FlowIssue[]>;
 
   private boundHandleEscape = this.handleEscapeKey.bind(this);
+  private boundSwallowEscapeUp = this.swallowEscapeUp.bind(this);
 
   connectedCallback(): void {
     super.connectedCallback();
     this.initializeFormData();
     document.addEventListener('keydown', this.boundHandleEscape);
+    document.addEventListener('keyup', this.boundSwallowEscapeUp, true);
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
     document.removeEventListener('keydown', this.boundHandleEscape);
+    document.removeEventListener('keyup', this.boundSwallowEscapeUp, true);
   }
 
   private handleEscapeKey(event: KeyboardEvent): void {
     if (event.key === 'Escape' && this.isOpen) {
+      if (
+        this.hasUnsavedChanges() &&
+        !window.confirm(Dialog.UNSAVED_CHANGES_MESSAGE)
+      ) {
+        return;
+      }
       this.handleCancel();
     }
+  }
+
+  // temba-dialog handles escape itself on KEYUP reaching its container, which
+  // would prompt a second time after the keydown handler above has already
+  // asked (or dismiss unprompted if its keyup ever arrived first). While the
+  // editor is open, escape is owned entirely by the keydown handler, so stop
+  // escape keyups before the dialog sees them.
+  private swallowEscapeUp(event: KeyboardEvent): void {
+    if (event.key === 'Escape' && this.isOpen) {
+      event.stopPropagation();
+    }
+  }
+
+  private hasUnsavedChanges(): boolean {
+    return this.getComparableFormData() !== this.pristineFormData;
+  }
+
+  // JSON of formData with array-editor scaffolding filtered out: array editors
+  // seed a blank row (carrying field defaults, e.g. an attachment type) into
+  // form data on first render, which must not count as a user edit
+  private getComparableFormData(): string {
+    const form = this.getConfig()?.form;
+    const comparable = { ...this.formData };
+
+    if (form) {
+      Object.entries(form).forEach(([fieldName, fieldConfig]) => {
+        const value = comparable[fieldName];
+        if (fieldConfig.type === 'array' && Array.isArray(value)) {
+          // same emptiness semantics as ArrayEditor.isEmptyItem
+          const isEmpty =
+            fieldConfig.isEmptyItem ||
+            ((item: any) => {
+              const values = Object.values(item || {});
+              return (
+                values.length === 0 ||
+                values.every((v) => v === undefined || v === null || v === '')
+              );
+            });
+          comparable[fieldName] = value.filter((item: any) => !isEmpty(item));
+        }
+      });
+    }
+
+    return JSON.stringify(comparable);
   }
 
   willUpdate(changedProperties: PropertyValues): void {
@@ -719,6 +778,9 @@ export class NodeEditor extends RapidElement {
         this.formData[key] = { ...value };
       }
     });
+
+    // fresh form, so nothing to warn about discarding yet
+    this.pristineFormData = this.getComparableFormData();
   }
 
   private async resolveFormData(): Promise<void> {
@@ -748,6 +810,9 @@ export class NodeEditor extends RapidElement {
             }
           });
         }
+
+        // resolving isn't a user edit; rebase the unsaved-changes baseline
+        this.pristineFormData = this.getComparableFormData();
 
         this.requestUpdate();
       }
@@ -2690,6 +2755,7 @@ export class NodeEditor extends RapidElement {
         .open="${this.isOpen}"
         .originX=${this.dialogOrigin?.x ?? null}
         .originY=${this.dialogOrigin?.y ?? null}
+        .checkForChanges=${() => this.hasUnsavedChanges()}
         @temba-button-clicked=${this.handleDialogButtonClick}
         primaryButtonName="Save"
         cancelButtonName="Cancel"

--- a/src/flow/NodeEditor.ts
+++ b/src/flow/NodeEditor.ts
@@ -538,6 +538,24 @@ export class NodeEditor extends RapidElement {
 
   private handleEscapeKey(event: KeyboardEvent): void {
     if (event.key === 'Escape' && this.isOpen) {
+      const path = event.composedPath();
+
+      // an escape aimed at an open select dropdown just closes the dropdown
+      if (
+        path.some(
+          (el) =>
+            el instanceof Element &&
+            el.tagName === 'TEMBA-SELECT' &&
+            (el as any).isOpen?.()
+        )
+      ) {
+        return;
+      }
+
+      if (!this.ownsEscape(path)) {
+        return;
+      }
+
       if (
         this.hasUnsavedChanges() &&
         !window.confirm(Dialog.UNSAVED_CHANGES_MESSAGE)
@@ -548,13 +566,30 @@ export class NodeEditor extends RapidElement {
     }
   }
 
+  // an escape routed through a dialog other than our own (e.g. a nested
+  // dialog or modax opened from a field) belongs to that dialog; an escape
+  // with no dialog in its path (canvas or body focus) is ours to handle
+  private ownsEscape(path: EventTarget[]): boolean {
+    for (const el of path) {
+      if (el instanceof Element && el.tagName === 'TEMBA-DIALOG') {
+        return el === this.shadowRoot?.querySelector('temba-dialog');
+      }
+    }
+    return true;
+  }
+
   // temba-dialog handles escape itself on KEYUP reaching its container, which
   // would prompt a second time after the keydown handler above has already
   // asked (or dismiss unprompted if its keyup ever arrived first). While the
-  // editor is open, escape is owned entirely by the keydown handler, so stop
-  // escape keyups before the dialog sees them.
+  // editor is open, escape within our own dialog is owned entirely by the
+  // keydown handler, so stop those keyups before the dialog sees them —
+  // but leave escapes belonging to a dialog layered above us alone.
   private swallowEscapeUp(event: KeyboardEvent): void {
-    if (event.key === 'Escape' && this.isOpen) {
+    if (
+      event.key === 'Escape' &&
+      this.isOpen &&
+      this.ownsEscape(event.composedPath())
+    ) {
       event.stopPropagation();
     }
   }
@@ -787,8 +822,15 @@ export class NodeEditor extends RapidElement {
     const config = this.getConfig();
     if (!config?.resolveFormData) return;
 
+    const input = this.formData;
     try {
-      const resolved = await config.resolveFormData(this.formData);
+      const resolved = await config.resolveFormData(input);
+
+      // if the user edited while the resolve was in flight, applying the
+      // stale result would overwrite their edit — and rebasing the baseline
+      // below would then mask the loss as a clean form
+      if (this.formData !== input) return;
+
       if (resolved && resolved !== this.formData) {
         this.formData = resolved;
         this.processFormDataForEditing();

--- a/src/layout/Dialog.ts
+++ b/src/layout/Dialog.ts
@@ -292,11 +292,12 @@ export class Dialog extends ResizeElement {
   // the default signal that escape would discard the user's edits
   private contentEdited = false;
 
-  // whether the user has actually interacted (pointer or key) with the dialog
-  // since opening; components initializing their values fire synthetic change
-  // events while the content loads (e.g. selects with preset values), so
-  // edits only count once an interaction has happened
-  private contentInteracted = false;
+  // elements the user has actually interacted with (pointer or key) since the
+  // dialog opened; components fire synthetic change events on programmatic
+  // value changes (initialization of preset values, async option resolution),
+  // so an input/change only counts as an edit when it originates from an
+  // element the user has touched
+  private interactedElements = new WeakSet<EventTarget>();
 
   scrollOffset: any = 0;
 
@@ -342,7 +343,7 @@ export class Dialog extends ResizeElement {
 
     if (changes.has('open')) {
       this.contentEdited = false;
-      this.contentInteracted = false;
+      this.interactedElements = new WeakSet<EventTarget>();
       const body = document.querySelector('body');
 
       if (this.open) {
@@ -482,12 +483,17 @@ export class Dialog extends ResizeElement {
     return this.checkForChanges ? this.checkForChanges() : this.contentEdited;
   }
 
-  private handleContentInteraction() {
-    this.contentInteracted = true;
+  private handleContentInteraction(event: Event) {
+    // the path covers the interacted element and its ancestors, so a change
+    // fired later by a containing component (e.g. a select whose inner input
+    // was clicked) still matches
+    event.composedPath().forEach((el) => this.interactedElements.add(el));
   }
 
-  private handleContentEdited() {
-    if (this.contentInteracted) {
+  private handleContentEdited(event: Event) {
+    // only the originating element is checked (not its ancestors, which the
+    // paths of unrelated interactions also pass through)
+    if (this.interactedElements.has(event.composedPath()[0])) {
       this.contentEdited = true;
     }
   }

--- a/src/layout/Dialog.ts
+++ b/src/layout/Dialog.ts
@@ -20,6 +20,9 @@ export class DialogButton {
 }
 
 export class Dialog extends ResizeElement {
+  public static readonly UNSAVED_CHANGES_MESSAGE =
+    'You have unsaved changes. Are you sure you want to discard them?';
+
   static get widths(): { [size: string]: string } {
     return {
       small: '400px',
@@ -273,11 +276,27 @@ export class Dialog extends ResizeElement {
   @property({ attribute: false })
   onButtonClicked: (button: Button) => void;
 
+  // when set, consulted instead of the built-in edit tracking to decide
+  // whether escape should confirm before dismissing — for owners that can
+  // compare actual values (and so ignore edits that were reverted)
+  @property({ attribute: false })
+  checkForChanges?: () => boolean;
+
   @property({ type: Number })
   originX: number | null = null;
 
   @property({ type: Number })
   originY: number | null = null;
+
+  // whether any input/change has bubbled from our content since opening;
+  // the default signal that escape would discard the user's edits
+  private contentEdited = false;
+
+  // whether the user has actually interacted (pointer or key) with the dialog
+  // since opening; components initializing their values fire synthetic change
+  // events while the content loads (e.g. selects with preset values), so
+  // edits only count once an interaction has happened
+  private contentInteracted = false;
 
   scrollOffset: any = 0;
 
@@ -322,6 +341,8 @@ export class Dialog extends ResizeElement {
     super.updated(changes);
 
     if (changes.has('open')) {
+      this.contentEdited = false;
+      this.contentInteracted = false;
       const body = document.querySelector('body');
 
       if (this.open) {
@@ -457,8 +478,28 @@ export class Dialog extends ResizeElement {
     return this.shadowRoot.querySelector(`temba-button[primary]`);
   }
 
+  public hasUnsavedChanges(): boolean {
+    return this.checkForChanges ? this.checkForChanges() : this.contentEdited;
+  }
+
+  private handleContentInteraction() {
+    this.contentInteracted = true;
+  }
+
+  private handleContentEdited() {
+    if (this.contentInteracted) {
+      this.contentEdited = true;
+    }
+  }
+
   private handleKeyUp(event: KeyboardEvent) {
     if (event.key === 'Escape') {
+      if (
+        this.hasUnsavedChanges() &&
+        !window.confirm(Dialog.UNSAVED_CHANGES_MESSAGE)
+      ) {
+        return;
+      }
       this.clickCancel();
     }
   }
@@ -533,6 +574,10 @@ export class Dialog extends ResizeElement {
           }"></div>
           <div
             @keyup=${this.handleKeyUp}
+            @keydown=${this.handleContentInteraction}
+            @pointerdown=${this.handleContentInteraction}
+            @input=${this.handleContentEdited}
+            @change=${this.handleContentEdited}
             style=${styleMap(dialogStyle)}
             class="dialog-container"
           >

--- a/test/temba-dialog.test.ts
+++ b/test/temba-dialog.test.ts
@@ -129,4 +129,117 @@ describe('temba-dialog', () => {
     expect(primary.submitting).to.equal(true);
     expect(cancel.submitting).to.equal(false);
   });
+
+  describe('escape with unsaved changes', () => {
+    let confirmStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      confirmStub = sinon.stub(window, 'confirm');
+    });
+
+    afterEach(() => {
+      confirmStub.restore();
+    });
+
+    const pressEscape = (dialog: Dialog) => {
+      const container = dialog.shadowRoot.querySelector('.dialog-container');
+      container.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }));
+    };
+
+    const editContent = (dialog: Dialog) => {
+      const input = dialog.querySelector('input');
+      // edits only count after a user interaction with the dialog
+      input.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+
+    it('hides without confirming when content was not edited', async () => {
+      const dialog: Dialog = await fixture(getDialogHTML());
+      await open(dialog);
+
+      pressEscape(dialog);
+
+      expect(confirmStub.called).to.equal(false);
+      expect(dialog.open).to.equal(false);
+    });
+
+    it('ignores change events fired without user interaction', async () => {
+      const dialog: Dialog = await fixture(getDialogHTML());
+      await open(dialog);
+
+      // components initializing preset values fire change events on load;
+      // without a pointer or key interaction these must not count as edits
+      dialog
+        .querySelector('input')
+        .dispatchEvent(new Event('change', { bubbles: true }));
+      pressEscape(dialog);
+
+      expect(confirmStub.called).to.equal(false);
+      expect(dialog.open).to.equal(false);
+    });
+
+    it('stays open when content was edited and confirm is declined', async () => {
+      const dialog: Dialog = await fixture(getDialogHTML());
+      await open(dialog);
+      confirmStub.returns(false);
+
+      editContent(dialog);
+      pressEscape(dialog);
+
+      expect(confirmStub.calledOnce).to.equal(true);
+      expect(confirmStub.firstCall.args[0]).to.equal(
+        Dialog.UNSAVED_CHANGES_MESSAGE
+      );
+      expect(dialog.open).to.equal(true);
+    });
+
+    it('hides when content was edited and confirm is accepted', async () => {
+      const dialog: Dialog = await fixture(getDialogHTML());
+      await open(dialog);
+      confirmStub.returns(true);
+
+      editContent(dialog);
+      pressEscape(dialog);
+
+      expect(confirmStub.calledOnce).to.equal(true);
+      expect(dialog.open).to.equal(false);
+    });
+
+    it('resets edit tracking when reopened', async () => {
+      const dialog: Dialog = await fixture(getDialogHTML());
+      await open(dialog);
+
+      editContent(dialog);
+      await close(dialog);
+      await open(dialog);
+
+      pressEscape(dialog);
+
+      expect(confirmStub.called).to.equal(false);
+      expect(dialog.open).to.equal(false);
+    });
+
+    it('prefers checkForChanges over event tracking', async () => {
+      const dialog: Dialog = await fixture(getDialogHTML());
+      await open(dialog);
+
+      // owner says nothing changed, so edit events don't matter
+      dialog.checkForChanges = () => false;
+      editContent(dialog);
+      pressEscape(dialog);
+
+      expect(confirmStub.called).to.equal(false);
+      expect(dialog.open).to.equal(false);
+
+      await open(dialog);
+      confirmStub.returns(false);
+
+      // owner says there are changes even though no events fired
+      dialog.checkForChanges = () => true;
+      pressEscape(dialog);
+
+      expect(confirmStub.calledOnce).to.equal(true);
+      expect(dialog.open).to.equal(true);
+    });
+  });
 });

--- a/test/temba-dialog.test.ts
+++ b/test/temba-dialog.test.ts
@@ -178,6 +178,46 @@ describe('temba-dialog', () => {
       expect(dialog.open).to.equal(false);
     });
 
+    it('ignores change events from elements the user never touched', async () => {
+      const dialog: Dialog = await fixture(getDialogHTML());
+      await open(dialog);
+
+      // interact with the input, but a change arrives from a different
+      // element (e.g. an async select resolving preset values late)
+      const other = document.createElement('span');
+      dialog.appendChild(other);
+      dialog
+        .querySelector('input')
+        .dispatchEvent(new Event('pointerdown', { bubbles: true }));
+      other.dispatchEvent(new Event('change', { bubbles: true }));
+
+      pressEscape(dialog);
+
+      expect(confirmStub.called).to.equal(false);
+      expect(dialog.open).to.equal(false);
+    });
+
+    it('counts changes fired by a component containing the touched element', async () => {
+      const dialog: Dialog = await fixture(getDialogHTML());
+      await open(dialog);
+      confirmStub.returns(false);
+
+      // interaction lands on an inner element; the change is fired by its
+      // container (how temba components re-fire changes on their host)
+      const container = document.createElement('div');
+      const inner = document.createElement('span');
+      container.appendChild(inner);
+      dialog.appendChild(container);
+
+      inner.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+      container.dispatchEvent(new Event('change', { bubbles: true }));
+
+      pressEscape(dialog);
+
+      expect(confirmStub.calledOnce).to.equal(true);
+      expect(dialog.open).to.equal(true);
+    });
+
     it('stays open when content was edited and confirm is declined', async () => {
       const dialog: Dialog = await fixture(getDialogHTML());
       await open(dialog);

--- a/test/temba-node-editor.test.ts
+++ b/test/temba-node-editor.test.ts
@@ -1391,6 +1391,90 @@ describe('temba-node-editor', () => {
       expect(cancelled).to.equal(true);
     });
 
+    it('leaves escapes aimed at an open select dropdown alone', async () => {
+      const el = await openSendMsgEditor();
+      confirmStub.returns(false);
+
+      let cancelled = false;
+      el.addEventListener('temba-node-edit-cancelled', () => {
+        cancelled = true;
+      });
+
+      // escape whose path passes through a select with an open dropdown
+      // should only close the dropdown, not touch the editor
+      const select = document.createElement('temba-select') as any;
+      select.isOpen = () => true;
+      el.appendChild(select);
+      select.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          composed: true
+        })
+      );
+      await el.updateComplete;
+
+      expect(confirmStub.called).to.equal(false);
+      expect(cancelled).to.equal(false);
+    });
+
+    it('leaves escapes belonging to a nested dialog alone', async () => {
+      const el = await openSendMsgEditor();
+      confirmStub.returns(false);
+
+      let cancelled = false;
+      el.addEventListener('temba-node-edit-cancelled', () => {
+        cancelled = true;
+      });
+
+      // escape routed through a dialog other than the editor's own belongs
+      // to that dialog
+      const nested = document.createElement('temba-dialog');
+      const content = document.createElement('div');
+      nested.appendChild(content);
+      document.body.appendChild(nested);
+      try {
+        content.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'Escape',
+            bubbles: true,
+            composed: true
+          })
+        );
+        await el.updateComplete;
+
+        expect(confirmStub.called).to.equal(false);
+        expect(cancelled).to.equal(false);
+      } finally {
+        nested.remove();
+      }
+    });
+
+    it('does not apply a stale resolve over a concurrent edit', async () => {
+      const el = await openSendMsgEditor();
+
+      // a resolve that only completes after the user has edited
+      let release: () => void;
+      const gate = new Promise<void>((r) => (release = r));
+      const realConfig = (el as any).getConfig();
+      (el as any).getConfig = () => ({
+        ...realConfig,
+        resolveFormData: async (formData: any) => {
+          await gate;
+          return { ...formData, text: 'resolved late' };
+        }
+      });
+
+      const pending = (el as any).resolveFormData();
+      (el as any).formData = { ...(el as any).formData, text: 'user edit' };
+      release!();
+      await pending;
+
+      // the stale resolve must not overwrite the edit or rebase the baseline
+      expect((el as any).formData.text).to.equal('user edit');
+      expect((el as any).hasUnsavedChanges()).to.equal(true);
+    });
+
     it('stops escape keyups from reaching the dialog', async () => {
       const el = await openSendMsgEditor();
       confirmStub.returns(false);

--- a/test/temba-node-editor.test.ts
+++ b/test/temba-node-editor.test.ts
@@ -1,6 +1,8 @@
 import '../temba-modules';
 import { html, fixture, expect } from '@open-wc/testing';
+import * as sinon from 'sinon';
 import { assertScreenshot, getClip } from './utils.test';
+import { Dialog } from '../src/layout/Dialog';
 import { zustand } from '../src/store/AppState';
 
 // Define interface for NodeEditor component
@@ -1267,6 +1269,157 @@ describe('temba-node-editor', () => {
       ]);
       const el = await createNewWaitNode();
       expect((el as any).formData.result_name).to.equal('Result 4');
+    });
+  });
+
+  describe('escape with unsaved changes', () => {
+    let confirmStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      confirmStub = sinon.stub(window, 'confirm');
+    });
+
+    afterEach(() => {
+      confirmStub.restore();
+    });
+
+    const openSendMsgEditor = async () => {
+      const action = {
+        uuid: 'test-action-uuid',
+        type: 'send_msg',
+        text: 'Hello world',
+        quick_replies: []
+      };
+
+      const el = (await fixture(html`
+        <temba-node-editor
+          .action=${action}
+          .isOpen=${true}
+        ></temba-node-editor>
+      `)) as NodeEditorElement;
+
+      await el.updateComplete;
+      return el;
+    };
+
+    const pressEscape = () => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+    };
+
+    it('cancels without confirming when nothing was modified', async () => {
+      const el = await openSendMsgEditor();
+
+      let cancelled = false;
+      el.addEventListener('temba-node-edit-cancelled', () => {
+        cancelled = true;
+      });
+
+      pressEscape();
+      await el.updateComplete;
+
+      expect(confirmStub.called).to.equal(false);
+      expect(cancelled).to.equal(true);
+    });
+
+    it('keeps editing when the confirm is declined', async () => {
+      const el = await openSendMsgEditor();
+      confirmStub.returns(false);
+
+      let cancelled = false;
+      el.addEventListener('temba-node-edit-cancelled', () => {
+        cancelled = true;
+      });
+
+      (el as any).formData = { ...(el as any).formData, text: 'Changed text' };
+      await el.updateComplete;
+
+      pressEscape();
+      await el.updateComplete;
+
+      expect(confirmStub.calledOnce).to.equal(true);
+      expect(confirmStub.firstCall.args[0]).to.equal(
+        Dialog.UNSAVED_CHANGES_MESSAGE
+      );
+      expect(cancelled).to.equal(false);
+
+      // still dirty, so a second escape asks again
+      pressEscape();
+      await el.updateComplete;
+      expect(confirmStub.calledTwice).to.equal(true);
+      expect(cancelled).to.equal(false);
+    });
+
+    it('discards changes when the confirm is accepted', async () => {
+      const el = await openSendMsgEditor();
+      confirmStub.returns(true);
+
+      let cancelled = false;
+      el.addEventListener('temba-node-edit-cancelled', () => {
+        cancelled = true;
+      });
+
+      (el as any).formData = { ...(el as any).formData, text: 'Changed text' };
+      await el.updateComplete;
+
+      pressEscape();
+      await el.updateComplete;
+
+      expect(confirmStub.calledOnce).to.equal(true);
+      expect(cancelled).to.equal(true);
+    });
+
+    it('does not confirm when reverted back to the original values', async () => {
+      const el = await openSendMsgEditor();
+
+      let cancelled = false;
+      el.addEventListener('temba-node-edit-cancelled', () => {
+        cancelled = true;
+      });
+
+      const original = (el as any).formData;
+      (el as any).formData = { ...original, text: 'Changed text' };
+      (el as any).formData = { ...original };
+      await el.updateComplete;
+
+      pressEscape();
+      await el.updateComplete;
+
+      // matches the original, so no warning
+      expect(confirmStub.called).to.equal(false);
+      expect(cancelled).to.equal(true);
+    });
+
+    it('stops escape keyups from reaching the dialog', async () => {
+      const el = await openSendMsgEditor();
+      confirmStub.returns(false);
+
+      let cancelled = false;
+      el.addEventListener('temba-node-edit-cancelled', () => {
+        cancelled = true;
+      });
+
+      (el as any).formData = { ...(el as any).formData, text: 'Changed text' };
+      await el.updateComplete;
+
+      // temba-dialog handles escape keyups from within itself, which would
+      // prompt a second time after the editor's keydown handler already has;
+      // the editor's capture listener must stop them
+      const form = el.shadowRoot!.querySelector('.node-editor-form');
+      form!.dispatchEvent(
+        new KeyboardEvent('keyup', {
+          key: 'Escape',
+          bubbles: true,
+          composed: true
+        })
+      );
+      await el.updateComplete;
+
+      expect(confirmStub.called).to.equal(false);
+      expect(cancelled).to.equal(false);
+      const dialog = el.shadowRoot!.querySelector('temba-dialog') as any;
+      expect(dialog.open).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Pressing escape on a dialog with unsaved changes now asks for confirmation (via the native browser confirm) before dismissing, instead of silently discarding the user's edits. This applies to all `temba-dialog` consumers generically, with precise value-based change detection in the flow editor's node dialog.

## Changes

**`src/layout/Dialog.ts`**
- Escape now checks for unsaved changes before dismissing; if there are any, the user must confirm (`Dialog.UNSAVED_CHANGES_MESSAGE`) first.
- Built-in change tracking: `input`/`change` events bubbling from dialog content mark it edited — but only when the event originates from an element the user has actually interacted with. Each `pointerdown`/`keydown`'s composed path is recorded in a `WeakSet`, and an `input`/`change` only counts when its originating element is in that set. This ignores synthetic change events from components initializing preset values (e.g. selects on the contact edit form) or resolving values asynchronously after an unrelated interaction, while still catching changes re-fired on a component host after the user touched its inner input. Tracking resets each time the dialog opens.
- New optional `checkForChanges: () => boolean` property lets owners supply exact change detection instead of the event heuristic.

**`src/flow/NodeEditor.ts`**
- Value-based unsaved-change detection: a pristine JSON snapshot of the form data is captured on open, rebased after async `resolveFormData` (not a user edit), and compared with array-editor scaffold rows filtered out (blank rows seeded on first render, e.g. send_msg runtime attachments). Edits reverted back to the original values dismiss without a prompt.
- `resolveFormData` guards against a race: if the user edits while a resolve is in flight, the stale result is discarded rather than overwriting the edit and rebasing the baseline over it (which would have masked the lost edit as a clean form).
- The document-level escape keydown handler applies the same confirm, scoped by composed path: escapes aimed at an open select dropdown just close the dropdown, and escapes routed through a dialog other than the editor's own (e.g. a nested dialog opened from a field) are left to that dialog. A capture-phase listener stops escape keyups the editor owns from reaching its dialog, so the dialog's own keyup handling can't prompt a second time.
- The editor's dialog wires `checkForChanges` to the value-based check.

## Behavior examples

| Scenario | Before | After |
|---|---|---|
| Edit a node dialog field, press escape | Dialog closes, edits lost | Confirm shown; decline keeps editing, accept discards |
| Open contact edit modal, press escape untouched | Closes | Closes (init-time synthetic change events don't count as edits) |
| Type in a modax form, press escape | Closes, input lost | Confirm shown |
| Edit then revert to original values, escape (node editor) | — | Closes without prompt |
| Escape with a select dropdown open (node editor) | Dropdown closed and editor cancelled | Only the dropdown closes |

## Review notes

Pre-PR review returned ready with low-severity notes only. A post-PR review round surfaced three real issues, all fixed in fc0e40ad:
- Document-level escape handlers fired for escapes aimed at overlays above the editor → now scoped by composed path.
- A `resolveFormData` race could overwrite a concurrent user edit and mask it as clean → stale resolves are now discarded.
- A single stray interaction armed edit tracking for the whole dialog session, so late programmatic mutations false-positived → tracking is now per-element.

## Test plan

- [x] Dialog tests: no prompt when untouched, prompt on edit (decline keeps open / accept closes), init-time synthetic changes ignored, changes from untouched elements ignored, container-fired changes counted, tracking resets on reopen, `checkForChanges` overrides event tracking
- [x] Node editor tests: clean escape cancels without prompt, decline/accept flows, revert-to-original dismisses silently, dropdown/nested-dialog escapes left alone, stale resolve discarded, escape keyups can't bypass the guard
- [x] Full suite passing (1914 tests)
- [x] Verified in the running app: flow editor node dialog, contact edit modal (untouched, typed, and select-only edits), Create Contact modax