### PR TITLE
Render placeholder for messages with no content

### DIFF
--- a/demo/data/contact-chat-history.json
+++ b/demo/data/contact-chat-history.json
@@ -2,6 +2,38 @@
   "next": null,
   "events": [
     {
+      "uuid": "019f1e71-4a20-7c15-9d42-8b1f6e2a9c04",
+      "type": "msg_received",
+      "created_on": "2026-07-01T16:09:29.000000+00:00",
+      "msg": {
+        "urn": "telegram:7856382063",
+        "channel": {
+          "uuid": "246dfb67-dfcb-475d-ae81-cb49357537c7",
+          "name": "Telegram ureportglobal"
+        },
+        "external_id": "123751",
+        "text": "This message was deleted"
+      },
+      "_deleted": {
+        "created_on": "2026-07-01T16:10:00.000000+00:00",
+        "by_contact": true
+      }
+    },
+    {
+      "uuid": "019f1e70-ed92-7861-8b57-93cf1a1f88b3",
+      "type": "msg_received",
+      "created_on": "2026-07-01T16:09:05.262559+00:00",
+      "msg": {
+        "urn": "telegram:7856382063",
+        "channel": {
+          "uuid": "246dfb67-dfcb-475d-ae81-cb49357537c7",
+          "name": "Telegram ureportglobal"
+        },
+        "external_id": "123750",
+        "text": ""
+      }
+    },
+    {
       "uuid": "019a0001-0001-7001-8001-000000000010",
       "type": "msg_created",
       "created_on": "2025-09-24T20:40:27.239439+00:00",

--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -351,13 +351,15 @@ export class Chat extends RapidElement {
         color: rgba(192, 24, 41, 0.6);
       }
 
-      .deleted .bubble {
+      .deleted .bubble,
+      .empty .bubble {
         background: #fff;
         color: #999;
         border: 1px solid #e0e0e0;
       }
 
-      .deleted .bubble .name {
+      .deleted .bubble .name,
+      .empty .bubble .name {
         color: #aaa;
       }
 
@@ -369,7 +371,8 @@ export class Chat extends RapidElement {
         font-size: 13px;
       }
 
-      .message-deleted {
+      .message-deleted,
+      .message-empty {
         font-style: italic;
         margin-bottom: 0;
         line-height: 1.2;
@@ -1325,13 +1328,20 @@ export class Chat extends RapidElement {
                   (statusClass === 'failed' || statusClass === 'errored'));
               const unsendableClass = hasError ? 'error' : '';
               const deletedClass = msgEvent._deleted ? 'deleted' : '';
+              const emptyClass =
+                !msgEvent._deleted &&
+                msgEvent.msg &&
+                !msgEvent.msg.text &&
+                (msgEvent.msg.attachments || []).length === 0
+                  ? 'empty'
+                  : '';
               const latestClass = index === msgIds.length - 1 ? 'latest' : '';
               const eventClass = msg._rendered ? 'is-event' : '';
               const noteClass = msg.type === 'ticket_note_added' ? 'note' : '';
               const matchClass =
                 this.highlightMessageUuid === msg.uuid ? 'search-match' : '';
               return html`<div
-                class="row message ${statusClass} ${unsendableClass} ${deletedClass} ${latestClass} ${eventClass} ${noteClass} ${matchClass}"
+                class="row message ${statusClass} ${unsendableClass} ${deletedClass} ${emptyClass} ${latestClass} ${eventClass} ${noteClass} ${matchClass}"
                 data-uuid=${msg.uuid || nothing}
               >
                 ${this.renderMessage(
@@ -1430,6 +1440,12 @@ export class Chat extends RapidElement {
         : message._deleted.user?.name || 'user'
       : null;
 
+    // messages with no text and no attachments get a muted placeholder
+    const isEmpty =
+      !isDeleted &&
+      !message.msg.text &&
+      (message.msg.attachments || []).length === 0;
+
     // check if message has location attachment and text is just coordinates
     const hasLocationAttachment = message.msg.attachments?.some((att) =>
       att.startsWith('geo:')
@@ -1480,12 +1496,17 @@ export class Chat extends RapidElement {
                 Message deleted by ${deletedByText}
               </div>
             </div>`
-          : message.msg.text && !textIsCoordinates
+          : isEmpty
             ? html`<div class="bubble">
                 ${name ? html`<div class="name">${name}</div>` : null}
-                <div class="message-text">${messageText}</div>
+                <div class="message-empty">Empty Message</div>
               </div>`
-            : null}
+            : message.msg.text && !textIsCoordinates
+              ? html`<div class="bubble">
+                  ${name ? html`<div class="name">${name}</div>` : null}
+                  <div class="message-text">${messageText}</div>
+                </div>`
+              : null}
 
         <div class="attachments">
           ${(message.msg.attachments || []).map(

--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -113,6 +113,13 @@ export interface MsgEvent extends ContactEvent {
   _logs_url?: string;
 }
 
+// whether a message has nothing to show in its bubble (and isn't deleted)
+const isEmptyMsg = (event: MsgEvent): boolean =>
+  !event._deleted &&
+  !!event.msg &&
+  !event.msg.text &&
+  (event.msg.attachments || []).length === 0;
+
 const TIME_FORMAT = { hour: 'numeric', minute: '2-digit' } as any;
 const VERBOSE_FORMAT = {
   weekday: undefined,
@@ -1328,13 +1335,7 @@ export class Chat extends RapidElement {
                   (statusClass === 'failed' || statusClass === 'errored'));
               const unsendableClass = hasError ? 'error' : '';
               const deletedClass = msgEvent._deleted ? 'deleted' : '';
-              const emptyClass =
-                !msgEvent._deleted &&
-                msgEvent.msg &&
-                !msgEvent.msg.text &&
-                (msgEvent.msg.attachments || []).length === 0
-                  ? 'empty'
-                  : '';
+              const emptyClass = isEmptyMsg(msgEvent) ? 'empty' : '';
               const latestClass = index === msgIds.length - 1 ? 'latest' : '';
               const eventClass = msg._rendered ? 'is-event' : '';
               const noteClass = msg.type === 'ticket_note_added' ? 'note' : '';
@@ -1441,10 +1442,7 @@ export class Chat extends RapidElement {
       : null;
 
     // messages with no text and no attachments get a muted placeholder
-    const isEmpty =
-      !isDeleted &&
-      !message.msg.text &&
-      (message.msg.attachments || []).length === 0;
+    const isEmpty = isEmptyMsg(message);
 
     // check if message has location attachment and text is just coordinates
     const hasLocationAttachment = message.msg.attachments?.some((att) =>


### PR DESCRIPTION
## Summary

Messages that arrive with no text and no attachments previously rendered as an avatar next to empty space in the chat history. They now get the same muted treatment as deleted messages, with an italic "Empty Message" placeholder in the bubble.

## Changes

**`src/display/Chat.ts`**
- Added a module-level `isEmptyMsg()` helper that decides whether a message has nothing to show in its bubble (not deleted, no text, no attachments), used by both the row class and the bubble rendering so the two can't drift apart.
- Empty messages render a bubble with an italic "Empty Message" placeholder instead of nothing.
- Added an `empty` row class that shares the deleted-message styling (white background, gray border, muted text and name color).

**`demo/data/contact-chat-history.json`**
- Added two events to the contact-chat demo data for manual testing: an empty incoming Telegram message and a contact-deleted message right after it, so both muted treatments can be compared side by side.

## Behavior

| Message state | Before | After |
|---|---|---|
| No text, no attachments | Avatar next to empty space | Muted bubble with italic "Empty Message" |
| Deleted | Muted bubble with "Message deleted by …" | Unchanged |
| Text or attachments | Normal bubble | Unchanged |

## Test plan

- [x] `temba-chat` and `temba-contact-chat` suites pass in the worktree container
- [x] Build and formatting clean
- [x] Verified in the local dev stack against real DynamoDB history events (empty and deleted messages render adjacently with the expected treatments)