### PR TITLE
Fetch contacts with expand_urns so URNs are resolved against channels

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -192,8 +192,8 @@ export interface ContactGroup {
 export interface URN {
   scheme: string;
   path: string;
-  display?: string;
-  channel?: ObjectReference;
+  display?: string | null;
+  channel?: ObjectReference | null;
 }
 
 export interface Group {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -192,6 +192,8 @@ export interface ContactGroup {
 export interface URN {
   scheme: string;
   path: string;
+  display?: string;
+  channel?: ObjectReference;
 }
 
 export interface Group {
@@ -224,7 +226,7 @@ export interface Contact {
   uuid: string;
   stopped: boolean;
   blocked: boolean;
-  urns: string[];
+  urns: URN[];
   language?: string;
   fields: { [key: string]: string };
   groups: Group[];

--- a/src/list/ContactList.ts
+++ b/src/list/ContactList.ts
@@ -284,7 +284,9 @@ export class ContactList extends ContentList<Contact> {
     if (i.urn) return i.urn;
     if (Array.isArray(i.urns) && i.urns.length > 0) {
       const u = i.urns[0];
-      return typeof u === 'string' ? u.split(':')[1] || u : u?.display || '';
+      return typeof u === 'string'
+        ? u.split(':')[1] || u
+        : u?.display || u?.path || '';
     }
     return '';
   }

--- a/src/live/ContactDetails.ts
+++ b/src/live/ContactDetails.ts
@@ -90,14 +90,13 @@ export class ContactDetails extends ContactStoreElement {
             </div>`
           : null}
         ${this.data.urns.map((urn) => {
-          const parts = urn.split(':');
-          let scheme = SCHEMES[parts[0]];
+          let scheme = SCHEMES[urn.scheme];
           if (!scheme) {
-            scheme = capitalize(parts[0] as any);
+            scheme = capitalize(urn.scheme as any);
           }
           return html`<temba-contact-field
             name=${scheme}
-            value=${parts[1]}
+            value=${urn.display || urn.path}
             disabled
           ></temba-contact-field>`;
         })}

--- a/src/live/ContactFields.ts
+++ b/src/live/ContactFields.ts
@@ -151,7 +151,7 @@ export class ContactFields extends ContactStoreElement {
     const value = field.value;
 
     // TODO: Use contact.postChanges instead of postJSON
-    postJSON('/api/v2/contacts.json?uuid=' + this.data.uuid, {
+    postJSON(this.endpoint + this.data.uuid, {
       fields: { [field.key]: value }
     })
       .then((response: any) => {

--- a/src/live/ContactNameFetch.ts
+++ b/src/live/ContactNameFetch.ts
@@ -1,6 +1,6 @@
 import { css, html, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
-import { ContactStoreElement } from './ContactStoreElement';
+import { ContactStoreElement, getDestinationURN } from './ContactStoreElement';
 
 export class ContactNameFetch extends ContactStoreElement {
   @property({ type: Number, attribute: 'icon-size' })
@@ -21,7 +21,9 @@ export class ContactNameFetch extends ContactStoreElement {
 
   public render(): TemplateResult {
     if (this.data) {
-      const urn = this.data.urns.length > 0 ? this.data.urns[0] : null;
+      // show the URN that will be used when messaging the contact, falling
+      // back to their highest priority URN if none are sendable
+      const urn = getDestinationURN(this.data) || this.data.urns[0] || null;
       return html` <temba-contact-name
           name=${this.data.name || this.data.ref}
           urn=${urn ? `${urn.scheme}:${urn.display || urn.path}` : null}

--- a/src/live/ContactNameFetch.ts
+++ b/src/live/ContactNameFetch.ts
@@ -21,9 +21,10 @@ export class ContactNameFetch extends ContactStoreElement {
 
   public render(): TemplateResult {
     if (this.data) {
+      const urn = this.data.urns.length > 0 ? this.data.urns[0] : null;
       return html` <temba-contact-name
           name=${this.data.name || this.data.ref}
-          urn=${this.data.urns.length > 0 ? this.data.urns[0] : null}
+          urn=${urn ? `${urn.scheme}:${urn.display || urn.path}` : null}
         ></temba-contact-name>
         <slot></slot>`;
     }

--- a/src/live/ContactStoreElement.ts
+++ b/src/live/ContactStoreElement.ts
@@ -7,7 +7,7 @@ import { EndpointMonitorElement } from '../store/EndpointMonitorElement';
  * Returns the URN that will be used to message the given contact — URNs are
  * ordered by priority and only ones with a channel are sendable.
  */
-export const getDestinationURN = (contact: Contact): URN => {
+export const getDestinationURN = (contact: Contact | null): URN | null => {
   return (contact?.urns || []).find((urn) => !!urn.channel) || null;
 };
 

--- a/src/live/ContactStoreElement.ts
+++ b/src/live/ContactStoreElement.ts
@@ -1,7 +1,15 @@
 import { PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
-import { Contact, Group } from '../interfaces';
+import { Contact, Group, URN } from '../interfaces';
 import { EndpointMonitorElement } from '../store/EndpointMonitorElement';
+
+/**
+ * Returns the URN that will be used to message the given contact — URNs are
+ * ordered by priority and only ones with a channel are sendable.
+ */
+export const getDestinationURN = (contact: Contact): URN => {
+  return (contact?.urns || []).find((urn) => !!urn.channel) || null;
+};
 
 export class ContactStoreElement extends EndpointMonitorElement {
   @property({ type: String })
@@ -10,8 +18,10 @@ export class ContactStoreElement extends EndpointMonitorElement {
   @property({ type: Object, attribute: false })
   data: Contact;
 
+  // expand_urns resolves each URN against a channel so we know which one
+  // will be used when messaging the contact
   @property({ type: String })
-  endpoint = '/api/v2/contacts.json?uuid=';
+  endpoint = '/api/v2/contacts.json?expand_urns=true&uuid=';
 
   prepareData(data: any) {
     if (data && data.length > 0) {

--- a/test-assets/contacts/contact-barack-archived
+++ b/test-assets/contacts/contact-barack-archived
@@ -8,7 +8,15 @@
       "status": "archived",
       "language": "fra",
       "urns": [
-        "telegram:25028613#bobama"
+        {
+          "channel": {
+            "uuid": "chan-2",
+            "name": "Telegram Channel"
+          },
+          "scheme": "telegram",
+          "path": "25028613",
+          "display": "bobama"
+        }
       ],
       "groups": [
         {

--- a/test-assets/contacts/contact-carter-active
+++ b/test-assets/contacts/contact-carter-active
@@ -8,12 +8,48 @@
       "status": "active",
       "language": "eng",
       "urns": [
-        "telegram:24028613#dmb4ever",
-        "facebook:123123",
-        "instagram:123232",
-        "line:12322",
-        "whatsapp:2342334422",
-        "tel:+12065553567"
+        {
+          "channel": {
+            "uuid": "chan-2",
+            "name": "Telegram Channel"
+          },
+          "scheme": "telegram",
+          "path": "24028613",
+          "display": "dmb4ever"
+        },
+        {
+          "channel": null,
+          "scheme": "facebook",
+          "path": "123123",
+          "display": null
+        },
+        {
+          "channel": null,
+          "scheme": "instagram",
+          "path": "123232",
+          "display": null
+        },
+        {
+          "channel": null,
+          "scheme": "line",
+          "path": "12322",
+          "display": null
+        },
+        {
+          "channel": null,
+          "scheme": "whatsapp",
+          "path": "2342334422",
+          "display": null
+        },
+        {
+          "channel": {
+            "uuid": "chan-3",
+            "name": "SMS Channel"
+          },
+          "scheme": "tel",
+          "path": "+12065553567",
+          "display": null
+        }
       ],
       "groups": [
         {

--- a/test-assets/contacts/contact-dave-active
+++ b/test-assets/contacts/contact-dave-active
@@ -8,12 +8,48 @@
       "status": "active",
       "language": "eng",
       "urns": [
-        "telegram:24028613#dmb4ever",
-        "facebook:123123",
-        "instagram:123232",
-        "line:12322",
-        "whatsapp:2342334422",
-        "tel:+12065553567"
+        {
+          "channel": {
+            "uuid": "chan-2",
+            "name": "Telegram Channel"
+          },
+          "scheme": "telegram",
+          "path": "24028613",
+          "display": "dmb4ever"
+        },
+        {
+          "channel": null,
+          "scheme": "facebook",
+          "path": "123123",
+          "display": null
+        },
+        {
+          "channel": null,
+          "scheme": "instagram",
+          "path": "123232",
+          "display": null
+        },
+        {
+          "channel": null,
+          "scheme": "line",
+          "path": "12322",
+          "display": null
+        },
+        {
+          "channel": null,
+          "scheme": "whatsapp",
+          "path": "2342334422",
+          "display": null
+        },
+        {
+          "channel": {
+            "uuid": "chan-3",
+            "name": "SMS Channel"
+          },
+          "scheme": "tel",
+          "path": "+12065553567",
+          "display": null
+        }
       ],
       "groups": [
         {

--- a/test-assets/contacts/contact-michelle-blocked
+++ b/test-assets/contacts/contact-michelle-blocked
@@ -8,7 +8,15 @@
       "status": "blocked",
       "language": "fra",
       "urns": [
-        "telegram:25028613#bobama"
+        {
+          "channel": {
+            "uuid": "chan-2",
+            "name": "Telegram Channel"
+          },
+          "scheme": "telegram",
+          "path": "25028613",
+          "display": "bobama"
+        }
       ],
       "groups": [
         {

--- a/test-assets/contacts/contact-tim-stopped
+++ b/test-assets/contacts/contact-tim-stopped
@@ -8,12 +8,48 @@
       "status": "stopped",
       "language": "eng",
       "urns": [
-        "telegram:24028613#dmb4ever",
-        "facebook:123123",
-        "instagram:123232",
-        "line:12322",
-        "whatsapp:2342334422",
-        "tel:+12065553567"
+        {
+          "channel": {
+            "uuid": "chan-2",
+            "name": "Telegram Channel"
+          },
+          "scheme": "telegram",
+          "path": "24028613",
+          "display": "dmb4ever"
+        },
+        {
+          "channel": null,
+          "scheme": "facebook",
+          "path": "123123",
+          "display": null
+        },
+        {
+          "channel": null,
+          "scheme": "instagram",
+          "path": "123232",
+          "display": null
+        },
+        {
+          "channel": null,
+          "scheme": "line",
+          "path": "12322",
+          "display": null
+        },
+        {
+          "channel": null,
+          "scheme": "whatsapp",
+          "path": "2342334422",
+          "display": null
+        },
+        {
+          "channel": {
+            "uuid": "chan-3",
+            "name": "SMS Channel"
+          },
+          "scheme": "tel",
+          "path": "+12065553567",
+          "display": null
+        }
       ],
       "groups": [
         {

--- a/test/get-destination-urn.test.ts
+++ b/test/get-destination-urn.test.ts
@@ -1,0 +1,43 @@
+import { expect } from '@open-wc/testing';
+import { Contact } from '../src/interfaces';
+import { getDestinationURN } from '../src/live/ContactStoreElement';
+
+const contactWithURNs = (urns: any[]): Contact => {
+  return { urns } as Contact;
+};
+
+describe('getDestinationURN', () => {
+  it('returns the first URN with a channel', () => {
+    const contact = contactWithURNs([
+      { scheme: 'facebook', path: '123123', display: null, channel: null },
+      {
+        scheme: 'telegram',
+        path: '24028613',
+        display: 'dmb4ever',
+        channel: { uuid: 'chan-2', name: 'Telegram Channel' }
+      },
+      {
+        scheme: 'tel',
+        path: '+12065553567',
+        display: null,
+        channel: { uuid: 'chan-3', name: 'SMS Channel' }
+      }
+    ]);
+
+    expect(getDestinationURN(contact).scheme).to.equal('telegram');
+  });
+
+  it('returns null if no URNs are sendable', () => {
+    const contact = contactWithURNs([
+      { scheme: 'facebook', path: '123123', display: null, channel: null }
+    ]);
+
+    expect(getDestinationURN(contact)).to.be.null;
+  });
+
+  it('returns null for missing contact or URNs', () => {
+    expect(getDestinationURN(null)).to.be.null;
+    expect(getDestinationURN({} as Contact)).to.be.null;
+    expect(getDestinationURN(contactWithURNs([]))).to.be.null;
+  });
+});

--- a/test/temba-contact-details.test.ts
+++ b/test/temba-contact-details.test.ts
@@ -18,7 +18,7 @@ const getContactDetails = async (attrs: any = {}) => {
 describe('temba-contact-tickets', () => {
   beforeEach(() => {
     mockGET(
-      /\/api\/v2\/contacts.json\?.*uuid=24d64810-3315-4ff5-be85-48e3fe055bf9/,
+      /\/api\/v2\/contacts.json\?expand_urns=true&uuid=24d64810-3315-4ff5-be85-48e3fe055bf9/,
       '/test-assets/contacts/contact-dave-active'
     );
   });

--- a/test/temba-contact-details.test.ts
+++ b/test/temba-contact-details.test.ts
@@ -18,7 +18,7 @@ const getContactDetails = async (attrs: any = {}) => {
 describe('temba-contact-tickets', () => {
   beforeEach(() => {
     mockGET(
-      /\/api\/v2\/contacts.json\?uuid=24d64810-3315-4ff5-be85-48e3fe055bf9/,
+      /\/api\/v2\/contacts.json\?.*uuid=24d64810-3315-4ff5-be85-48e3fe055bf9/,
       '/test-assets/contacts/contact-dave-active'
     );
   });

--- a/test/temba-contact-fields.test.ts
+++ b/test/temba-contact-fields.test.ts
@@ -40,7 +40,8 @@ describe(TAG, () => {
     data.groups.forEach((group) => {
       delete group['is_dynamic'];
     });
-    mockPOST(/api\/v2\/contacts\.json\?uuid=contact-dave-active/, data);
+    // field updates post to the same endpoint the contact was fetched from
+    mockPOST(/\/test-assets\/contacts\/contact-dave-active/, data);
 
     // update our fields
     await typeInto(


### PR DESCRIPTION
The contacts API endpoint supports an undocumented `expand_urns` param that returns each URN as an object resolved against a channel (`{scheme, path, display, channel}`) instead of a plain string, but the frontend never used it. Using it lets components know which of a contact's URNs will be used when messaging them — URNs come back in priority order and only sendable ones have a non-null `channel`, matching how sends are resolved.

## Changes

* `ContactStoreElement` (the shared fetcher behind the contact chat, details, fields, badges, notepad and name-fetch components) now fetches with `expand_urns=true`, and exports a `getDestinationURN(contact)` helper that returns the first URN with a channel — i.e. the one that will be used when chatting — or `null` if the contact isn't reachable.
* `Contact.urns` is now typed as `URN[]`, with `URN` gaining optional `display` and `channel` fields.
* Consumers updated for the object shape: `ContactDetails` renders `display || path` per URN instead of string-splitting, `ContactNameFetch` rebuilds the `scheme:path` string expected by `temba-contact-name`, and `ContactFields` posts field updates to the same endpoint the contact was fetched from so the response written back to the cache keeps the expanded format (write responses honor `expand_urns` as well).
* Test fixtures converted to the expanded format.

## Notes for review

* No UI changes yet — this is plumbing so components can start surfacing the destination URN/channel.
* `ContactList` fetches without `expand_urns` and already handled both URN shapes; it just gains a `path` fallback when `display` is unset.