### PR TITLE
Mobile nav and chat-first layout fixes

### DIFF
--- a/src/form/Compose.ts
+++ b/src/form/Compose.ts
@@ -406,11 +406,25 @@ export class Compose extends FieldElement {
     if (!this.hasAttribute('tabindex')) {
       this.setAttribute('tabindex', '-1');
     }
+    // both phases: capture claims a send-Enter before the rich editor's
+    // own keydown inserts a newline (which would flash before the send
+    // clears it); bubble keeps Enter-to-send working from anywhere else
+    // in the compose after inner widgets have had their shot at it
+    this.addEventListener(
+      'keydown',
+      this.handleHostKeyDown as EventListener,
+      true
+    );
     this.addEventListener('keydown', this.handleHostKeyDown as EventListener);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
+    this.removeEventListener(
+      'keydown',
+      this.handleHostKeyDown as EventListener,
+      true
+    );
     this.removeEventListener(
       'keydown',
       this.handleHostKeyDown as EventListener
@@ -453,6 +467,15 @@ export class Compose extends FieldElement {
         return;
       }
       const editor = this.getMessageEditor();
+      // during capture only editor presses are claimed — anything else
+      // (quick replies, attachments) waits for the bubble so the widget
+      // it targets keeps first claim on the event
+      if (
+        evt.eventPhase === Event.CAPTURING_PHASE &&
+        !(editor && evt.composedPath().includes(editor))
+      ) {
+        return;
+      }
       if (editor) {
         const richEdit = editor.getRichEditor();
         if (richEdit && richEdit.hasVisibleOptions()) {
@@ -460,7 +483,10 @@ export class Compose extends FieldElement {
         }
       }
       evt.preventDefault();
-      evt.stopPropagation();
+      // immediate: the handler is registered for both phases, and an
+      // at-target event would otherwise reach the second registration
+      // and send twice
+      evt.stopImmediatePropagation();
       this.triggerSend();
     }
   };

--- a/src/form/Compose.ts
+++ b/src/form/Compose.ts
@@ -463,6 +463,10 @@ export class Compose extends FieldElement {
     }
 
     if (evt.key === 'Enter' && !evt.shiftKey) {
+      // an Enter confirming an IME composition belongs to the editor
+      if (evt.isComposing || evt.keyCode === 229) {
+        return;
+      }
       if (this.showShortcuts) {
         return;
       }

--- a/src/layout/Card.ts
+++ b/src/layout/Card.ts
@@ -20,6 +20,12 @@ export class Card extends RapidElement {
         display: block;
       }
 
+      /* an empty panel drops its card entirely — in tab (plain) mode the
+         pane still renders so the tab keeps working */
+      :host([empty]:not([plain])) {
+        display: none;
+      }
+
       /* The chrome lives on an inner frame rather than the host so
          document-level universal rules (e.g. tailwind's preflight
          border-color) can't override it. */
@@ -130,6 +136,16 @@ export class Card extends RapidElement {
         padding: 0 10px 10px;
       }
 
+      /* card chrome bounds the panel tightly — slotted panels scale their
+         empty-state treatment down from the roomy tab-pane default to a
+         single quiet line */
+      :host(:not([plain])) .content ::slotted(*) {
+        --empty-padding: 1em;
+        --empty-extras-display: none;
+        --empty-title-size: 0.9em;
+        --empty-title-color: var(--text-3);
+      }
+
       /* bleed mode: the body content runs edge-to-edge so a panel with its
          own surface (e.g. the notepad) fills the card, clipped to the card
          radius. The footer of such content sits on the card's bottom edge. */
@@ -210,6 +226,12 @@ export class Card extends RapidElement {
   @property({ type: Boolean, reflect: true })
   bleed = false;
 
+  // the slotted panel reported (via temba-details-changed) that it has
+  // nothing to show — the card hides entirely in card mode, though its
+  // tab remains available in narrow mode
+  @property({ type: Boolean, reflect: true })
+  empty = false;
+
   // named surface treatments, e.g. "note" for the sticky-note look
   @property({ type: String, reflect: true })
   variant = '';
@@ -251,6 +273,9 @@ export class Card extends RapidElement {
     }
     if ('count' in event.detail) {
       this.count = event.detail.count;
+    }
+    if ('empty' in event.detail) {
+      this.empty = event.detail.empty;
     }
   }
 

--- a/src/layout/CardLayout.ts
+++ b/src/layout/CardLayout.ts
@@ -88,13 +88,13 @@ export class CardLayout extends RapidElement {
         /* the column soaks up whatever the main view doesn't take. Its
            scrollport runs the full height (the host supplies no vertical
            padding) so the scrollbar bleeds top to bottom, while the inner
-           padding aligns the first card with the main view and doubles as
-           room for card shadows. */
+           padding aligns the cards with the main view — including below,
+           so the last card scrolls to rest level with the bottom of the
+           main view — and doubles as room for card shadows. */
         flex: 1 0 var(--card-column-width, 360px);
         min-height: 0;
         overflow-y: auto;
         padding: var(--layout-spacing, 8px);
-        padding-bottom: 0;
       }
 
       temba-tabs {

--- a/src/layout/HeaderBar.ts
+++ b/src/layout/HeaderBar.ts
@@ -22,7 +22,10 @@ export class HeaderBar extends RapidElement {
         box-sizing: border-box;
         padding: 0 8px;
         background: var(--surface);
-        border-bottom: 1px solid var(--border);
+        /* the rule is a box-shadow, not a border — host pages (tailwind
+           preflight) reset border-width on every element, and outer-scope
+           element styles beat :host */
+        box-shadow: inset 0 -1px 0 0 var(--border);
       }
 
       ::slotted(*) {

--- a/src/list/TembaList.ts
+++ b/src/list/TembaList.ts
@@ -220,6 +220,14 @@ export class TembaList extends RapidElement {
     return this.selected;
   }
 
+  /** Deselects without firing a change — e.g. mobile going back to the
+   *  list, so the same row can be selected again. */
+  public clearSelection() {
+    this.cursorIndex = -1;
+    this.selected = null;
+    this.value = null;
+  }
+
   public refresh(): void {
     this.refreshKey = 'requested_' + new Date().getTime();
   }

--- a/src/list/TembaMenu.ts
+++ b/src/list/TembaMenu.ts
@@ -400,7 +400,9 @@ export class TembaMenu extends ResizeElement {
         flex-direction: row;
       }
 
-      /* when collapsed on mobile, the only thing in the header is the hamburger */
+      /* when collapsed on mobile, the only thing in the header is the
+         hamburger — any new direct child of level-0 must opt in with
+         the .top class to stay visible here */
       .root.fully-collapsed.mobile .level.level-0 > *:not(.top) {
         display: none;
       }

--- a/src/list/TembaMenu.ts
+++ b/src/list/TembaMenu.ts
@@ -33,7 +33,6 @@ export interface MenuItem {
   avatar?: string;
   trigger?: boolean;
   event?: string;
-  mobile?: boolean;
   initial?: string;
 }
 
@@ -401,27 +400,9 @@ export class TembaMenu extends ResizeElement {
         flex-direction: row;
       }
 
-      .root.fully-collapsed.mobile .level.level-0 > .item {
+      /* when collapsed on mobile, the only thing in the header is the hamburger */
+      .root.fully-collapsed.mobile .level.level-0 > *:not(.top) {
         display: none;
-      }
-
-      .root.fully-collapsed.mobile .level.level-0 > .empty {
-        display: block;
-        width: 100%;
-        min-width: inherit;
-        max-width: inherit;
-      }
-
-      .root .level.level-0 > .show-mobile {
-        display: none;
-      }
-
-      .root.mobile .level.level-0 > .show-mobile {
-        display: flex;
-      }
-
-      .root.fully-collapsed.mobile .level.level-0 > .show-mobile {
-        display: contents !important;
       }
 
       .root.fully-collapsed.mobile .level.level-0 .expand-icon {
@@ -455,25 +436,10 @@ export class TembaMenu extends ResizeElement {
         min-width: inherit;
       }
 
-      .mobile.fully-collapsed .item {
-      }
-
       .mobile .expand-icon {
         transition: none;
         transform: rotate(-90deg);
         align-self: center;
-      }
-
-      .mobile.fully-collapsed .level-0 .empty {
-        flex-grow: 1;
-      }
-
-      .mobile.fully-collapsed .top-spacer {
-        flex-grow: 0;
-      }
-
-      .mobile.fully-collapsed #dd-workspace {
-        display: none;
       }
 
       .mobile.fully-collapsed .expand-icon {
@@ -1203,8 +1169,7 @@ export class TembaMenu extends ResizeElement {
       expanding: this.expanding && this.expanding === menuItem.id,
       expanded: this.isExpanded(menuItem),
       iconless: !icon && !collapsedIcon && !menuItem.avatar,
-      pressed: this.pressedItem && this.pressedItem.id == menuItem.id,
-      'show-mobile': menuItem.mobile
+      pressed: this.pressedItem && this.pressedItem.id == menuItem.id
     });
 
     if (menuItem.avatar) {

--- a/src/live/ContactDetails.ts
+++ b/src/live/ContactDetails.ts
@@ -38,7 +38,7 @@ export class ContactDetails extends ContactStoreElement {
 
       .row .label {
         color: var(--text-2);
-        font-size: 12px;
+        font-size: 11px;
         font-weight: var(--w-medium);
         margin-top: 0.25em;
         margin-left: 0.25em;
@@ -46,7 +46,7 @@ export class ContactDetails extends ContactStoreElement {
 
       .row .value {
         margin-left: 0.25em;
-        margin-top: 0.1em;
+        margin-top: 0.35em;
         min-height: 1.75em;
         display: flex;
         flex-wrap: wrap;
@@ -54,6 +54,12 @@ export class ContactDetails extends ContactStoreElement {
       }
 
       .group {
+      }
+
+      /* the last row needs no separator — the card edge closes it off */
+      temba-contact-field:last-of-type {
+        --contact-field-separator: none;
+        margin-bottom: 0;
       }
     `;
   }
@@ -70,6 +76,17 @@ export class ContactDetails extends ContactStoreElement {
 
     return html`
       <div class="wrapper">
+        ${this.data.urns.map((urn) => {
+          let scheme = SCHEMES[urn.scheme];
+          if (!scheme) {
+            scheme = capitalize(urn.scheme as any);
+          }
+          return html`<temba-contact-field
+            name=${scheme}
+            value=${urn.display || urn.path}
+            disabled
+          ></temba-contact-field>`;
+        })}
         ${this.data.groups.length > 0
           ? html` <div class="row">
               <div class="label">Groups</div>
@@ -89,17 +106,6 @@ export class ContactDetails extends ContactStoreElement {
               </div>
             </div>`
           : null}
-        ${this.data.urns.map((urn) => {
-          let scheme = SCHEMES[urn.scheme];
-          if (!scheme) {
-            scheme = capitalize(urn.scheme as any);
-          }
-          return html`<temba-contact-field
-            name=${scheme}
-            value=${urn.display || urn.path}
-            disabled
-          ></temba-contact-field>`;
-        })}
         ${this.data.ref
           ? html`<temba-contact-field
               name="Ref"

--- a/src/live/ContactDetails.ts
+++ b/src/live/ContactDetails.ts
@@ -57,7 +57,7 @@ export class ContactDetails extends ContactStoreElement {
       }
 
       /* the last row needs no separator — the card edge closes it off */
-      temba-contact-field:last-of-type {
+      temba-contact-field.last-field {
         --contact-field-separator: none;
         margin-bottom: 0;
       }
@@ -134,6 +134,7 @@ export class ContactDetails extends ContactStoreElement {
           disabled
         ></temba-contact-field>
         <temba-contact-field
+          class="last-field"
           name="Last Seen"
           value=${this.data.last_seen_on}
           type="datetime"

--- a/src/live/ContactFieldEditor.ts
+++ b/src/live/ContactFieldEditor.ts
@@ -61,7 +61,7 @@ export class ContactFieldEditor extends RapidElement {
         --color-widget-bg-focused: #fff;
         --widget-box-shadow: none;
         padding-bottom: 0.6em;
-        border-bottom: 1px solid #ececec;
+        border-bottom: var(--contact-field-separator, 1px solid #ececec);
       }
 
       .wrapper.disabled {
@@ -108,9 +108,12 @@ export class ContactFieldEditor extends RapidElement {
         text-overflow: ellipsis;
       }
 
+      /* read-only rows set the label clearly apart from the value — the
+         same quiet label treatment as .field-label on the editable rows,
+         a touch smaller, over a full-color value */
       .label .name {
         color: var(--text-2);
-        font-size: 12px;
+        font-size: 11px;
         font-weight: var(--w-medium);
       }
 
@@ -120,8 +123,9 @@ export class ContactFieldEditor extends RapidElement {
       }
 
       .disabled .value {
+        color: var(--text-1);
         margin-left: 0.25em;
-        margin-top: 0.1em;
+        margin-top: 0.35em;
         min-height: 1.75em;
       }
 

--- a/src/live/ContactStoreElement.ts
+++ b/src/live/ContactStoreElement.ts
@@ -66,7 +66,8 @@ export class ContactStoreElement extends EndpointMonitorElement {
   }
 
   public willUpdate(changed: PropertyValues): void {
-    super.willUpdate(changed);
+    // derive our url before the base class runs so it sees the url change
+    // in this same pass (clearing stale data when the contact is unset)
     if (changed.has('contact') || changed.has('endpoint')) {
       if (this.contact) {
         this.url = `${this.endpoint}${this.contact}`;
@@ -74,5 +75,6 @@ export class ContactStoreElement extends EndpointMonitorElement {
         this.url = null;
       }
     }
+    super.willUpdate(changed);
   }
 }

--- a/src/live/ContactTimeline.ts
+++ b/src/live/ContactTimeline.ts
@@ -115,7 +115,9 @@ export class ContactTimeline extends EndpointMonitorElement {
         flex-direction: column;
         align-items: center;
         text-align: center;
-        padding: 7em 1em 4em;
+        /* a host card sets --empty-padding to compact this treatment —
+           the default suits a full-height tab pane */
+        padding: var(--empty-padding, 7em 1em 4em);
         color: var(--text-color);
       }
 
@@ -124,9 +126,17 @@ export class ContactTimeline extends EndpointMonitorElement {
         --icon-color: var(--text-3, #7b8593);
       }
 
+      /* the icon / blurb / link around the title — a host card hides
+         these so the empty card is just the stylized message */
+      .empty-extras {
+        display: var(--empty-extras-display, contents);
+      }
+
       .empty-title {
         font-weight: 600;
         margin-bottom: 0.4em;
+        font-size: var(--empty-title-size, inherit);
+        color: var(--empty-title-color, inherit);
       }
 
       .empty-help {
@@ -547,7 +557,14 @@ export class ContactTimeline extends EndpointMonitorElement {
             : Array.isArray(this.data.future)
               ? this.data.future.length
               : 0;
-        this.fireCustomEvent(CustomEventType.DetailsChanged, { count });
+        // empty mirrors the render()'s empty-state condition so a host
+        // card can drop its chrome entirely when there's nothing to show
+        const empty =
+          count === 0 &&
+          !(Array.isArray(this.data.campaigns) && this.data.campaigns.length) &&
+          !(Array.isArray(this.data.future) && this.data.future.length) &&
+          !(Array.isArray(this.data.past) && this.data.past.length);
+        this.fireCustomEvent(CustomEventType.DetailsChanged, { count, empty });
       }
     }
   }
@@ -810,12 +827,16 @@ export class ContactTimeline extends EndpointMonitorElement {
     ) {
       return html`<div class="empty">
         <slot name="empty">
-          <temba-icon name=${Icon.schedule} size="2"></temba-icon>
+          <div class="empty-extras">
+            <temba-icon name=${Icon.schedule} size="2"></temba-icon>
+          </div>
           <div class="empty-title">${this.lang_empty}</div>
-          <div class="empty-help">${this.lang_empty_help}</div>
-          <a class="empty-link" href="/campaign/" onclick="goto(event, this)"
-            >${this.lang_campaigns_link}</a
-          >
+          <div class="empty-extras">
+            <div class="empty-help">${this.lang_empty_help}</div>
+            <a class="empty-link" href="/campaign/" onclick="goto(event, this)"
+              >${this.lang_campaigns_link}</a
+            >
+          </div>
         </slot>
       </div>`;
     }

--- a/test-assets/menu/menu-support.json
+++ b/test-assets/menu/menu-support.json
@@ -1,0 +1,33 @@
+{
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": "tasks",
+      "name": "Tasks",
+      "icon": "icon.tickets_mine",
+      "endpoint": "/test-assets/menu/menu-tasks.json"
+    },
+    {
+      "id": "support",
+      "name": "Support",
+      "icon": "help",
+      "bottom": true,
+      "mobile": true,
+      "event": "temba-show-support"
+    },
+    {
+      "id": "notifications",
+      "name": "Notifications",
+      "icon": "notification",
+      "bottom": true,
+      "popup": true,
+      "items": [
+        {
+          "id": "latest",
+          "name": "Latest"
+        }
+      ]
+    }
+  ]
+}

--- a/test-assets/menu/menu-support.json
+++ b/test-assets/menu/menu-support.json
@@ -13,7 +13,6 @@
       "name": "Support",
       "icon": "help",
       "bottom": true,
-      "mobile": true,
       "event": "temba-show-support"
     },
     {

--- a/test/temba-contact-chat.test.ts
+++ b/test/temba-contact-chat.test.ts
@@ -175,6 +175,33 @@ describe('temba-contact-chat', () => {
     await assertScreenshot('contacts/chat-for-blocked-contact', getClip(chat));
   });
 
+  it('reloads history when the same contact is set again after clearing', async () => {
+    await loadStore();
+    const chat: ContactChat = await getContactChat({
+      contact: 'contact-barack-archived'
+    });
+    expect(chat.currentContact).to.not.be.null;
+
+    // dismissing the chat (mobile back) clears everything
+    chat.contact = null;
+    chat.currentTicket = null;
+    chat.currentContact = null;
+    await chat.updateComplete;
+    expect(chat.data, 'data should clear with the contact').to.be.null;
+
+    // re-selecting the same ticket sets the same contact again
+    chat.contact = 'contact-barack-archived';
+    for (let i = 0; i < 40; i++) {
+      await waitFor(50);
+      clock.tick(0);
+      if (chat.currentContact && chat.blockFetching) break;
+    }
+
+    expect(chat.currentContact, 'contact should reload').to.not.be.null;
+    const inner = chat.shadowRoot.querySelector('temba-chat') as any;
+    expect(inner.messageGroups.length).to.be.greaterThan(0);
+  });
+
   it('show history and hide chatbox if contact is stopped', async () => {
     // we are a StoreElement, so load a store first
     await loadStore();

--- a/test/temba-header-bar.test.ts
+++ b/test/temba-header-bar.test.ts
@@ -13,9 +13,10 @@ describe('temba-header-bar', () => {
 
     const styles = getComputedStyle(bar);
 
-    // the 52px strip plus its full-bleed 1px rule
+    // the 52px strip plus its full-bleed 1px rule — an inset box-shadow
+    // so host-page border resets (tailwind preflight) can't strip it
     expect(styles.height).to.equal('53px');
-    expect(styles.borderBottomWidth).to.equal('1px');
+    expect(styles.boxShadow).to.contain('inset');
     expect(styles.display).to.equal('flex');
 
     // slotted content stretches to fill the strip

--- a/test/temba-list.test.ts
+++ b/test/temba-list.test.ts
@@ -71,6 +71,37 @@ describe('temba-list', () => {
     await assertScreenshot('list/items-selected', getClip(list));
   });
 
+  it('clears selection without firing change', async () => {
+    const list: TembaList = await getList({
+      endpoint: '/test-assets/list/temba-list.json'
+    });
+
+    list.cursorIndex = 1;
+    await list.updateComplete;
+    expect(list.getSelection()).to.not.be.null;
+
+    let fired = false;
+    list.addEventListener('change', () => {
+      fired = true;
+    });
+
+    list.clearSelection();
+    await list.updateComplete;
+
+    expect(list.cursorIndex).to.equal(-1);
+    expect(list.getSelection()).to.be.null;
+    expect(fired).to.equal(false);
+
+    // selecting the same item again fires change
+    const changeTest = new Promise<void>((resolve) => {
+      list.addEventListener('change', () => {
+        resolve();
+      });
+    });
+    list.cursorIndex = 1;
+    await changeTest;
+  });
+
   it('fires change when first element changes after fetch', async () => {
     const list: TembaList = await getList({
       endpoint: '/test-assets/list/temba-list.json'

--- a/test/temba-menu-support.test.ts
+++ b/test/temba-menu-support.test.ts
@@ -1,0 +1,95 @@
+import { expect } from '@open-wc/testing';
+
+import { TembaMenu } from '../src/list/TembaMenu';
+import { getComponent } from './utils.test';
+import { CustomEventType } from '../src/interfaces';
+
+const TAG = 'temba-menu';
+const getMenu = async (attrs: any = {}, width = 0) => {
+  const menu = (await getComponent(
+    TAG,
+    attrs,
+    '',
+    width,
+    0,
+    'display:inline-block'
+  )) as TembaMenu;
+  await menu.httpComplete;
+  return menu;
+};
+
+describe('temba-menu support item', () => {
+  it('fires button clicked for event items', async () => {
+    const menu: TembaMenu = await getMenu({
+      endpoint: '/test-assets/menu/menu-support.json'
+    });
+
+    let clickedItem: any = null;
+    menu.addEventListener(CustomEventType.ButtonClicked, (event: any) => {
+      clickedItem = event.detail.item;
+    });
+
+    const supportItem = menu.getDiv('#menu-support') as HTMLElement;
+    expect(supportItem, 'support item should render').to.exist;
+
+    // mobile items should be visible on desktop too
+    const style = window.getComputedStyle(supportItem);
+    expect(style.display).to.not.equal('none');
+
+    supportItem.click();
+    await menu.updateComplete;
+
+    expect(clickedItem, 'button clicked event should fire').to.exist;
+    expect(clickedItem.event).to.equal('temba-show-support');
+  });
+
+  it('invokes the -temba-button-clicked attribute handler like frame.html', async () => {
+    // replicate frame.js handleMenuClicked + frame_top.html listener
+    let supportShown = false;
+    document.addEventListener('temba-show-support', () => {
+      supportShown = true;
+    });
+    (window as any).handleMenuClicked = (event: any) => {
+      const item = event.detail.item;
+      if (item.event) {
+        document.dispatchEvent(new CustomEvent(item.event, { detail: item }));
+      }
+    };
+
+    const menu: TembaMenu = await getMenu({
+      endpoint: '/test-assets/menu/menu-support.json',
+      '-temba-button-clicked': 'handleMenuClicked(event)'
+    });
+
+    const supportItem = menu.getDiv('#menu-support') as HTMLElement;
+    supportItem.click();
+    await menu.updateComplete;
+
+    expect(supportShown, 'temba-show-support should be dispatched').to.equal(
+      true
+    );
+  });
+
+  it('only shows the hamburger when collapsed on mobile', async () => {
+    (window as any).isMobile = () => true;
+    try {
+      const menu: TembaMenu = await getMenu({
+        endpoint: '/test-assets/menu/menu-support.json',
+        collapsed: 'collapsed'
+      });
+      await menu.updateComplete;
+
+      const hamburger = menu.getDiv('.expand-icon') as HTMLElement;
+      expect(window.getComputedStyle(hamburger).display).to.not.equal('none');
+
+      // everything else in the header should be hidden, including popups
+      const support = menu.getDiv('#menu-support') as HTMLElement;
+      expect(window.getComputedStyle(support).display).to.equal('none');
+
+      const notifications = menu.getDiv('#dd-notifications') as HTMLElement;
+      expect(window.getComputedStyle(notifications).display).to.equal('none');
+    } finally {
+      delete (window as any).isMobile;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

A round of mobile and layout fixes for the nav menu and the chat-first pages (contact read, tickets): mobile-flagged menu items now show everywhere, the collapsed mobile menu is reduced to just the hamburger, and re-selecting the same contact no longer leaves the chat blank.

## Changes

**TembaMenu**
- Menu items flagged for mobile (e.g. Support) now render on desktop too, at the bottom of the rail
- The fully-collapsed mobile header hides everything except the hamburger — previously popup items like the notifications dropdown leaked into the header and mobile-flagged items rendered misaligned via `display: contents`
- Removed the now-unused `show-mobile` class and `MenuItem.mobile` field

**TembaList**
- New `clearSelection()` method that deselects without firing a change event, so pages can clear the focused row (mobile back navigation) and the same row can be selected again

**ContactStoreElement**
- `willUpdate` now derives `url` before calling `super.willUpdate()`, so the base class sees the url change in the same pass and clears stale `data` when the contact is unset. Previously the stale object survived, and re-setting the same contact hit the store cache and returned the identical reference — failing Lit's change check, so nothing reloaded and the chat rendered blank

**Layout**
- HeaderBar: the bottom rule is a box-shadow instead of a border, so host-page CSS resets (tailwind preflight) can't strip it
- Card: new reflected `empty` property — an empty panel hides its card in card mode but keeps its tab in narrow mode; empty-state CSS hooks for slotted panels
- CardLayout: the card column keeps its bottom padding so the last card rests level with the main view

**Compose**
- Enter-to-send is handled in both capture and bubble phases: capture claims editor presses before the rich editor inserts a newline (no flash before send), bubble keeps Enter-to-send working elsewhere; `stopImmediatePropagation` prevents an at-target double-send

**Contact panels**
- ContactDetails: URNs render above groups; last row drops its separator
- ContactFieldEditor: separator exposed as a CSS var; read-only label/value styling aligned with editable rows
- ContactTimeline: reports an `empty` state via `temba-details-changed`

## Review notes

Pre-PR review found no blocking issues. Noted, not addressed:
- The timeline's `empty` condition is slightly stricter than its render-time empty state (`count === 0` term) — errs toward showing the card, never wrongly hides it
- Escape is now also observed during the capture phase while the shortcuts panel is open — narrow scope, closes the panel globally

## Test plan

- [x] Full suite in the dev container: 2023 passed, 0 failed (142 files, screenshots included)
- [x] New tests: mobile/support menu item rendering + event dispatch, hamburger-only collapsed mobile header, `clearSelection()` (no change fired, re-select re-fires), same-contact reload regression for the blank-chat bug (verified failing before the fix)