### PR TITLE
Add fixed mode with interrupt confirmation to temba-contact-search

### DIFF
--- a/src/form/ContactSearch.ts
+++ b/src/form/ContactSearch.ts
@@ -331,17 +331,12 @@ export class ContactSearch extends FieldElement {
     }
   }
 
-  public updated(changedProperties: Map<string, any>) {
-    super.updated(changedProperties);
-
-    if (changedProperties.has('recipients')) {
-      this.handleRecipientsChanged();
-    }
+  protected willUpdate(changedProperties: Map<string, any>) {
+    super.willUpdate(changedProperties);
 
     // if we remove the in_a_flow option, make sure it's not part of our exclusions
     if (changedProperties.has('in_a_flow') && !this.in_a_flow) {
       delete this.exclusions['in_a_flow'];
-      this.requestUpdate('exclusions');
     }
 
     // a fixed contact already in a flow stays excluded until interruption is confirmed
@@ -356,7 +351,14 @@ export class ContactSearch extends FieldElement {
       } else {
         delete this.exclusions['in_a_flow'];
       }
-      this.requestUpdate('exclusions');
+    }
+  }
+
+  public updated(changedProperties: Map<string, any>) {
+    super.updated(changedProperties);
+
+    if (changedProperties.has('recipients')) {
+      this.handleRecipientsChanged();
     }
 
     if (

--- a/src/form/ContactSearch.ts
+++ b/src/form/ContactSearch.ts
@@ -617,10 +617,10 @@ export class ContactSearch extends FieldElement {
             ></temba-checkbox>
             <div>
               ${this.flow && this.flow.name === this.currentFlow
-                ? html`${msg("It's okay to restart")} <b>${this.currentFlow}</b>
-                  ${msg('from the beginning')}`
+                ? html`${msg("It's okay to restart")}
+                    <b>${this.currentFlow}</b> ${msg('from the beginning')}`
                 : html`${msg("It's okay to interrupt")}
-                  <b>${this.currentFlow}</b> ${msg('and start this one')}`}
+                    <b>${this.currentFlow}</b> ${msg('and start this one')}`}
             </div>
           </div>`
         : null;
@@ -630,115 +630,115 @@ export class ContactSearch extends FieldElement {
         this.fixed
           ? null
           : this.advanced
-          ? html`<div class="query">
-              <temba-textinput
-                .helpText=${this.helpText}
-                .widgetOnly=${this.widgetOnly}
-                .errors=${this.errors}
-                name=${this.name}
-                .inputRoot=${this}
-                @input=${this.handleQueryChange}
-                placeholder=${this.placeholder}
-                .value=${this.query}
-                textarea
-                autogrow
-              >
-              </temba-textinput>
-            </div>`
-          : html`<temba-omnibox
-                placeholder="Search for contacts or groups"
-                widget_only=""
-                groups=""
-                contacts=""
-                label="Recipients"
-                help_text="The contacts to send the message to."
-                .errors=${this.errors}
-                id="recipients"
-                name="recipients"
-                .values=${this.recipients}
-                endpoint="/contact/omnibox/?"
-                @change=${this.handleRecipientsChanged}
-              >
-              </temba-omnibox>
+            ? html`<div class="query">
+                <temba-textinput
+                  .helpText=${this.helpText}
+                  .widgetOnly=${this.widgetOnly}
+                  .errors=${this.errors}
+                  name=${this.name}
+                  .inputRoot=${this}
+                  @input=${this.handleQueryChange}
+                  placeholder=${this.placeholder}
+                  .value=${this.query}
+                  textarea
+                  autogrow
+                >
+                </temba-textinput>
+              </div>`
+            : html`<temba-omnibox
+                  placeholder="Search for contacts or groups"
+                  widget_only=""
+                  groups=""
+                  contacts=""
+                  label="Recipients"
+                  help_text="The contacts to send the message to."
+                  .errors=${this.errors}
+                  id="recipients"
+                  name="recipients"
+                  .values=${this.recipients}
+                  endpoint="/contact/omnibox/?"
+                  @change=${this.handleRecipientsChanged}
+                >
+                </temba-omnibox>
 
-              ${this.not_seen_since_days ||
-              this.in_a_flow ||
-              this.started_previously
-                ? html`
-                    <div class="filters">
-                      <div
-                        style="display:flex;font-size:1em;margin-bottom:0.5em"
-                      >
-                        <temba-icon size="1" name="filter"></temba-icon>
-                        <div style="margin-left:0.5em">
-                          Only include contacts who...
+                ${this.not_seen_since_days ||
+                this.in_a_flow ||
+                this.started_previously
+                  ? html`
+                      <div class="filters">
+                        <div
+                          style="display:flex;font-size:1em;margin-bottom:0.5em"
+                        >
+                          <temba-icon size="1" name="filter"></temba-icon>
+                          <div style="margin-left:0.5em">
+                            Only include contacts who...
+                          </div>
                         </div>
-                      </div>
-                      ${this.in_a_flow
-                        ? html`<temba-checkbox
-                            name="in_a_flow"
-                            label="${msg('Are not currently in a flow')}"
-                            ?checked=${this.exclusions['in_a_flow']}
-                            @change=${this.handleExclusionChanged}
-                          ></temba-checkbox>`
-                        : null}
-                      ${this.not_seen_since_days
-                        ? html`
-                            <div
-                              class="activity-select"
-                              @click=${this.handleActivityLabelClicked}
-                            >
-                              <temba-checkbox
-                                style="display:inline;"
-                                name="not_seen_since_days"
-                                ?checked=${notSeenSinceDays}
-                                @change=${this.handleExclusionChanged}
+                        ${this.in_a_flow
+                          ? html`<temba-checkbox
+                              name="in_a_flow"
+                              label="${msg('Are not currently in a flow')}"
+                              ?checked=${this.exclusions['in_a_flow']}
+                              @change=${this.handleExclusionChanged}
+                            ></temba-checkbox>`
+                          : null}
+                        ${this.not_seen_since_days
+                          ? html`
+                              <div
+                                class="activity-select"
+                                @click=${this.handleActivityLabelClicked}
                               >
-                              </temba-checkbox>
+                                <temba-checkbox
+                                  style="display:inline;"
+                                  name="not_seen_since_days"
+                                  ?checked=${notSeenSinceDays}
+                                  @change=${this.handleExclusionChanged}
+                                >
+                                </temba-checkbox>
 
-                              <div>
-                                ${msg('Have sent a message in the last')}
+                                <div>
+                                  ${msg('Have sent a message in the last')}
+                                </div>
+
+                                <temba-select
+                                  style="margin-left:0.5em"
+                                  class="small-select"
+                                  @change=${this.handleActivityLevelChanged}
+                                  ?disabled=${!notSeenSinceDays}
+                                >
+                                  <temba-option
+                                    name="90 days"
+                                    value="90"
+                                    ?selected=${notSeenSinceDays === 90}
+                                  ></temba-option>
+                                  <temba-option
+                                    name="180 days"
+                                    value="180"
+                                    ?selected=${notSeenSinceDays === 180}
+                                  ></temba-option>
+                                  <temba-option
+                                    name="Year"
+                                    value="365"
+                                    ?selected=${notSeenSinceDays === 365}
+                                  ></temba-option>
+                                </temba-select>
+                                <div></div>
                               </div>
-
-                              <temba-select
-                                style="margin-left:0.5em"
-                                class="small-select"
-                                @change=${this.handleActivityLevelChanged}
-                                ?disabled=${!notSeenSinceDays}
-                              >
-                                <temba-option
-                                  name="90 days"
-                                  value="90"
-                                  ?selected=${notSeenSinceDays === 90}
-                                ></temba-option>
-                                <temba-option
-                                  name="180 days"
-                                  value="180"
-                                  ?selected=${notSeenSinceDays === 180}
-                                ></temba-option>
-                                <temba-option
-                                  name="Year"
-                                  value="365"
-                                  ?selected=${notSeenSinceDays === 365}
-                                ></temba-option>
-                              </temba-select>
-                              <div></div>
-                            </div>
-                          `
-                        : null}
-                      ${this.started_previously
-                        ? html`<temba-checkbox
-                            name="started_previously"
-                            label="${msg(
-                              'Have not started this flow in the last 90 days'
-                            )}"
-                            ?checked=${this.exclusions['started_previously']}
-                            @change=${this.handleExclusionChanged}
-                          ></temba-checkbox>`
-                        : null}
-                    </div>
-                  `
-                : null} `
+                            `
+                          : null}
+                        ${this.started_previously
+                          ? html`<temba-checkbox
+                              name="started_previously"
+                              label="${msg(
+                                'Have not started this flow in the last 90 days'
+                              )}"
+                              ?checked=${this.exclusions['started_previously']}
+                              @change=${this.handleExclusionChanged}
+                            ></temba-checkbox>`
+                          : null}
+                      </div>
+                    `
+                  : null} `
       }
               </div>
       ${interruptConfirm}

--- a/src/form/ContactSearch.ts
+++ b/src/form/ContactSearch.ts
@@ -226,11 +226,32 @@ export class ContactSearch extends FieldElement {
         border: 1px solid var(--color-borders);
         border-radius: var(--curvature);
       }
+
+      .interrupt-confirm {
+        display: flex;
+        align-items: center;
+        margin-top: 0.5em;
+        margin-left: 0.6em;
+        cursor: pointer;
+      }
     `;
   }
 
   @property({ type: Boolean })
   in_a_flow: boolean;
+
+  // recipients are locked, e.g. starting a specific contact from their read page -
+  // no recipient editing, filters or query editing
+  @property({ type: Boolean })
+  fixed: boolean;
+
+  // name of the flow the fixed contact is currently in, if any
+  @property({ type: String, attribute: 'current_flow' })
+  currentFlow: string;
+
+  // whether the user has explicitly confirmed interrupting the current flow
+  @property({ type: Boolean })
+  interruptConfirmed = false;
 
   @property({ type: Boolean })
   started_previously: boolean;
@@ -320,6 +341,21 @@ export class ContactSearch extends FieldElement {
     // if we remove the in_a_flow option, make sure it's not part of our exclusions
     if (changedProperties.has('in_a_flow') && !this.in_a_flow) {
       delete this.exclusions['in_a_flow'];
+      this.requestUpdate('exclusions');
+    }
+
+    // a fixed contact already in a flow stays excluded until interruption is confirmed
+    if (
+      this.fixed &&
+      this.currentFlow &&
+      (changedProperties.has('in_a_flow') ||
+        changedProperties.has('interruptConfirmed'))
+    ) {
+      if (this.in_a_flow && !this.interruptConfirmed) {
+        this.exclusions['in_a_flow'] = true;
+      } else {
+        delete this.exclusions['in_a_flow'];
+      }
       this.requestUpdate('exclusions');
     }
 
@@ -455,6 +491,28 @@ export class ContactSearch extends FieldElement {
     }
   }
 
+  private async handleInterruptChanged(evt: any) {
+    const checkbox = evt.target as Checkbox;
+    this.interruptConfirmed = checkbox.checked;
+
+    // wait for updated() to adjust our exclusions
+    await this.updateComplete;
+
+    this.setValue({
+      advanced: this.advanced,
+      query: this.query,
+      exclusions: this.exclusions,
+      recipients: this.recipients
+    });
+
+    // we already know whether our fixed contact will be included so no need to re-run the
+    // search - just let the modal know
+    this.fireCustomEvent(CustomEventType.ContentChanged, {
+      ...(this.summary || {}),
+      total: this.interruptConfirmed ? this.recipients.length : 0
+    });
+  }
+
   private handleExclusionChanged(evt: any) {
     if (evt.target.tagName === 'TEMBA-CHECKBOX') {
       const ex = JSON.stringify(this.exclusions);
@@ -487,7 +545,7 @@ export class ContactSearch extends FieldElement {
 
   public renderWidget(): TemplateResult {
     let summary: TemplateResult;
-    if (this.summary) {
+    if (this.summary && !this.fixed) {
       if (!this.summary.error) {
         const count = this.summary.total || 0;
 
@@ -544,9 +602,32 @@ export class ContactSearch extends FieldElement {
       )}`;
     }
 
+    const interruptConfirm =
+      this.fixed && this.currentFlow && this.in_a_flow && !this.fetching
+        ? html`<div
+            class="interrupt-confirm"
+            @click=${this.handleActivityLabelClicked}
+          >
+            <temba-checkbox
+              name="interrupt"
+              ?checked=${this.interruptConfirmed}
+              @change=${this.handleInterruptChanged}
+            ></temba-checkbox>
+            <div>
+              ${this.flow && this.flow.name === this.currentFlow
+                ? html`${msg("It's okay to restart")} <b>${this.currentFlow}</b>
+                  ${msg('from the beginning')}`
+                : html`${msg("It's okay to interrupt")}
+                  <b>${this.currentFlow}</b> ${msg('and start this one')}`}
+            </div>
+          </div>`
+        : null;
+
     return html`
       ${
-        this.advanced
+        this.fixed
+          ? null
+          : this.advanced
           ? html`<div class="query">
               <temba-textinput
                 .helpText=${this.helpText}
@@ -658,18 +739,33 @@ export class ContactSearch extends FieldElement {
                 : null} `
       }
               </div>
-      <div
-        class="results ${getClasses({
-          fetching: this.fetching,
-          initialized: this.initialized || this.fetching,
-          empty:
-            ((this.summary && this.summary.error) || !this.summary) &&
-            !this.fetching
-        })}"
-      >
-        <temba-loading units="6" size="8"></temba-loading>
-        <div class="summary ${this.expanded ? 'expanded' : ''}">${summary}</div>
-      </div>
+      ${interruptConfirm}
+      ${
+        this.fixed
+          ? html`<div
+              class="results ${getClasses({
+                fetching: this.fetching,
+                initialized: this.fetching,
+                empty: !this.fetching
+              })}"
+            >
+              <temba-loading units="6" size="8"></temba-loading>
+            </div>`
+          : html`<div
+              class="results ${getClasses({
+                fetching: this.fetching,
+                initialized: this.initialized || this.fetching,
+                empty:
+                  ((this.summary && this.summary.error) || !this.summary) &&
+                  !this.fetching
+              })}"
+            >
+              <temba-loading units="6" size="8"></temba-loading>
+              <div class="summary ${this.expanded ? 'expanded' : ''}">
+                ${summary}
+              </div>
+            </div>`
+      }
       ${blockers}
       ${
         !blockers && this.summary && this.summary.warnings

--- a/test/temba-contact-search.test.ts
+++ b/test/temba-contact-search.test.ts
@@ -67,6 +67,103 @@ describe('temba-contact-search', () => {
     await assertScreenshot('contact-search/missing-group', getClip(search));
   });
 
+  it('locks recipients in fixed mode', async () => {
+    const search: ContactSearch = await fixture(
+      getHTML('temba-contact-search', {
+        fixed: true,
+        recipients: JSON.stringify([
+          { id: 'contact-uuid', name: 'Ben Haggerty', type: 'contact' }
+        ])
+      })
+    );
+
+    await search.updateComplete;
+
+    // no way to edit who gets started
+    expect(search.shadowRoot.querySelector('temba-omnibox')).to.not.exist;
+    expect(search.shadowRoot.querySelector('.filters')).to.not.exist;
+    expect(search.shadowRoot.querySelector('temba-button.edit')).to.not.exist;
+  });
+
+  it('requires confirmation to interrupt a current flow', async () => {
+    const search: ContactSearch = await fixture(
+      getHTML('temba-contact-search', {
+        fixed: true,
+        current_flow: 'Survey Flow',
+        recipients: JSON.stringify([
+          { id: 'contact-uuid', name: 'Ben Haggerty', type: 'contact' }
+        ])
+      })
+    );
+
+    await search.updateComplete;
+
+    // no confirmation until a flow that interrupts is selected
+    expect(search.shadowRoot.querySelector('.interrupt-confirm')).to.not.exist;
+
+    // selecting a non-background flow asks for interrupt confirmation
+    search.in_a_flow = true;
+    await search.updateComplete;
+
+    // but not while a search is running
+    search.fetching = true;
+    await search.updateComplete;
+    expect(search.shadowRoot.querySelector('.interrupt-confirm')).to.not.exist;
+
+    search.fetching = false;
+    await search.updateComplete;
+
+    const confirm = search.shadowRoot.querySelector('.interrupt-confirm');
+    expect(confirm).to.exist;
+    expect(confirm.querySelector('temba-checkbox')).to.exist;
+    expect(confirm.querySelector('b').textContent).to.equal('Survey Flow');
+    expect(confirm.textContent).to.contain('interrupt');
+    expect(search.exclusions['in_a_flow']).to.equal(true);
+
+    // starting the same flow they are already in is a restart
+    search.flow = { name: 'Survey Flow' };
+    await search.updateComplete;
+    expect(
+      search.shadowRoot.querySelector('.interrupt-confirm').textContent
+    ).to.contain('restart');
+    search.flow = null;
+    await search.updateComplete;
+
+    // confirming interruption lifts the exclusion so the start can proceed, without
+    // re-running the search - the widget reports the new total itself
+    const checkbox = confirm.querySelector('temba-checkbox') as any;
+    let eventPromise = new Promise<any>((resolve) =>
+      search.addEventListener(
+        CustomEventType.ContentChanged,
+        (e: any) => resolve(e.detail),
+        { once: true }
+      )
+    );
+    checkbox.checked = true;
+    let detail = await eventPromise;
+    expect(detail.total).to.equal(1);
+    expect(search.exclusions['in_a_flow']).to.be.undefined;
+
+    // unconfirming puts it back
+    eventPromise = new Promise<any>((resolve) =>
+      search.addEventListener(
+        CustomEventType.ContentChanged,
+        (e: any) => resolve(e.detail),
+        { once: true }
+      )
+    );
+    checkbox.checked = false;
+    detail = await eventPromise;
+    expect(detail.total).to.equal(0);
+    expect(search.exclusions['in_a_flow']).to.equal(true);
+
+    // background flows don't interrupt, no confirmation needed
+    search.in_a_flow = false;
+    await search.updateComplete;
+    expect(search.shadowRoot.querySelector('.interrupt-confirm')).to.not.exist;
+    expect(search.exclusions['in_a_flow']).to.be.undefined;
+  });
+
   xit('allows manual searches', async () => {
     const endpoint = '/contact-search-manual';
     const search: ContactSearch = await fixture(

--- a/test/temba-contact-search.test.ts
+++ b/test/temba-contact-search.test.ts
@@ -85,6 +85,23 @@ describe('temba-contact-search', () => {
     expect(search.shadowRoot.querySelector('temba-button.edit')).to.not.exist;
   });
 
+  it('excludes a contact in a flow from first render', async () => {
+    const search: ContactSearch = await fixture(
+      getHTML('temba-contact-search', {
+        fixed: true,
+        current_flow: 'Survey Flow',
+        in_a_flow: true,
+        recipients: JSON.stringify([
+          { id: 'contact-uuid', name: 'Ben Haggerty', type: 'contact' }
+        ])
+      })
+    );
+
+    await search.updateComplete;
+    expect(search.exclusions['in_a_flow']).to.equal(true);
+    expect(search.shadowRoot.querySelector('.interrupt-confirm')).to.exist;
+  });
+
   it('requires confirmation to interrupt a current flow', async () => {
     const search: ContactSearch = await fixture(
       getHTML('temba-contact-search', {
@@ -143,6 +160,8 @@ describe('temba-contact-search', () => {
     let detail = await eventPromise;
     expect(detail.total).to.equal(1);
     expect(search.exclusions['in_a_flow']).to.be.undefined;
+    expect(search.getDeserializedValue().exclusions['in_a_flow']).to.be
+      .undefined;
 
     // unconfirming puts it back
     eventPromise = new Promise<any>((resolve) =>


### PR DESCRIPTION
## Summary

Adds a "fixed" mode to `temba-contact-search` for flow starts that are seeded with a single contact (e.g. from the contact read page or a ticket). In this mode the recipient can't be changed, and if the contact is already waiting in a flow the user must explicitly confirm the interruption before the start can proceed.

## Changes

- **`fixed` property** — locks the widget: no omnibox recipient editing, no "Only include contacts who…" filters, no Edit Query/advanced toggle, and no result-count link. While a preview fetch runs, only the loading spinner shows.
- **`current_flow` attribute** — the name of the flow the seeded contact is currently in. When set and the selected flow would interrupt it (non-background), a confirmation row renders: *"It's okay to interrupt **<flow>** and start this one"* — or *"It's okay to restart **<flow>** from the beginning"* when the selected flow is the same one.
- **Confirmation drives the `in_a_flow` exclusion** — until confirmed, the exclusion stays in place so the preview evaluates to 0 recipients and the host modal keeps its Start button disabled; warnings/blockers from the preview endpoint render as usual. Toggling the confirmation does not re-issue the preview search: the widget updates its form value and fires `temba-content-changed` itself with the known total (1/0), carrying forward the last summary's warnings/blockers.
- Background flows never require confirmation (they don't interrupt).
- Exclusion reconciliation happens in `willUpdate()` so no extra render cycle is scheduled.

## Review notes

- Pre-PR review confirmed the exclusion state machine is consistent across `in_a_flow`/`interruptConfirmed` transitions and that the checkbox change event fires exactly once for both direct clicks and row-label clicks.
- Review-driven fix: moved exclusion reconciliation from `updated()` to `willUpdate()` to avoid Lit's change-in-update re-render.
- Confirmation intentionally persists across flow re-selection — it's consent to disrupt the contact's *current* flow, which doesn't change with the target selection.

## Test plan

- [x] Fixed mode renders no recipient editing UI (omnibox/filters/edit query)
- [x] Mounting with `in_a_flow` set excludes the contact from first render
- [x] Confirmation appears only for interrupting flows, hides while a search is running, and flips the exclusion + reported total without a fetch
- [x] Restart wording when the selected flow equals the current flow
- [x] Full suite green (`bun run test:fast`); `bun run build` succeeds