### PR TITLE
Initialize deep-linked search and reflect list state in the URL

### DIFF
--- a/src/list/ContentList.ts
+++ b/src/list/ContentList.ts
@@ -1151,12 +1151,19 @@ export class ContentList<T = any> extends RapidElement {
    * page-header attribute to this (rather than the raw endpoint) makes
    * the menu re-fetch whenever the committed search changes. */
   private contentMenuEndpointWithSearch(): string {
-    if (!this.contentMenuEndpoint || !this.search) {
+    if (!this.contentMenuEndpoint) {
       return this.contentMenuEndpoint;
     }
     try {
       const url = new URL(this.contentMenuEndpoint, window.location.origin);
-      url.searchParams.set('search', this.search);
+      // With no committed search, *strip* any search param rather than
+      // passing the endpoint through — hosts typically bake the
+      // original request's query string into the attribute (so a
+      // deep-linked search seeds the menu), and clearing the search in
+      // the list must also clear it from the menu fetch or
+      // search-dependent items (e.g. "Create Smart Group") linger.
+      if (this.search) url.searchParams.set('search', this.search);
+      else url.searchParams.delete('search');
       return url.pathname + url.search;
     } catch {
       return this.contentMenuEndpoint;
@@ -1589,6 +1596,20 @@ export class ContentList<T = any> extends RapidElement {
   private writeUrlState(replace = false): void {
     this.bubbleHistoryState(replace);
     if (!this.urlState) return;
+    const url = this.buildBrowserUrl();
+    if (replace) {
+      window.history.replaceState({}, '', url);
+    } else {
+      window.history.pushState({}, '', url);
+    }
+  }
+
+  /** The address-bar URL reflecting the current list state: the
+   * page's path with the list's search/sort/page params folded into
+   * the existing query string (set when active, removed when not —
+   * so a cleared search drops its param). Params the list doesn't
+   * own are preserved. */
+  private buildBrowserUrl(): string {
     const params = new URLSearchParams(window.location.search);
     const k = (name: string) =>
       this.urlParamPrefix ? `${this.urlParamPrefix}_${name}` : name;
@@ -1602,12 +1623,7 @@ export class ContentList<T = any> extends RapidElement {
     setOrDelete(k('page'), this.page > 1 ? String(this.page) : '');
 
     const qs = params.toString();
-    const url = window.location.pathname + (qs ? '?' + qs : '');
-    if (replace) {
-      window.history.replaceState({}, '', url);
-    } else {
-      window.history.pushState({}, '', url);
-    }
+    return window.location.pathname + (qs ? '?' + qs : '');
   }
 
   /** Read saved list state out of the host's history entry under
@@ -1620,7 +1636,19 @@ export class ContentList<T = any> extends RapidElement {
   private readHistoryState(): void {
     const key = this.historyStateKey;
     if (!key) return;
-    const stash = (window.history.state || {})[key] || {};
+    const state = window.history.state || {};
+    // A fresh navigation has no stash for this list yet, but the link
+    // itself may deep-link a query (e.g. /contact/?search=age%3E10) —
+    // fall back to the URL params so the list initializes on them.
+    // Once the list has bubbled state for this entry the stash exists
+    // (even with an empty search) and takes precedence, so a cleared
+    // search isn't resurrected by a stale query string.
+    if (!(key in state)) {
+      this.restoreUrl = '';
+      this.readUrlState();
+      return;
+    }
+    const stash = state[key] || {};
     const previousSearch = this.search;
     this.search = typeof stash.search === 'string' ? stash.search : '';
     this.sort = typeof stash.sort === 'string' ? stash.sort : '';
@@ -1670,10 +1698,18 @@ export class ContentList<T = any> extends RapidElement {
     if (this.cursorMode && this.currentUrl) {
       state.url = this.currentUrl;
     }
+    // `url` (distinct from `state.url`, the fetch cursor) is the
+    // address-bar URL for this list state — the host should pass it
+    // as the url argument of its pushState/replaceState so a
+    // committed or cleared search is reflected in the address bar,
+    // while keeping its own stashed page URL (frame.js's
+    // `state.url`) stable so in-list back/forward isn't mistaken
+    // for a cross-page navigation.
     this.fireCustomEvent(CustomEventType.HistoryChange, {
       key: this.historyStateKey,
       state,
-      replace
+      replace,
+      url: this.buildBrowserUrl()
     });
   }
 

--- a/test/temba-content-list.test.ts
+++ b/test/temba-content-list.test.ts
@@ -129,7 +129,9 @@ describe('temba-content-list', () => {
   it('folds the committed search into the content-menu-endpoint', async () => {
     const list = (await getList({
       endpoint: '/test-assets/content-list/items.json',
-      'content-menu-endpoint': '/contact/active/?'
+      // hosts bake the original request's query string into the
+      // attribute, so a deep-linked search arrives pre-folded
+      'content-menu-endpoint': '/contact/active/?search=stale'
     })) as ContentList;
 
     const header = () =>
@@ -137,8 +139,10 @@ describe('temba-content-list', () => {
         .shadowRoot!.querySelector('temba-page-header')!
         .getAttribute('content-menu-endpoint');
 
-    // no search → the menu endpoint is untouched
-    expect(header()).to.equal('/contact/active/?');
+    // no committed search → any search baked into the attribute is
+    // stripped, so search-dependent items (e.g. Create Smart Group)
+    // don't linger once the search is gone
+    expect(header()).to.equal('/contact/active/');
 
     // a committed search is folded in so the server's build_context_menu
     // sees it (and can surface e.g. the Create Smart Group button)
@@ -146,10 +150,10 @@ describe('temba-content-list', () => {
     await list.updateComplete;
     expect(header()).to.contain('search=age');
 
-    // clearing the search reverts the endpoint
+    // clearing the search strips it again
     (list as any).search = '';
     await list.updateComplete;
-    expect(header()).to.equal('/contact/active/?');
+    expect(header()).to.equal('/contact/active/');
   });
 
   it('marks the frame scrolled-down so the header gets a scroll shadow', async () => {
@@ -1092,6 +1096,23 @@ describe('temba-content-list', () => {
     const searchEvent = events[events.length - 1];
     expect(searchEvent.replace).to.equal(false);
     expect(searchEvent.state.search).to.equal('a');
+    // the event carries the address-bar URL for the new state so the
+    // host can reflect it when it pushes the history entry
+    expect(searchEvent.url).to.contain('search=a');
+
+    // clearing the search drops the param from the bubbled URL
+    events.length = 0;
+    const onClear = new Promise<void>((resolve) => {
+      list.addEventListener(CustomEventType.FetchComplete, () => resolve(), {
+        once: true
+      });
+    });
+    (list as any).clearSearch();
+    await onClear;
+
+    const clearEvent = events[events.length - 1];
+    expect(clearEvent.state.search).to.equal('');
+    expect(clearEvent.url).to.not.contain('search=');
   });
 
   it('restores from history.state and re-fetches on popstate', async () => {
@@ -1124,6 +1145,44 @@ describe('temba-content-list', () => {
 
     expect((list as any).sort).to.equal('name');
     expect((list as any).search).to.equal('');
+  });
+
+  it('falls back to URL params when history has no stash for the key', async () => {
+    const originalUrl = window.location.pathname + window.location.search;
+    // Fresh navigation: no stash for this key yet, but the link itself
+    // deep-links a search (e.g. /contact/?search=age%3E10).
+    history.replaceState({}, '', '?search=age+%3E+10&sort=-name');
+    try {
+      const list = (await getList({
+        endpoint: '/test-assets/content-list/items.json',
+        'history-state-key': 'contacts'
+      })) as ContentList;
+      list.columns = [{ key: 'name', label: 'Name' }];
+      await list.updateComplete;
+
+      expect((list as any).search).to.equal('age > 10');
+      expect((list as any).sort).to.equal('-name');
+      // the search bar opens showing the active query
+      expect((list as any).searchOpen).to.equal(true);
+      expect((list as any).searchDraft).to.equal('age > 10');
+      // and the fetch carried it to the endpoint
+      expect((list as any).currentUrl).to.contain('search=');
+
+      // Once a stash exists for the key it wins over the (now stale)
+      // query string still sitting in the URL.
+      history.replaceState({ contacts: { page: 1, sort: '', search: '' } }, '');
+      const onFetch = new Promise<void>((resolve) => {
+        list.addEventListener(CustomEventType.FetchComplete, () => resolve(), {
+          once: true
+        });
+      });
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      await onFetch;
+      expect((list as any).search).to.equal('');
+      expect((list as any).searchOpen).to.equal(false);
+    } finally {
+      history.replaceState({}, '', originalUrl);
+    }
   });
 
   it('toggles sort direction on header click', async () => {


### PR DESCRIPTION
## Summary

Fixes deep-linked searches on the new `temba-content-list`-based list pages: navigating to a list with `?search=` in the URL now initializes the search (previously ignored in `history-state-key` mode), committed/cleared searches are reflected in the address bar via the host, and the content menu stays in sync with the active search (e.g. "Create Smart Group" no longer lingers after clearing).

## Changes

**`src/list/ContentList.ts`**
- `readHistoryState` now falls back to reading `search`/`sort`/`page` from the URL query string when the history entry has no stash for the list's key — so a fresh navigation to a deep link like `/contact/?search=age%3E10` initializes the search and opens the search bar. Once a stash exists (even with an empty search) it takes precedence, so a cleared search isn't resurrected by a stale query string.
- Extracted `buildBrowserUrl()` (path + list params folded into the existing query string, non-owned params preserved) from `writeUrlState`, and the `temba-history-change` event now carries it as `detail.url` — hosts pass it as the URL argument of `pushState`/`replaceState` so list state stays shareable in the address bar. Hosts that ignore `detail.url` keep the previous behavior. `url-state` mode is unchanged.
- `contentMenuEndpointWithSearch` now strips the `search` param when there is no committed search (hosts bake the original request's query string into `content-menu-endpoint`, so a stale search would otherwise keep search-dependent menu items alive after clearing) and sets it when there is one.

**`test/temba-content-list.test.ts`**
- New test: URL-param fallback on fresh navigation, including stash precedence over the stale query string on popstate.
- Extended the history-change test to assert `detail.url` carries a committed search and drops it on clear.
- Updated the content-menu test to cover stripping a baked-in `search` param.

## Review notes

Two pre-PR review cycles with expert review agents:
- The reviewer confirmed the `!(key in state)` stash-presence check, multi-list `urlParamPrefix` coherence, and byte-for-byte equivalence for `url-state` consumers.
- One Medium interplay finding landed in the host repo: with entry addresses now diverging from the host's stashed page URL, the SPA frame's post-fetch cache guard needed to key off entry identity instead of `location.href` (fixed in the companion host PR).

## Test plan

- [x] `bun run validate` (format, build, full suite with coverage) green in the dev container
- [x] New/updated unit tests for the URL fallback, bubbled `detail.url`, and content-menu strip
- [ ] Manual QA with the companion host PR: hard-refresh a deep link, commit a search → navigate away → back → back/forward across search states, verify the address bar tracks state and the menu drops "Create Smart Group" on clear