### PR TITLE
Fix flaky simulator tests by waiting for chat messages to render

### DIFF
--- a/test/temba-simulator.test.ts
+++ b/test/temba-simulator.test.ts
@@ -206,6 +206,12 @@ const getMessageCount = (simulator: Simulator): number => {
   );
 };
 
+// the chat component renders messages asynchronously (batched via setTimeout),
+// so poll rather than counting immediately after opening the simulator
+const waitForMessages = async (simulator: Simulator, minCount: number = 1) => {
+  await waitForCondition(() => getMessageCount(simulator) >= minCount, 40, 50);
+};
+
 // mock responses for simulation endpoints
 const mockSimulatorStart = () => {
   const response = {
@@ -406,6 +412,7 @@ describe('temba-simulator', () => {
     expect(phoneScreen).to.exist;
 
     // verify initial message is displayed via chat component
+    await waitForMessages(simulator);
     const messageCount = getMessageCount(simulator);
     expect(messageCount).to.be.greaterThan(0);
 
@@ -422,7 +429,8 @@ describe('temba-simulator', () => {
     await simulator.updateComplete;
     await openSimulator(simulator);
 
-    // count initial messages
+    // count initial messages once the initial message has rendered
+    await waitForMessages(simulator);
     const initialCount = getMessageCount(simulator);
 
     // mock the resume response
@@ -543,7 +551,8 @@ describe('temba-simulator', () => {
     simulator.resetAttachmentIndices();
     await openSimulator(simulator);
 
-    // count initial messages
+    // count initial messages once the initial message has rendered
+    await waitForMessages(simulator);
     const initialCount = getMessageCount(simulator);
 
     // mock the response for image attachment
@@ -741,6 +750,9 @@ describe('temba-simulator', () => {
     await simulator.updateComplete;
     await openSimulator(simulator);
 
+    // wait for the initial message to render before sending
+    await waitForMessages(simulator);
+
     // send a message first
     mockSimulatorResume('Response to test message');
     const input = simulator.shadowRoot.querySelector(
@@ -755,7 +767,8 @@ describe('temba-simulator', () => {
     });
     input.dispatchEvent(enterEvent);
 
-    await delay(1000);
+    // wait for the sent message and response to render
+    await waitForMessages(simulator, 2);
     await simulator.updateComplete;
 
     // verify we have multiple messages
@@ -775,7 +788,15 @@ describe('temba-simulator', () => {
     expect(resetButton).to.exist;
     resetButton.click();
 
-    await delay(100);
+    // wait for the chat to be cleared and the initial message to re-render
+    await waitForCondition(
+      () => {
+        const count = getMessageCount(simulator);
+        return count > 0 && count < messageCountBefore;
+      },
+      40,
+      50
+    );
     await simulator.updateComplete;
 
     // verify messages are reset - should go back to just initial message
@@ -949,6 +970,7 @@ describe('temba-simulator', () => {
     await openSimulator(simulator);
 
     // verify events are displayed via chat component (field change + message = 2 events)
+    await waitForMessages(simulator);
     const messageCount = getMessageCount(simulator);
     expect(messageCount).to.be.greaterThan(0);
 


### PR DESCRIPTION
The test `temba-simulator > displays event info messages` was flaky on CI, failing with `AssertionError: expected 0 to be above 0` — it asserted the message count immediately after opening the simulator, but the chat component renders messages asynchronously (batched via `setTimeout`), so on slow runners the count could still be 0.

This adds a `waitForMessages()` helper that polls the message count via the existing `waitForCondition` utility (50ms intervals, 2s cap) and uses it everywhere a test counted messages right after opening the simulator:

- **displays event info messages** — waits before asserting (the flaky failure)
- **opens simulator window and starts flow** — same immediate-assert pattern
- **sends a text message** / **sends an image attachment** — captured `initialCount` immediately after open; a too-early read of 0 could let the later `> initialCount` assertion pass without the actual response rendering, so these now wait for the initial message first
- **resets simulation** — replaced the fixed `delay(1000)` after sending with a wait for ≥2 messages, and the `delay(100)` after reset with a poll for the count to drop below the pre-reset count

Verified with 5 consecutive full runs of the file (23/23 passing each time) in the containerized test environment.