### PR TITLE
Speed up and de-flake contact chat tests

### DIFF
--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -339,8 +339,11 @@ export class ContactChat extends ContactStoreElement {
         margin: 0.5em;
         border-radius: 999px;
         background: rgba(255, 255, 255, 0.75);
-        backdrop-filter: blur(8px);
-        -webkit-backdrop-filter: blur(8px);
+        /* tests set --test-backdrop-filter to none - the blur layer's
+           fractional offset rasterizes nondeterministically in headless
+           screenshots */
+        backdrop-filter: var(--test-backdrop-filter, blur(8px));
+        -webkit-backdrop-filter: var(--test-backdrop-filter, blur(8px));
         box-shadow: var(--shadow-1);
       }
 

--- a/test-assets/style.css
+++ b/test-assets/style.css
@@ -79,6 +79,7 @@
   --transition-speed: 0ms !important;
   --test-animation-duration: 0s !important;
   --test-animation-play-state: paused !important;
+  --test-backdrop-filter: none !important;
   caret-color: transparent;
 }
 

--- a/test/temba-contact-chat.test.ts
+++ b/test/temba-contact-chat.test.ts
@@ -27,6 +27,35 @@ let mockSocket: MockSocketProvider;
 let previousSocketProvider: SocketProvider;
 
 const TAG = 'temba-contact-chat';
+
+// polls with short real sleeps (so mocked HTTP roundtrips can complete) while
+// advancing fake timers, until the predicate holds
+const settle = async (
+  predicate: () => boolean,
+  tickMs = 0,
+  maxAttempts = 400
+) => {
+  for (let i = 0; i < maxAttempts; i++) {
+    await waitFor(10);
+    clock.tick(tickMs);
+    if (predicate()) {
+      return;
+    }
+  }
+  throw new Error('Condition not met while settling');
+};
+
+// the contact and its history have loaded and rendered
+const chatLoaded = (chat: ContactChat) => {
+  const inner = chat.shadowRoot.querySelector('temba-chat') as any;
+  return !!(
+    chat.currentContact &&
+    inner &&
+    !inner.fetching &&
+    inner.messageGroups.length > 0
+  );
+};
+
 const getContactChat = async (attrs: any = {}) => {
   attrs['endpoint'] = '/test-assets/contacts/';
   // add some sizes and styles to force our chat history to scroll
@@ -39,13 +68,9 @@ const getContactChat = async (attrs: any = {}) => {
     'display:flex;flex-direction:column;flex-grow:1;min-height:0;'
   )) as ContactChat;
 
-  // wait for contact data and history to load (real HTTP)
-  // and flush fake timers so addMessages' setTimeout(fn, 0) fires
-  for (let i = 0; i < 40; i++) {
-    await waitFor(50);
-    clock.tick(0);
-    if (chat.currentContact && chat.blockFetching) break;
-  }
+  // wait for contact data and history to load (real HTTP), flushing fake
+  // timers so addMessages' setTimeout(fn, 0) fires
+  await settle(() => chatLoaded(chat));
   return chat;
 };
 
@@ -63,6 +88,11 @@ describe('temba-contact-chat', () => {
   beforeEach(() => {
     mockedNow = mockNow('2021-03-31T00:31:00.000-00:00');
     clearMockPosts();
+
+    // the catch-up fetch on subscribe (after=) finds nothing new - without
+    // this it races the initial history fetch for the same page of events and
+    // the rendered grouping depends on which one lands first
+    mockGET(/\/contact\/chat\/contact-.*\?after=/, { events: [], next: null });
     mockGET(
       /\/contact\/chat\/contact-.*/,
       '/test-assets/contacts/history.json'
@@ -135,11 +165,7 @@ describe('temba-contact-chat', () => {
 
     // re-selecting the same ticket sets the same contact again
     chat.contact = 'contact-barack-archived';
-    for (let i = 0; i < 40; i++) {
-      await waitFor(50);
-      clock.tick(0);
-      if (chat.currentContact && chat.blockFetching) break;
-    }
+    await settle(() => chatLoaded(chat));
 
     expect(chat.currentContact, 'contact should reload').to.not.be.null;
     const inner = chat.shadowRoot.querySelector('temba-chat') as any;
@@ -337,8 +363,9 @@ describe('temba-contact-chat', () => {
     expect(searchToggle).to.exist;
     searchToggle.click();
 
-    // wait for search mode to activate and input to render
-    await waitFor(100);
+    // wait for search mode to activate, the input to render and the 150ms
+    // slide-in animation (real time) to finish
+    await waitFor(200);
     clock.tick(100);
     await chat.updateComplete;
 
@@ -357,22 +384,21 @@ describe('temba-contact-chat', () => {
     searchGo.click();
 
     // wait for the search API response and results to load
-    for (let i = 0; i < 30; i++) {
-      await waitFor(50);
-      clock.tick(50);
-      await chat.updateComplete;
-      if (chat.searchResults && chat.searchResults.length > 0) break;
-    }
+    await settle(
+      () => chat.searchResults && chat.searchResults.length > 0,
+      50,
+      30
+    );
 
     expect(chat.searchResults.length).to.equal(2);
     expect(chat.searchIndex).to.equal(0);
 
-    // wait for the navigation to settle (fade out + load + fade in)
-    for (let i = 0; i < 20; i++) {
-      await waitFor(50);
-      clock.tick(50);
-      await chat.updateComplete;
-    }
+    // wait for the navigation to settle (fade out + load + fade in), then
+    // give the 150ms opacity transition (real time) room to finish
+    const inner = chat.shadowRoot.querySelector('temba-chat') as any;
+    await settle(() => inner.style.opacity === '1', 50, 30);
+    await waitFor(200);
+    await chat.updateComplete;
 
     await assertScreenshot('contacts/chat-search-result', getClip(chat));
   });
@@ -396,7 +422,8 @@ describe('temba-contact-chat', () => {
       '.search-toggle'
     ) as HTMLElement;
     searchToggle.click();
-    await waitFor(100);
+    // include real time for the 150ms slide-in animation before screenshots
+    await waitFor(200);
     clock.tick(100);
     await chat.updateComplete;
 
@@ -412,12 +439,8 @@ describe('temba-contact-chat', () => {
     searchGo.click();
 
     // wait for the search API response
-    for (let i = 0; i < 30; i++) {
-      await waitFor(50);
-      clock.tick(50);
-      await chat.updateComplete;
-      if (chat.searchNoResults) break;
-    }
+    await settle(() => chat.searchNoResults, 50, 30);
+    await chat.updateComplete;
 
     expect(chat.searchResults.length).to.equal(0);
     expect(chat.searchNoResults).to.be.true;
@@ -455,17 +478,19 @@ describe('temba-contact-chat', () => {
     });
 
     // flush the render timeouts in addMessages
-    for (let i = 0; i < 10; i++) {
-      await waitFor(50);
-      clock.tick(50);
-      await chat.updateComplete;
-    }
+    const tembaChat = chat.shadowRoot.querySelector('temba-chat');
+    await settle(
+      () =>
+        !!tembaChat.shadowRoot.querySelector(`.row[data-uuid="${eventUUID}"]`),
+      50,
+      10
+    );
+    await chat.updateComplete;
 
     // the event was ingested and is now our newest seen event
     expect(chat.afterUUID).to.equal(eventUUID);
 
     // and it rendered in the chat
-    const tembaChat = chat.shadowRoot.querySelector('temba-chat');
     const row = tembaChat.shadowRoot.querySelector(
       `.row[data-uuid="${eventUUID}"]`
     );
@@ -484,7 +509,7 @@ describe('temba-contact-chat', () => {
       '.search-toggle'
     ) as HTMLElement;
     searchToggle.click();
-    await waitFor(100);
+    await waitFor(10);
     clock.tick(100);
     await chat.updateComplete;
 
@@ -568,11 +593,7 @@ describe('temba-contact-chat', () => {
     ]);
 
     // let the contact fetch land
-    for (let i = 0; i < 40; i++) {
-      await waitFor(50);
-      clock.tick(0);
-      if (chat.currentContact?.uuid === 'contact-barack-archived') break;
-    }
+    await settle(() => chat.currentContact?.uuid === 'contact-barack-archived');
     await chat.updateComplete;
 
     expect(mockSocket.activeChannels()).to.deep.equal([


### PR DESCRIPTION
The contact chat test file had grown to ~71s on its own, intermittently exceeding web-test-runner's 120s per-file timeout in CI.

## What changed

- **Replaced dead-end wait loops with converging polls.** The shared `getContactChat` helper (and several per-test loops) polled `blockFetching` with 50ms real sleeps, but that flag never becomes true with the mocked history (the fixture always has a `next` cursor and nothing triggers a follow-up fetch), so every test silently slept the full 2s budget. The loops now poll every 10ms against conditions that actually occur (contact + history rendered, search results present, etc.), converging in tens of milliseconds. The file now runs in ~5.5s.

- **Removed a fetch race the sleeps had been masking.** The catch-up fetch that runs on socket subscribe (`?after=`) raced the initial history fetch, and both were mocked to the same full history page, so the rendered grouping depended on which response landed first. The catch-up fetch is now mocked to return no events — matching what it returns in production — making rendering order-independent.

- **Fixed nondeterministic screenshot rendering of the flow footer chip.** The chip's `backdrop-filter: blur(8px)` compositing layer sits at a fractional pixel offset that headless Chromium rasterizes bimodally: identical DOM and layout, but the chip contents paint 1px lower in some runs — just enough to fail the pixel comparison. This likely predates these changes (it's plausibly why the first test in the file was already disabled as flaky). The blur is now `var(--test-backdrop-filter, blur(8px))` and the test stylesheet sets it to `none`, following the existing `--test-animation-*` pattern. The chip sits on plain white in all affected screenshots, so the committed goldens are unchanged.

- Screenshots taken right after opening search keep a short real-time wait, since the overlay's 150ms slide-in runs on the wall clock regardless of fake timers.

## Verification

- `test/temba-contact-chat.test.ts`: 14 consecutive green runs at ~5.5s each (previously ~71s with intermittent screenshot failures).
- Full suite: green twice, ~38s.
- No screenshot goldens were modified.