### PR TITLE
Add urn-label attribute to contact list

### DIFF
--- a/src/list/ContactList.ts
+++ b/src/list/ContactList.ts
@@ -49,11 +49,11 @@ export class ContactList extends ContentList<Contact> {
   @property({ type: String, attribute: 'fields-endpoint' })
   fieldsEndpoint = '/api/v2/fields.json';
 
-  /** Header for the primary URN column. Anonymous workspaces pass
-   * "Ref" since their endpoint serves contact refs in place of the
-   * (masked) URNs. */
-  @property({ type: String, attribute: 'urn-label' })
-  urnLabel = 'URN';
+  /** Anonymous workspaces mask URN values, so instead of the URN
+   * column the list shows each contact's ref (served as its own
+   * anon-only key by the endpoint). */
+  @property({ type: Boolean })
+  anon = false;
 
   @state()
   private featuredFields: any[] = [];
@@ -100,9 +100,9 @@ export class ContactList extends ContentList<Contact> {
   protected willUpdate(changes: PropertyValues): void {
     super.willUpdate(changes);
     // Rebuilding here (rather than in updated()) means a mounted
-    // urn-label is reflected in the first paint instead of flashing
-    // the default header for a frame.
-    if (changes.has('urnLabel')) {
+    // anon attribute is reflected in the first paint instead of
+    // flashing the URN header for a frame.
+    if (changes.has('anon')) {
       this.columns = this.buildColumns();
     }
   }
@@ -184,12 +184,19 @@ export class ContactList extends ContentList<Contact> {
         maxWidth: '260px',
         pinned: true
       },
-      {
-        key: 'urn',
-        label: this.urnLabel,
-        minWidth: '120px',
-        maxWidth: '190px'
-      },
+      this.anon
+        ? {
+            key: 'ref',
+            label: 'Ref',
+            minWidth: '120px',
+            maxWidth: '190px'
+          }
+        : {
+            key: 'urn',
+            label: 'URN',
+            minWidth: '120px',
+            maxWidth: '190px'
+          },
       ...fieldColumns,
       {
         key: 'last_seen_on',
@@ -248,6 +255,10 @@ export class ContactList extends ContentList<Contact> {
         return html`<span class="contact-urn"
           >${this.primaryUrn(item) || EMPTY}</span
         >`;
+      case 'ref':
+        return html`<span class="contact-urn"
+          >${(item as any).ref || EMPTY}</span
+        >`;
       case 'last_seen_on':
         return item.last_seen_on
           ? html`<temba-date
@@ -297,7 +308,11 @@ export class ContactList extends ContentList<Contact> {
 
   private primaryUrn(item: Contact): string {
     const i = item as any;
-    if (i.urn) return i.urn;
+    if (i.urn) {
+      // served as {scheme, display} by the list endpoint, but tolerate
+      // a plain string (e.g. the public API's urn field)
+      return typeof i.urn === 'string' ? i.urn : i.urn.display || '';
+    }
     if (Array.isArray(i.urns) && i.urns.length > 0) {
       const u = i.urns[0];
       return typeof u === 'string'

--- a/src/list/ContactList.ts
+++ b/src/list/ContactList.ts
@@ -97,13 +97,20 @@ export class ContactList extends ContentList<Contact> {
     super.disconnectedCallback();
   }
 
+  protected willUpdate(changes: PropertyValues): void {
+    super.willUpdate(changes);
+    // Rebuilding here (rather than in updated()) means a mounted
+    // urn-label is reflected in the first paint instead of flashing
+    // the default header for a frame.
+    if (changes.has('urnLabel')) {
+      this.columns = this.buildColumns();
+    }
+  }
+
   protected updated(changes: PropertyValues): void {
     super.updated(changes);
     if (changes.has('fieldsEndpoint') && this.fieldsEndpoint) {
       this.loadFields();
-    }
-    if (changes.has('urnLabel')) {
-      this.columns = this.buildColumns();
     }
   }
 

--- a/src/list/ContactList.ts
+++ b/src/list/ContactList.ts
@@ -49,6 +49,12 @@ export class ContactList extends ContentList<Contact> {
   @property({ type: String, attribute: 'fields-endpoint' })
   fieldsEndpoint = '/api/v2/fields.json';
 
+  /** Header for the primary URN column. Anonymous workspaces pass
+   * "Ref" since their endpoint serves contact refs in place of the
+   * (masked) URNs. */
+  @property({ type: String, attribute: 'urn-label' })
+  urnLabel = 'URN';
+
   @state()
   private featuredFields: any[] = [];
 
@@ -95,6 +101,9 @@ export class ContactList extends ContentList<Contact> {
     super.updated(changes);
     if (changes.has('fieldsEndpoint') && this.fieldsEndpoint) {
       this.loadFields();
+    }
+    if (changes.has('urnLabel')) {
+      this.columns = this.buildColumns();
     }
   }
 
@@ -170,7 +179,7 @@ export class ContactList extends ContentList<Contact> {
       },
       {
         key: 'urn',
-        label: 'URN',
+        label: this.urnLabel,
         minWidth: '120px',
         maxWidth: '190px'
       },

--- a/test-assets/content-list/contacts-anon.json
+++ b/test-assets/content-list/contacts-anon.json
@@ -1,0 +1,27 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "uuid": "c-101",
+      "name": "Amelia Chen",
+      "urn": { "scheme": "tel", "display": "********" },
+      "ref": "S5XQ4X",
+      "groups": [],
+      "fields": {},
+      "last_seen_on": "2026-05-11T13:42:11Z",
+      "created_on": "2024-03-12T09:15:00Z"
+    },
+    {
+      "uuid": "c-102",
+      "name": "",
+      "urn": { "scheme": "tel", "display": "********" },
+      "ref": "WG67XY",
+      "groups": [],
+      "fields": {},
+      "last_seen_on": null,
+      "created_on": "2023-11-01T17:30:00Z"
+    }
+  ]
+}

--- a/test-assets/content-list/contacts.json
+++ b/test-assets/content-list/contacts.json
@@ -6,7 +6,7 @@
     {
       "uuid": "c-001",
       "name": "Amelia Chen",
-      "urn": "+15551112222",
+      "urn": { "scheme": "tel", "display": "+15551112222" },
       "groups": [{ "name": "VIPs" }, { "name": "Subscribers" }],
       "fields": {
         "state": "California",
@@ -22,7 +22,7 @@
     {
       "uuid": "c-002",
       "name": "Ben Okonkwo",
-      "urn": "+15553334444",
+      "urn": { "scheme": "tel", "display": "+15553334444" },
       "groups": [{ "name": "Subscribers" }],
       "fields": {
         "state": "Lagos",
@@ -38,7 +38,7 @@
     {
       "uuid": "c-003",
       "name": "Camila Reyes",
-      "urn": "+15555556666",
+      "urn": { "scheme": "tel", "display": "+15555556666" },
       "groups": [],
       "fields": {
         "state": "Western Cape",
@@ -54,7 +54,7 @@
     {
       "uuid": "c-004",
       "name": "Daniel Park",
-      "urn": "+15557778888",
+      "urn": { "scheme": "tel", "display": "+15557778888" },
       "groups": [{ "name": "Birds" }],
       "fields": {
         "state": "Seoul",
@@ -70,7 +70,7 @@
     {
       "uuid": "c-005",
       "name": "Esther Mwangi",
-      "urn": "+15559990000",
+      "urn": { "scheme": "tel", "display": "+15559990000" },
       "groups": [{ "name": "Dogs" }, { "name": "VIPs" }],
       "fields": {
         "state": "Nairobi",
@@ -86,7 +86,7 @@
     {
       "uuid": "c-006",
       "name": "Farouk Ali",
-      "urn": "+15551110001",
+      "urn": { "scheme": "tel", "display": "+15551110001" },
       "groups": [{ "name": "Cats" }],
       "fields": {
         "state": "Cairo",
@@ -102,7 +102,7 @@
     {
       "uuid": "c-007",
       "name": "Greta Lindqvist",
-      "urn": "+15552223333",
+      "urn": { "scheme": "tel", "display": "+15552223333" },
       "groups": [],
       "fields": {
         "state": "Stockholm",

--- a/test/temba-content-list.test.ts
+++ b/test/temba-content-list.test.ts
@@ -529,6 +529,43 @@ describe('temba-content-list', () => {
     await assertScreenshot('content-list/contacts', getClip(list));
   });
 
+  it('renders a custom urn column header via urn-label', async () => {
+    await loadStore();
+    const list = (await getComponent(
+      'temba-contact-list',
+      {
+        endpoint: '/test-assets/content-list/contacts.json',
+        'urn-label': 'Ref'
+      },
+      '',
+      1100
+    )) as ContactList;
+    await new Promise<void>((resolve) => {
+      list.addEventListener(CustomEventType.FetchComplete, () => resolve(), {
+        once: true
+      });
+    });
+    await list.updateComplete;
+
+    // the attribute maps through to the urn column's label...
+    const urnColumn = (list as any).columns.find((c: any) => c.key === 'urn');
+    expect(urnColumn.label).to.equal('Ref');
+
+    // ...and the rendered header shows it in place of the default
+    const headers = Array.from(
+      list.shadowRoot!.querySelectorAll('th .label')
+    ).map((el) => el.textContent?.trim());
+    expect(headers).to.include('Ref');
+    expect(headers).to.not.include('URN');
+
+    // a later attribute change rebuilds the columns
+    list.setAttribute('urn-label', 'ID');
+    await list.updateComplete;
+    expect(
+      (list as any).columns.find((c: any) => c.key === 'urn').label
+    ).to.equal('ID');
+  });
+
   it('overlays the bulk action bar on the column header when rows are selected (screenshot)', async () => {
     await loadStore();
     const list = (await getComponent(

--- a/test/temba-content-list.test.ts
+++ b/test/temba-content-list.test.ts
@@ -529,13 +529,13 @@ describe('temba-content-list', () => {
     await assertScreenshot('content-list/contacts', getClip(list));
   });
 
-  it('renders a custom urn column header via urn-label', async () => {
+  it('shows a Ref column instead of URN for anon workspaces', async () => {
     await loadStore();
     const list = (await getComponent(
       'temba-contact-list',
       {
-        endpoint: '/test-assets/content-list/contacts.json',
-        'urn-label': 'Ref'
+        endpoint: '/test-assets/content-list/contacts-anon.json',
+        anon: true
       },
       '',
       1100
@@ -547,23 +547,45 @@ describe('temba-content-list', () => {
     });
     await list.updateComplete;
 
-    // the attribute maps through to the urn column's label...
-    const urnColumn = (list as any).columns.find((c: any) => c.key === 'urn');
-    expect(urnColumn.label).to.equal('Ref');
-
-    // ...and the rendered header shows it in place of the default
+    // the urn column is replaced by a ref column...
+    const colKeys = (list as any).columns.map((c: any) => c.key);
+    expect(colKeys).to.include('ref');
+    expect(colKeys).to.not.include('urn');
     const headers = Array.from(
       list.shadowRoot!.querySelectorAll('th .label')
     ).map((el) => el.textContent?.trim());
     expect(headers).to.include('Ref');
     expect(headers).to.not.include('URN');
 
-    // a later attribute change rebuilds the columns
-    list.setAttribute('urn-label', 'ID');
+    // ...whose cells render each contact's ref, not the masked urn
+    const cells = Array.from(
+      list.shadowRoot!.querySelectorAll('td .contact-urn')
+    ).map((el) => el.textContent?.trim());
+    expect(cells).to.include('S5XQ4X');
+    expect(cells).to.include('WG67XY');
+    expect(cells).to.not.include('********');
+  });
+
+  it('renders the primary urn display from the urn object', async () => {
+    await loadStore();
+    const list = (await getComponent(
+      'temba-contact-list',
+      { endpoint: '/test-assets/content-list/contacts.json' },
+      '',
+      1100
+    )) as ContactList;
+    await new Promise<void>((resolve) => {
+      list.addEventListener(CustomEventType.FetchComplete, () => resolve(), {
+        once: true
+      });
+    });
     await list.updateComplete;
-    expect(
-      (list as any).columns.find((c: any) => c.key === 'urn').label
-    ).to.equal('ID');
+
+    expect((list as any).columns.map((c: any) => c.key)).to.include('urn');
+    const cells = Array.from(
+      list.shadowRoot!.querySelectorAll('td .contact-urn')
+    ).map((el) => el.textContent?.trim());
+    expect(cells).to.include('+15551112222');
   });
 
   it('overlays the bulk action bar on the column header when rows are selected (screenshot)', async () => {


### PR DESCRIPTION
## Summary

Anonymous workspaces mask URN values, so a URN column is useless there — but contact refs are useful. `temba-contact-list` now takes a boolean `anon` attribute that swaps the URN column for a "Ref" column rendering each contact's `ref` (an anon-only key in the list endpoint payload). The primary URN is now read as a structured `{scheme, display}` object to match the endpoint's new shape.

## Changes

- **src/list/ContactList.ts** — new boolean `anon` property: when set, `buildColumns()` emits a `ref` column (labeled "Ref") in place of the `urn` column, and `renderCell` renders `item.ref` for it. Columns rebuild in `willUpdate()` so a mounted attribute is right on the first paint. `primaryUrn()` reads `urn.display` from the new object shape (plain strings still tolerated for the public API's urn field).
- **test-assets/content-list/contacts.json** — urns converted to the `{scheme, display}` object shape served by the endpoint.
- **test-assets/content-list/contacts-anon.json** — new fixture with masked urn displays and `ref` keys.
- **test/temba-content-list.test.ts** — new cases: anon mode renders the Ref column/header with ref values (and no URN column or masked values), and the default mode renders the urn display from the object shape.

## Test plan

- [x] `bun run test` content-list suite passes
- [x] Verified on a local anon workspace that the contact list shows refs under a "Ref" header