### PR TITLE
Use default() in webhook router operand so null webhook routes cleanly

### DIFF
--- a/src/flow/nodes/split_by_resthook.ts
+++ b/src/flow/nodes/split_by_resthook.ts
@@ -87,7 +87,10 @@ export const split_by_resthook: NodeConfig = {
     const existingCases = originalNode.router?.cases || [];
 
     const { router, exits } = createSuccessFailureRouter(
-      '@webhook.status',
+      // default() guards against @webhook being null (e.g. the call was
+      // skipped because the request exceeded the engine's size limit) which
+      // would otherwise produce lookup errors when the router evaluates
+      '@(default(webhook.status, 0))',
       {
         type: 'has_number_between',
         arguments: ['200', '299']

--- a/src/flow/nodes/split_by_webhook.ts
+++ b/src/flow/nodes/split_by_webhook.ts
@@ -248,7 +248,10 @@ export const split_by_webhook: NodeConfig = {
     const existingCases = originalNode.router?.cases || [];
 
     const { router, exits } = createSuccessFailureRouter(
-      '@webhook.status',
+      // default() guards against @webhook being null (e.g. the call was
+      // skipped because the request exceeded the engine's size limit) which
+      // would otherwise produce lookup errors when the router evaluates
+      '@(default(webhook.status, 0))',
       {
         type: 'has_number_between',
         arguments: ['200', '299']

--- a/test/nodes/split_by_resthook.test.ts
+++ b/test/nodes/split_by_resthook.test.ts
@@ -110,7 +110,9 @@ describe('temba-split-by-resthook', () => {
     expect(action.type).to.equal('call_resthook');
 
     expect(resultNode.router!.type).to.equal('switch');
-    expect(resultNode.router!.operand).to.equal('@webhook.status');
+    expect(resultNode.router!.operand).to.equal(
+      '@(default(webhook.status, 0))'
+    );
     expect(resultNode.router!.categories).to.have.lengthOf(2); // Success + Failure
     expect(resultNode.exits).to.have.lengthOf(2); // Success + Failure
 
@@ -276,7 +278,9 @@ describe('temba-split-by-resthook', () => {
     const resultNode = split_by_resthook.fromFormData!(formData, originalNode);
 
     // operand and case should be normalised to the canonical shape
-    expect(resultNode.router!.operand).to.equal('@webhook.status');
+    expect(resultNode.router!.operand).to.equal(
+      '@(default(webhook.status, 0))'
+    );
     expect(resultNode.router!.cases).to.have.lengthOf(1);
     expect(resultNode.router!.cases![0].type).to.equal('has_number_between');
     expect(resultNode.router!.cases![0].arguments).to.deep.equal([

--- a/test/nodes/split_by_webhook.test.ts
+++ b/test/nodes/split_by_webhook.test.ts
@@ -74,7 +74,87 @@ describe('split_by_webhook node config', () => {
       // Should have Success/Failure router
       expect(resultNode.router).to.exist;
       expect(resultNode.router!.type).to.equal('switch');
+      // operand uses default() so a null @webhook (e.g. skipped call) routes
+      // to Failure without evaluation errors
+      expect(resultNode.router!.operand).to.equal(
+        '@(default(webhook.status, 0))'
+      );
       expect(resultNode.exits).to.have.lengthOf(2);
+    });
+
+    it('should upgrade legacy @webhook.status operand on re-save', () => {
+      const originalNode: Node = {
+        uuid: 'test-node',
+        actions: [
+          {
+            type: 'call_webhook',
+            uuid: 'existing-action-uuid',
+            method: 'GET',
+            url: 'https://example.com/api'
+          } as CallWebhook
+        ],
+        router: {
+          type: 'switch',
+          cases: [
+            {
+              uuid: 'existing-case-uuid',
+              type: 'has_number_between',
+              arguments: ['200', '299'],
+              category_uuid: 'existing-success-uuid'
+            }
+          ],
+          categories: [
+            {
+              uuid: 'existing-success-uuid',
+              name: 'Success',
+              exit_uuid: 'existing-success-exit-uuid'
+            },
+            {
+              uuid: 'existing-failure-uuid',
+              name: 'Failure',
+              exit_uuid: 'existing-failure-exit-uuid'
+            }
+          ],
+          default_category_uuid: 'existing-failure-uuid',
+          operand: '@webhook.status'
+        } as any,
+        exits: [
+          {
+            uuid: 'existing-success-exit-uuid',
+            destination_uuid: 'some-node-uuid'
+          },
+          {
+            uuid: 'existing-failure-exit-uuid',
+            destination_uuid: 'another-node-uuid'
+          }
+        ]
+      };
+
+      const formData = {
+        uuid: 'test-node',
+        method: [{ value: 'GET', name: 'GET' }],
+        url: 'https://example.com/api',
+        headers: [],
+        body: ''
+      };
+
+      const resultNode = split_by_webhook.fromFormData!(formData, originalNode);
+
+      // operand should be upgraded to the null-safe form
+      expect(resultNode.router!.operand).to.equal(
+        '@(default(webhook.status, 0))'
+      );
+
+      // everything else should be preserved
+      expect(resultNode.actions![0].uuid).to.equal('existing-action-uuid');
+      expect(resultNode.router!.cases![0].uuid).to.equal('existing-case-uuid');
+      expect(resultNode.router!.categories![0].uuid).to.equal(
+        'existing-success-uuid'
+      );
+      expect(resultNode.exits![0].destination_uuid).to.equal('some-node-uuid');
+      expect(resultNode.exits![1].destination_uuid).to.equal(
+        'another-node-uuid'
+      );
     });
 
     it('should transform from form data to flow definition (POST)', () => {


### PR DESCRIPTION
## What changed

The router generated for Call Webhook and Call Resthook nodes now uses `@(default(webhook.status, 0))` as its operand instead of `@webhook.status`.

## Why

When the engine skips a webhook call (e.g. the evaluated request exceeds the request size limit), `@webhook` is null and the old operand produced noisy error events in the run: `Error calling test has_number_between(...): null doesn't support lookups` and `null doesn't support lookups`. With `default()`, the operand evaluates to `0` with no errors (verified against goflow v0.284.3) and the router cleanly takes the Failure category.

## Notes for reviewers

- No migration code was needed for existing nodes: node type detection doesn't depend on the operand, and `fromFormData` always regenerates the router (preserving category/case/exit UUIDs and destinations), so nodes with the old operand load fine and upgrade automatically on re-save.
- Added a test covering that upgrade path for webhook nodes; the existing resthook legacy-normalisation test now covers the same for resthooks.