### PR TITLE
Draw chat popup arrow with CSS clip-path instead of a glyph

### DIFF
--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -1027,19 +1027,28 @@ export class Chat extends RapidElement {
 
       .popup .arrow {
         z-index: 1;
-        text-shadow: 0px 3px 3px rgba(0, 0, 0, 0.1);
         position: absolute;
-        justify-content: center;
-        text-align: center;
-        /* fixed so the arrow matches the event tips' 18px arrows
-           rather than tracking the popup's 11px text */
-        font-size: 18px;
-        /* same fat, stubby squash as the temba-tip arrows, pushed out
-           far enough to bridge the gap below while the base stays
-           buried under the popup */
-        transform: translateY(0.8em) scale(1.15, 0.6);
-        color: #fff;
-        bottom: 0;
+        bottom: -9px;
+        width: 16px;
+        height: 11px;
+        /* the shadow is on this wrapper rather than the clipped
+           shape below so it hugs the triangle's slanted edges */
+        filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.12));
+      }
+
+      /* a CSS-drawn tail rather than a ▼ glyph — glyph ink lands
+         wherever the platform font puts it, so the tip rendered
+         hidden on some systems and overshot on others. This triangle
+         is deterministic: its top 2px lie on the popup body hiding
+         the border where the tail meets it, the rest bridges the gap
+         below so the tip visibly laps over the top of the bubble */
+      .popup .arrow::after {
+        content: '';
+        display: block;
+        width: 100%;
+        height: 100%;
+        background: #fff;
+        clip-path: polygon(0 0, 100% 0, 50% 100%);
       }
 
       .bubble-wrap:hover .popup {
@@ -1924,7 +1933,7 @@ export class Chat extends RapidElement {
               value="${event.created_on.toISOString()}"
               display="datetime"
             ></temba-date>
-            <div class="arrow">▼</div>
+            <div class="arrow"></div>
           </div>`
         : null}
       <div class="bubble">
@@ -2025,7 +2034,7 @@ export class Chat extends RapidElement {
                   ></a>`
                 : null}
 
-              <div class="arrow">▼</div>
+              <div class="arrow"></div>
             </div>`
           : null}
         ${isDeleted


### PR DESCRIPTION
## Summary

Replaces the chat popup tooltip's `▼` text-glyph arrow with a CSS-drawn triangle. The glyph's ink position depended on platform font metrics, so the arrow tip rendered hidden on some systems and overshot the popup on others; the drawn triangle is deterministic across platforms.

## Changes

- **src/display/Chat.ts**
  - `.popup .arrow` is now a fixed 16×11px wrapper positioned at `bottom: -9px`, with a `drop-shadow` filter. The shadow lives on the wrapper (rather than the clipped shape) so it hugs the triangle's slanted edges instead of boxing the element.
  - Added `.popup .arrow::after`, which draws the tail via `clip-path: polygon(0 0, 100% 0, 50% 100%)`. Its top 2px sit on the popup body to hide the border where the tail meets it; the rest bridges the gap below so the tip laps over the top of the message bubble.
  - Both `<div class="arrow">▼</div>` render sites are now empty `<div class="arrow"></div>` elements (also removes a stray glyph character from the popup's text content).

## Review notes

Pre-PR review passed on the first cycle with no findings above Low severity. Noted for possible follow-up: `temba-tip` still uses glyph-based arrows with the same font-metric fragility this fixes in the chat popup, and the popup gap/border constants that `bottom: -9px` depends on are only recorded in the comment.

## Test plan

- [x] Full test suite (including screenshot comparisons) passes in the components container: 2142 passed, 0 failed, 5 skipped
- [x] Format, build, and locale regeneration produce no diffs