### PR TITLE
Allow resizing the chat in the card layout

### DIFF
--- a/src/layout/CardLayout.ts
+++ b/src/layout/CardLayout.ts
@@ -23,13 +23,15 @@ export interface CardSettings {
  * Panels are declared as slotted temba-cards with an id; the main view goes
  * in slot="main".
  *
- * The layout can persist card order and collapsed state itself: seed it
- * with `settings` and point `settings-endpoint` at a POST endpoint that
- * merges top-level keys (rapidpro's user settings view). Saves are
- * debounced and posted as `{[settingsKey]: {order, collapsed}}`. The saved
- * lists are the union across pages — a page rendering only a subset of the
- * cards merges its relative order into the full saved order rather than
- * clobbering the position of cards it doesn't show.
+ * The layout can persist card order, collapsed state and the chosen main
+ * width itself: seed it with `settings` and point `settings-endpoint` at a
+ * POST endpoint that merges top-level keys (rapidpro's user settings view).
+ * Saves are debounced and posted as `{[settingsKey]: {order, collapsed,
+ * width}}`. The saved state is the union across pages — a page rendering
+ * only a subset of the cards merges its relative order into the full saved
+ * order rather than clobbering the position of cards it doesn't show, and a
+ * page that never sets a width re-posts the saved one rather than clearing
+ * it.
  */
 export class CardLayout extends RapidElement {
   static get styles() {
@@ -197,9 +199,12 @@ export class CardLayout extends RapidElement {
   }
 
   /** The main width the layout actually renders. A width saved on a page
-   * with a lower floor still gets this page's minimum, but the floor is
-   * never written back into `mainWidth` — that would clobber the user's
-   * chosen width for the page it was chosen on. */
+   * with a lower floor still gets this page's minimum, but merely
+   * rendering at that floor never writes it back into `mainWidth` — that
+   * would clobber the user's chosen width for the page it was chosen on.
+   * An explicit resize here (drag or arrow key) does step from the floor
+   * and does commit: the user is choosing a width on this page, so this
+   * page's minimum is the right thing to start from. */
   private getEffectiveMainWidth(): number {
     return this.mainWidth > 0 ? Math.max(this.mainWidth, this.mainMinWidth) : 0;
   }
@@ -281,6 +286,10 @@ export class CardLayout extends RapidElement {
   // pages show, so a save from this page can't clobber their state
   private savedOrder: string[] = [];
   private savedCollapsed: string[] = [];
+  // the last width we know is stored — a page where the user never sets a
+  // width re-posts this rather than dropping the key and clearing the
+  // width chosen on another page
+  private savedWidth = 0;
 
   // cards whose collapsed state has been seeded from settings — seed once
   // so a later mutation can't undo the user's toggles
@@ -354,9 +363,13 @@ export class CardLayout extends RapidElement {
       this.hostWidth = width;
       this.narrow = width < this.getFlipWidth();
       this.compactTabs = width < CardLayout.COMPACT_TABS_WIDTH;
-      // keep the separator's announced width current without measuring
-      // on every render
-      this.mainPaneWidth = this.getMainPaneWidth();
+      // keep the separator's announced width current without measuring on
+      // every render — only while the width is automatic, since a chosen
+      // width is announced from state and measuring here would force a
+      // layout on every frame of a drag
+      if (this.mainWidth === 0) {
+        this.mainPaneWidth = this.getMainPaneWidth();
+      }
     }
   }
 
@@ -394,12 +407,16 @@ export class CardLayout extends RapidElement {
   // the chosen width when the drag began, restored if it is cancelled
   private dragStartMainWidth = 0;
   // whether the pointer has actually travelled — a click on the handle
-  // (a trackpad tap can fire a zero-delta pointermove) must not commit a
-  // width, which would also turn an automatic width into a chosen one
+  // (a trackpad tap can fire a pointermove with a pixel or two of drift)
+  // must not commit a width, which would also turn an automatic width
+  // into a chosen one
   private dragMoved = false;
   // whether the pointer moved far enough to change the width — a click on
   // the handle shouldn't announce a resize or post settings
   private dragChanged = false;
+  // a keyboard step is pending — if it flips the mode, focus follows the
+  // rebuilt handle
+  private refocusHandle = false;
   private previousBodyUserSelect = '';
   private previousBodyCursor = '';
 
@@ -408,6 +425,10 @@ export class CardLayout extends RapidElement {
   // to tabs — and come the complementary fraction back across it before
   // the cards pop back out
   static FLIP_DRAG_RATIO = 0.75;
+
+  // travel (px) before a press counts as a drag — a click on the handle
+  // carries a pixel or two of drift, which must not commit a width
+  static DRAG_THRESHOLD = 3;
 
   private handleResizeStart = (event: PointerEvent) => {
     if (event.pointerType === 'mouse' && event.button !== 0) return;
@@ -438,14 +459,20 @@ export class CardLayout extends RapidElement {
 
   private handleResizeMove = (event: PointerEvent) => {
     event.preventDefault();
-    if (event.clientX !== this.dragStartX) {
+    if (
+      Math.abs(event.clientX - this.dragStartX) >= CardLayout.DRAG_THRESHOLD
+    ) {
       this.dragMoved = true;
     }
-    // a press with no travel isn't a resize — leave the width alone (in
-    // particular, don't turn an automatic width into a chosen one)
+    // a press that hasn't really travelled isn't a resize — leave the
+    // width alone (in particular, don't turn an automatic width into a
+    // chosen one, which would also move the flip point for good)
     if (!this.dragMoved) {
       return;
     }
+    // deliberately the live width rather than the lagged `hostWidth`: mid
+    // window-resize the pointer is working against the layout as it is
+    // now, not as the resize observer last saw it
     const width = this.offsetWidth;
     // the widest chat that still leaves the cards their footprint
     const max = width - CardLayout.COLUMN_FOOTPRINT;
@@ -489,7 +516,8 @@ export class CardLayout extends RapidElement {
   };
 
   /** A cancelled gesture (the browser or OS taking the pointer away) is
-   * not a resize — put the width back where the drag found it. */
+   * not a resize — put the width back where the drag found it. This is a
+   * deliberate divergence from ContentList, which commits on cancel. */
   private handleResizeCancel = () => {
     const changed = this.dragChanged;
     this.releaseResize();
@@ -508,7 +536,10 @@ export class CardLayout extends RapidElement {
     event.stopPropagation();
     const step = event.shiftKey ? 25 : 10;
     const direction = event.key === 'ArrowRight' ? 1 : -1;
-    const current = this.getMainPaneWidth();
+    // step from state when a width is chosen — a measurement here would
+    // still read the previous step until its render has flushed, folding
+    // rapid same-task presses into one
+    const current = this.getEffectiveMainWidth() || this.getMainPaneWidth();
     const width = this.clampResizeWidth(current + direction * step);
 
     // in tab view the pane already spans more than the widest card-mode
@@ -520,19 +551,13 @@ export class CardLayout extends RapidElement {
 
     if (width !== this.mainWidth) {
       this.mainWidth = width;
+      // if this press flips the mode, the handle is rebuilt from the
+      // other template and focus falls to the body — move it to the new
+      // handle so the keyboard user isn't stranded
+      this.refocusHandle = true;
       this.fireCustomEvent(CustomEventType.Resized, { width });
       this.scheduleSave();
     }
-  };
-
-  /** The template binding keeps aria-valuenow live from the last measured
-   * pane width; refine it with a fresh measurement when the separator
-   * takes focus and screen readers are about to announce it. */
-  private handleResizeFocus = (event: FocusEvent) => {
-    (event.currentTarget as HTMLElement).setAttribute(
-      'aria-valuenow',
-      `${Math.round(this.clampResizeWidth(this.getMainPaneWidth()))}`
-    );
   };
 
   private releaseResize() {
@@ -656,8 +681,12 @@ export class CardLayout extends RapidElement {
       order: this.savedOrder,
       collapsed: this.savedCollapsed
     };
-    if (this.mainWidth > 0) {
-      settings.width = Math.round(this.mainWidth);
+    // an automatic width on this page doesn't mean "no width anywhere" —
+    // carry the stored one through so a save from here doesn't clear it
+    const width = Math.round(this.mainWidth) || this.savedWidth;
+    if (width > 0) {
+      settings.width = width;
+      this.savedWidth = width;
     }
 
     postJSON(this.settingsEndpoint, {
@@ -677,8 +706,9 @@ export class CardLayout extends RapidElement {
       if (this.savedOrder.length > 0) {
         this.order = this.savedOrder;
       }
-      if (this.settings.width > 0) {
-        this.mainWidth = this.settings.width;
+      this.savedWidth = this.settings.width > 0 ? this.settings.width : 0;
+      if (this.savedWidth > 0) {
+        this.mainWidth = this.savedWidth;
       }
       this.applyCollapsed();
     }
@@ -705,6 +735,14 @@ export class CardLayout extends RapidElement {
     if (changes.has('order')) {
       this.applyOrder();
     }
+    if (this.refocusHandle) {
+      this.refocusHandle = false;
+      if (changes.has('narrow')) {
+        (
+          this.shadowRoot.querySelector('.resize-handle') as HTMLElement
+        )?.focus();
+      }
+    }
   }
 
   private renderResizeHandle(edge = false): TemplateResult | null {
@@ -727,7 +765,6 @@ export class CardLayout extends RapidElement {
         tabindex="0"
         @pointerdown=${this.handleResizeStart}
         @keydown=${this.handleResizeKeydown}
-        @focus=${this.handleResizeFocus}
       >
         <div class="grip"></div>
       </div>

--- a/src/layout/CardLayout.ts
+++ b/src/layout/CardLayout.ts
@@ -511,11 +511,6 @@ export class CardLayout extends RapidElement {
     const current = this.getMainPaneWidth();
     const width = this.clampResizeWidth(current + direction * step);
 
-    (event.currentTarget as HTMLElement).setAttribute(
-      'aria-valuenow',
-      `${Math.round(width)}`
-    );
-
     // in tab view the pane already spans more than the widest card-mode
     // fit, so there is nothing to grow into — growing must not shrink the
     // pane (and pop the cards back out) as a side effect of the clamp
@@ -725,7 +720,7 @@ export class CardLayout extends RapidElement {
         })}
         role="separator"
         aria-orientation="vertical"
-        aria-label="Resize chat"
+        aria-label="Resize ${this.mainName}"
         aria-valuemin=${this.mainMinWidth}
         aria-valuemax=${this.getResizeMax()}
         aria-valuenow=${this.getAnnouncedWidth()}

--- a/src/layout/CardLayout.ts
+++ b/src/layout/CardLayout.ts
@@ -73,7 +73,8 @@ export class CardLayout extends RapidElement {
 
       /* drag handle for resizing the main view — in card view it rides the
          gap between the main view and the card column, in tab view (.edge)
-         it rides the layout's right inset */
+         it rides the layout's right inset. touch-action keeps the browser
+         from claiming the drag as a scroll gesture on touch pointers. */
       .resize-handle {
         position: absolute;
         top: 0;
@@ -84,6 +85,8 @@ export class CardLayout extends RapidElement {
         z-index: 1;
         display: flex;
         justify-content: center;
+        touch-action: none;
+        outline: none;
       }
 
       .resize-handle.edge {
@@ -97,6 +100,7 @@ export class CardLayout extends RapidElement {
       }
 
       .resize-handle:hover .grip,
+      .resize-handle:focus-visible .grip,
       .resize-handle.active .grip {
         background: rgba(0, 0, 0, 0.08);
       }
@@ -168,11 +172,11 @@ export class CardLayout extends RapidElement {
   mainWidth = 0;
 
   // a drag on the resize handle is in progress
-  @property({ type: Boolean })
+  @property({ type: Boolean, attribute: false })
   resizing = false;
 
-  // last observed layout width — the tab view uses it to decide whether a
-  // resize could reach card mode at all before offering the handle
+  // last observed layout width — the handles use it to decide whether a
+  // resize could reach card mode at all before offering themselves
   @property({ type: Number, attribute: false })
   hostWidth = 0;
 
@@ -183,13 +187,37 @@ export class CardLayout extends RapidElement {
       : this.mainMinWidth + CardLayout.COLUMN_FOOTPRINT;
   }
 
+  /** The main width the layout actually renders. A width saved on a page
+   * with a lower floor still gets this page's minimum, but the floor is
+   * never written back into `mainWidth` — that would clobber the user's
+   * chosen width for the page it was chosen on. */
+  private getEffectiveMainWidth(): number {
+    return this.mainWidth > 0 ? Math.max(this.mainWidth, this.mainMinWidth) : 0;
+  }
+
   private getFlipWidth(): number {
     const min = this.getMinFlipWidth();
+    const width = this.getEffectiveMainWidth();
     // a user-sized main view raises the bar — the cards keep their
     // footprint rather than being squeezed beside it
-    return this.mainWidth > 0
-      ? Math.max(min, this.mainWidth + CardLayout.COLUMN_FOOTPRINT)
-      : min;
+    return width > 0 ? Math.max(min, width + CardLayout.COLUMN_FOOTPRINT) : min;
+  }
+
+  /** Whether the layout is wide enough for a resize to land anywhere
+   * useful: the main view at its minimum beside the card column. Narrower
+   * than that a drag can only strand the layout in tab mode — the flip
+   * width it would need exceeds the layout — so no handle is offered.
+   * Note this is deliberately independent of the breakpoint: an explicit
+   * low breakpoint says "prefer cards", it doesn't make dragging work. */
+  private isResizable(): boolean {
+    return this.hostWidth >= this.mainMinWidth + CardLayout.COLUMN_FOOTPRINT;
+  }
+
+  /** Width the main view occupies now — in tab view it fills the layout,
+   * so a resize from there starts at the full width. */
+  private getMainPaneWidth(): number {
+    const main = this.shadowRoot?.querySelector('.main') as HTMLElement;
+    return main ? main.offsetWidth : this.offsetWidth;
   }
 
   @property({ type: Array })
@@ -321,6 +349,11 @@ export class CardLayout extends RapidElement {
 
   private dragStartX = 0;
   private dragStartWidth = 0;
+  // whether the pointer moved far enough to change the width — a click on
+  // the handle shouldn't announce a resize or post settings
+  private dragChanged = false;
+  private previousBodyUserSelect = '';
+  private previousBodyCursor = '';
 
   // dragging past the widest fit pins the chat there; the pointer must
   // then travel this fraction of the card column before the layout flips
@@ -328,22 +361,33 @@ export class CardLayout extends RapidElement {
   // the cards pop back out
   static FLIP_DRAG_RATIO = 0.75;
 
-  private handleResizeStart = (event: MouseEvent) => {
+  private handleResizeStart = (event: PointerEvent) => {
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+    // a second pointer replaces rather than overlaps an active drag, so
+    // the captured body styles stay the ones we found before any drag
+    this.releaseResize();
     event.preventDefault();
     // in tab view the main pane fills the layout, so the drag starts from
     // the full width — the cards return only once the pointer has come
     // most of the way back across the column they will occupy
-    const main = this.shadowRoot.querySelector('.main') as HTMLElement;
     this.dragStartX = event.clientX;
-    this.dragStartWidth = main ? main.offsetWidth : this.offsetWidth;
+    this.dragStartWidth = this.getMainPaneWidth();
+    this.dragChanged = false;
     this.resizing = true;
+    this.previousBodyUserSelect = document.body.style.userSelect;
+    this.previousBodyCursor = document.body.style.cursor;
     document.body.style.userSelect = 'none';
     document.body.style.cursor = 'col-resize';
-    window.addEventListener('mousemove', this.handleResizeMove);
-    window.addEventListener('mouseup', this.handleResizeEnd);
+    // deliberately no setPointerCapture: a flip between card and tab mode
+    // mid-drag tears this handle out of the shadow DOM, which would end
+    // the capture and kill the drag — window listeners survive the flip
+    window.addEventListener('pointermove', this.handleResizeMove);
+    window.addEventListener('pointerup', this.handleResizeEnd);
+    window.addEventListener('pointercancel', this.handleResizeEnd);
   };
 
-  private handleResizeMove = (event: MouseEvent) => {
+  private handleResizeMove = (event: PointerEvent) => {
+    event.preventDefault();
     const width = this.offsetWidth;
     // the widest chat that still leaves the cards their footprint
     const max = width - CardLayout.COLUMN_FOOTPRINT;
@@ -359,24 +403,67 @@ export class CardLayout extends RapidElement {
 
     const flipZone = CardLayout.COLUMN_FOOTPRINT * CardLayout.FLIP_DRAG_RATIO;
     const returnZone = CardLayout.COLUMN_FOOTPRINT - flipZone;
+    let next: number;
     if (this.narrow) {
       // in tabs the cards return only once the pointer has dragged far
       // enough back; until then the width keeps tracking the pointer so
       // a release leaves tab mode in place
-      this.mainWidth =
-        dragged < max + returnZone ? Math.min(dragged, max) : dragged;
+      next = dragged < max + returnZone ? Math.min(dragged, max) : dragged;
     } else {
       // in cards the chat stops growing at the widest fit — the flip to
       // tabs waits until the pointer has crossed most of the card column
-      this.mainWidth =
-        dragged > max + flipZone ? dragged : Math.min(dragged, max);
+      next = dragged > max + flipZone ? dragged : Math.min(dragged, max);
+    }
+
+    if (next !== this.mainWidth) {
+      this.mainWidth = next;
+      this.dragChanged = true;
     }
   };
 
   private handleResizeEnd = () => {
+    const changed = this.dragChanged;
     this.releaseResize();
-    this.fireCustomEvent(CustomEventType.Resized, { width: this.mainWidth });
-    this.scheduleSave();
+    if (changed) {
+      this.fireCustomEvent(CustomEventType.Resized, { width: this.mainWidth });
+      this.scheduleSave();
+    }
+  };
+
+  /** Arrow keys resize in 10px steps (25px with Shift), the keyboard
+   * equivalent of dragging the separator. There is no hysteresis here —
+   * the width simply clamps to what fits, so a press from tab mode lands
+   * in card mode at the widest width the cards leave room for. */
+  private handleResizeKeydown = (event: KeyboardEvent) => {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+    event.preventDefault();
+    event.stopPropagation();
+    const step = event.shiftKey ? 25 : 10;
+    const direction = event.key === 'ArrowRight' ? 1 : -1;
+    const max = this.hostWidth - CardLayout.COLUMN_FOOTPRINT;
+    const width = Math.min(
+      Math.max(this.getMainPaneWidth() + direction * step, this.mainMinWidth),
+      max
+    );
+
+    (event.currentTarget as HTMLElement).setAttribute(
+      'aria-valuenow',
+      `${Math.round(width)}`
+    );
+    if (width !== this.mainWidth) {
+      this.mainWidth = width;
+      this.scheduleSave();
+    }
+  };
+
+  /** The rendered main width isn't known at render time (it may be the
+   * flex basis rather than a set width), so measure it when the separator
+   * takes focus and screen readers are about to announce it. */
+  private handleResizeFocus = (event: FocusEvent) => {
+    (event.currentTarget as HTMLElement).setAttribute(
+      'aria-valuenow',
+      `${Math.round(this.getMainPaneWidth())}`
+    );
   };
 
   private releaseResize() {
@@ -384,10 +471,11 @@ export class CardLayout extends RapidElement {
       return;
     }
     this.resizing = false;
-    document.body.style.userSelect = '';
-    document.body.style.cursor = '';
-    window.removeEventListener('mousemove', this.handleResizeMove);
-    window.removeEventListener('mouseup', this.handleResizeEnd);
+    document.body.style.userSelect = this.previousBodyUserSelect;
+    document.body.style.cursor = this.previousBodyCursor;
+    window.removeEventListener('pointermove', this.handleResizeMove);
+    window.removeEventListener('pointerup', this.handleResizeEnd);
+    window.removeEventListener('pointercancel', this.handleResizeEnd);
   }
 
   /**
@@ -527,10 +615,10 @@ export class CardLayout extends RapidElement {
     }
     if (changes.has('mainWidth')) {
       // an undersized saved width (e.g. saved on a page with a lower
-      // floor) gets the same floor as a drag
-      if (this.mainWidth > 0) {
-        this.mainWidth = Math.max(this.mainWidth, this.mainMinWidth);
-        this.style.setProperty('--main-width', `${this.mainWidth}px`);
+      // floor) renders at this page's floor without being rewritten
+      const width = this.getEffectiveMainWidth();
+      if (width > 0) {
+        this.style.setProperty('--main-width', `${width}px`);
       } else {
         this.style.removeProperty('--main-width');
       }
@@ -550,7 +638,10 @@ export class CardLayout extends RapidElement {
     }
   }
 
-  private renderResizeHandle(edge = false): TemplateResult {
+  private renderResizeHandle(edge = false): TemplateResult | null {
+    if (!this.isResizable()) {
+      return null;
+    }
     return html`
       <div
         class=${getClasses({
@@ -558,7 +649,15 @@ export class CardLayout extends RapidElement {
           edge,
           active: this.resizing
         })}
-        @mousedown=${this.handleResizeStart}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize chat"
+        aria-valuemin=${this.mainMinWidth}
+        aria-valuemax=${this.hostWidth - CardLayout.COLUMN_FOOTPRINT}
+        tabindex="0"
+        @pointerdown=${this.handleResizeStart}
+        @keydown=${this.handleResizeKeydown}
+        @focus=${this.handleResizeFocus}
       >
         <div class="grip"></div>
       </div>
@@ -567,9 +666,6 @@ export class CardLayout extends RapidElement {
 
   public render(): TemplateResult {
     if (this.narrow) {
-      // resizing out of tab mode only works when the layout is wide enough
-      // to reach card mode at some main-view width — otherwise no handle
-      const resizable = this.hostWidth >= this.getMinFlipWidth();
       return html`
         <temba-tabs .focusedName=${this.compactTabs}>
           <temba-tab name=${this.mainName} icon=${this.mainIcon}>
@@ -588,7 +684,7 @@ export class CardLayout extends RapidElement {
             `
           )}
         </temba-tabs>
-        ${resizable ? this.renderResizeHandle(true) : null}
+        ${this.renderResizeHandle(true)}
       `;
     }
 

--- a/src/layout/CardLayout.ts
+++ b/src/layout/CardLayout.ts
@@ -31,7 +31,8 @@ export interface CardSettings {
  * only a subset of the cards merges its relative order into the full saved
  * order rather than clobbering the position of cards it doesn't show, and a
  * page that never sets a width re-posts the saved one rather than clearing
- * it.
+ * it. Double-clicking the resize handle returns to the automatic width and
+ * clears the saved one.
  */
 export class CardLayout extends RapidElement {
   static get styles() {
@@ -560,6 +561,22 @@ export class CardLayout extends RapidElement {
     }
   };
 
+  /** Double-click returns the layout to the automatic width — the one
+   * escape hatch from a chosen width. An explicit reset also clears the
+   * stored width (unlike a passive save from a page rendering at the
+   * automatic width, which carries the stored value through). The two
+   * clicks that make up the double-click commit nothing on their own —
+   * a press with no travel is not a resize. */
+  private handleResizeReset = () => {
+    if (this.mainWidth === 0 && this.savedWidth === 0) {
+      return;
+    }
+    this.mainWidth = 0;
+    this.savedWidth = 0;
+    this.fireCustomEvent(CustomEventType.Resized, { width: 0 });
+    this.scheduleSave();
+  };
+
   private releaseResize() {
     if (!this.resizing) {
       return;
@@ -764,6 +781,7 @@ export class CardLayout extends RapidElement {
         aria-valuenow=${this.getAnnouncedWidth()}
         tabindex="0"
         @pointerdown=${this.handleResizeStart}
+        @dblclick=${this.handleResizeReset}
         @keydown=${this.handleResizeKeydown}
       >
         <div class="grip"></div>

--- a/src/layout/CardLayout.ts
+++ b/src/layout/CardLayout.ts
@@ -2,7 +2,7 @@ import { css, html, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 import { RapidElement } from '../RapidElement';
 import { CustomEventType } from '../interfaces';
-import { postJSON } from '../utils';
+import { getClasses, postJSON } from '../utils';
 import { Card } from './Card';
 
 /** Saved card layout state — order and collapsed lists may reference cards
@@ -10,6 +10,7 @@ import { Card } from './Card';
 export interface CardSettings {
   order?: string[];
   collapsed?: string[];
+  width?: number;
 }
 
 /**
@@ -38,6 +39,8 @@ export class CardLayout extends RapidElement {
         flex-direction: column;
         flex-grow: 1;
         min-height: 0;
+        /* anchors the tab-view resize handle on the right inset */
+        position: relative;
       }
 
       /* in tab view there is no card column running to the edge — the
@@ -64,6 +67,38 @@ export class CardLayout extends RapidElement {
         flex-direction: column;
         padding-top: var(--layout-spacing, 8px);
         padding-bottom: var(--layout-spacing, 8px);
+        /* anchors the card-view resize handle in the gap to our right */
+        position: relative;
+      }
+
+      /* drag handle for resizing the main view — in card view it rides the
+         gap between the main view and the card column, in tab view (.edge)
+         it rides the layout's right inset */
+      .resize-handle {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        right: calc(var(--layout-spacing, 8px) * -1 - 1px);
+        width: calc(var(--layout-spacing, 8px) + 2px);
+        cursor: col-resize;
+        z-index: 1;
+        display: flex;
+        justify-content: center;
+      }
+
+      .resize-handle.edge {
+        right: 0;
+      }
+
+      .resize-handle .grip {
+        width: 3px;
+        border-radius: 2px;
+        background: transparent;
+      }
+
+      .resize-handle:hover .grip,
+      .resize-handle.active .grip {
+        background: rgba(0, 0, 0, 0.08);
       }
 
       slot[name='main']::slotted(*) {
@@ -126,10 +161,35 @@ export class CardLayout extends RapidElement {
   // sync with the .column CSS defaults
   static COLUMN_FOOTPRINT = 376;
 
-  private getFlipWidth(): number {
+  // user-chosen main-view width in px (0 = automatic). Dragging the resize
+  // handle sets it, and it participates in the flip: the cards always keep
+  // their footprint, so a wider chat flips to tabs sooner
+  @property({ type: Number, attribute: false })
+  mainWidth = 0;
+
+  // a drag on the resize handle is in progress
+  @property({ type: Boolean })
+  resizing = false;
+
+  // last observed layout width — the tab view uses it to decide whether a
+  // resize could reach card mode at all before offering the handle
+  @property({ type: Number, attribute: false })
+  hostWidth = 0;
+
+  /** The narrowest layout that can show card mode at any main-view width. */
+  private getMinFlipWidth(): number {
     return this.breakpoint > 0
       ? this.breakpoint
       : this.mainMinWidth + CardLayout.COLUMN_FOOTPRINT;
+  }
+
+  private getFlipWidth(): number {
+    const min = this.getMinFlipWidth();
+    // a user-sized main view raises the bar — the cards keep their
+    // footprint rather than being squeezed beside it
+    return this.mainWidth > 0
+      ? Math.max(min, this.mainWidth + CardLayout.COLUMN_FOOTPRINT)
+      : min;
   }
 
   @property({ type: Array })
@@ -216,15 +276,18 @@ export class CardLayout extends RapidElement {
     this.resizer = new ResizeObserver(() => {
       // defer out of the observer callback — flipping modes re-renders and
       // resizes us, which would otherwise trip the browser's RO loop guard
-      requestAnimationFrame(() => {
-        const width = this.offsetWidth;
-        if (width > 0) {
-          this.narrow = width < this.getFlipWidth();
-          this.compactTabs = width < CardLayout.COMPACT_TABS_WIDTH;
-        }
-      });
+      requestAnimationFrame(() => this.updateModes());
     });
     this.resizer.observe(this);
+  }
+
+  private updateModes() {
+    const width = this.offsetWidth;
+    if (width > 0) {
+      this.hostWidth = width;
+      this.narrow = width < this.getFlipWidth();
+      this.compactTabs = width < CardLayout.COMPACT_TABS_WIDTH;
+    }
   }
 
   public disconnectedCallback(): void {
@@ -235,6 +298,7 @@ export class CardLayout extends RapidElement {
     this.removeEventListener('toggle', this.handleToggle);
     this.resizer?.disconnect();
     this.mutations?.disconnect();
+    this.releaseResize();
 
     // flush a pending save so navigating away doesn't drop it
     if (this.saveTimeout) {
@@ -253,6 +317,77 @@ export class CardLayout extends RapidElement {
 
   public getIds(): string[] {
     return this.getCards().map((card) => card.id);
+  }
+
+  private dragStartX = 0;
+  private dragStartWidth = 0;
+
+  // dragging past the widest fit pins the chat there; the pointer must
+  // then travel this fraction of the card column before the layout flips
+  // to tabs — and come the complementary fraction back across it before
+  // the cards pop back out
+  static FLIP_DRAG_RATIO = 0.75;
+
+  private handleResizeStart = (event: MouseEvent) => {
+    event.preventDefault();
+    // in tab view the main pane fills the layout, so the drag starts from
+    // the full width — the cards return only once the pointer has come
+    // most of the way back across the column they will occupy
+    const main = this.shadowRoot.querySelector('.main') as HTMLElement;
+    this.dragStartX = event.clientX;
+    this.dragStartWidth = main ? main.offsetWidth : this.offsetWidth;
+    this.resizing = true;
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'col-resize';
+    window.addEventListener('mousemove', this.handleResizeMove);
+    window.addEventListener('mouseup', this.handleResizeEnd);
+  };
+
+  private handleResizeMove = (event: MouseEvent) => {
+    const width = this.offsetWidth;
+    // the widest chat that still leaves the cards their footprint
+    const max = width - CardLayout.COLUMN_FOOTPRINT;
+    // where the pointer says the chat edge should be — it can run past
+    // the widest fit without the chat following
+    const dragged = Math.min(
+      Math.max(
+        this.dragStartWidth + event.clientX - this.dragStartX,
+        this.mainMinWidth
+      ),
+      width
+    );
+
+    const flipZone = CardLayout.COLUMN_FOOTPRINT * CardLayout.FLIP_DRAG_RATIO;
+    const returnZone = CardLayout.COLUMN_FOOTPRINT - flipZone;
+    if (this.narrow) {
+      // in tabs the cards return only once the pointer has dragged far
+      // enough back; until then the width keeps tracking the pointer so
+      // a release leaves tab mode in place
+      this.mainWidth =
+        dragged < max + returnZone ? Math.min(dragged, max) : dragged;
+    } else {
+      // in cards the chat stops growing at the widest fit — the flip to
+      // tabs waits until the pointer has crossed most of the card column
+      this.mainWidth =
+        dragged > max + flipZone ? dragged : Math.min(dragged, max);
+    }
+  };
+
+  private handleResizeEnd = () => {
+    this.releaseResize();
+    this.fireCustomEvent(CustomEventType.Resized, { width: this.mainWidth });
+    this.scheduleSave();
+  };
+
+  private releaseResize() {
+    if (!this.resizing) {
+      return;
+    }
+    this.resizing = false;
+    document.body.style.userSelect = '';
+    document.body.style.cursor = '';
+    window.removeEventListener('mousemove', this.handleResizeMove);
+    window.removeEventListener('mouseup', this.handleResizeEnd);
   }
 
   /**
@@ -360,11 +495,16 @@ export class CardLayout extends RapidElement {
       .filter((id) => !present.includes(id))
       .concat(collapsed);
 
+    const settings: CardSettings = {
+      order: this.savedOrder,
+      collapsed: this.savedCollapsed
+    };
+    if (this.mainWidth > 0) {
+      settings.width = Math.round(this.mainWidth);
+    }
+
     postJSON(this.settingsEndpoint, {
-      [this.settingsKey]: {
-        order: this.savedOrder,
-        collapsed: this.savedCollapsed
-      }
+      [this.settingsKey]: settings
     }).catch(() => {
       // a failed save isn't worth interrupting the user over — the next
       // change will retry with the same merged state
@@ -380,7 +520,23 @@ export class CardLayout extends RapidElement {
       if (this.savedOrder.length > 0) {
         this.order = this.savedOrder;
       }
+      if (this.settings.width > 0) {
+        this.mainWidth = this.settings.width;
+      }
       this.applyCollapsed();
+    }
+    if (changes.has('mainWidth')) {
+      // an undersized saved width (e.g. saved on a page with a lower
+      // floor) gets the same floor as a drag
+      if (this.mainWidth > 0) {
+        this.mainWidth = Math.max(this.mainWidth, this.mainMinWidth);
+        this.style.setProperty('--main-width', `${this.mainWidth}px`);
+      } else {
+        this.style.removeProperty('--main-width');
+      }
+      // the flip point tracks the user width — resizing wide enough to
+      // crowd out the cards flips to tabs, and back again
+      this.updateModes();
     }
   }
 
@@ -394,8 +550,26 @@ export class CardLayout extends RapidElement {
     }
   }
 
+  private renderResizeHandle(edge = false): TemplateResult {
+    return html`
+      <div
+        class=${getClasses({
+          'resize-handle': true,
+          edge,
+          active: this.resizing
+        })}
+        @mousedown=${this.handleResizeStart}
+      >
+        <div class="grip"></div>
+      </div>
+    `;
+  }
+
   public render(): TemplateResult {
     if (this.narrow) {
+      // resizing out of tab mode only works when the layout is wide enough
+      // to reach card mode at some main-view width — otherwise no handle
+      const resizable = this.hostWidth >= this.getMinFlipWidth();
       return html`
         <temba-tabs .focusedName=${this.compactTabs}>
           <temba-tab name=${this.mainName} icon=${this.mainIcon}>
@@ -414,12 +588,16 @@ export class CardLayout extends RapidElement {
             `
           )}
         </temba-tabs>
+        ${resizable ? this.renderResizeHandle(true) : null}
       `;
     }
 
     return html`
       <div class="body">
-        <div class="main"><slot name="main"></slot></div>
+        <div class="main">
+          <slot name="main"></slot>
+          ${this.renderResizeHandle()}
+        </div>
         <div class="column">
           <temba-card-stack @temba-order-changed=${this.handleOrderChanged}>
             <slot @slotchange=${this.handleSlotChange}></slot>

--- a/src/layout/CardLayout.ts
+++ b/src/layout/CardLayout.ts
@@ -89,8 +89,12 @@ export class CardLayout extends RapidElement {
         outline: none;
       }
 
+      /* in tab view the handle rides the layout's right inset — keep it
+         inside that inset so it doesn't overlay (and swallow pointer
+         events on) the edge of the tab content */
       .resize-handle.edge {
         right: 0;
+        width: var(--layout-spacing, 8px);
       }
 
       .resize-handle .grip {
@@ -102,7 +106,7 @@ export class CardLayout extends RapidElement {
       .resize-handle:hover .grip,
       .resize-handle:focus-visible .grip,
       .resize-handle.active .grip {
-        background: rgba(0, 0, 0, 0.08);
+        background: var(--border-strong);
       }
 
       slot[name='main']::slotted(*) {
@@ -180,6 +184,11 @@ export class CardLayout extends RapidElement {
   @property({ type: Number, attribute: false })
   hostWidth = 0;
 
+  // last measured width of the rendered main pane — the separator
+  // announces it while the width is still automatic (no chosen width)
+  @property({ type: Number, attribute: false })
+  mainPaneWidth = 0;
+
   /** The narrowest layout that can show card mode at any main-view width. */
   private getMinFlipWidth(): number {
     return this.breakpoint > 0
@@ -204,13 +213,43 @@ export class CardLayout extends RapidElement {
   }
 
   /** Whether the layout is wide enough for a resize to land anywhere
-   * useful: the main view at its minimum beside the card column. Narrower
-   * than that a drag can only strand the layout in tab mode — the flip
-   * width it would need exceeds the layout — so no handle is offered.
-   * Note this is deliberately independent of the breakpoint: an explicit
-   * low breakpoint says "prefer cards", it doesn't make dragging work. */
+   * useful: the main view at its minimum beside the card column, and at
+   * or above any explicit breakpoint. Narrower than that a drag can only
+   * strand the layout in tab mode — the flip width it would need exceeds
+   * the layout — so no handle is offered. Note an explicit *low*
+   * breakpoint says "prefer cards", it doesn't make dragging work: the
+   * footprint floor still applies. */
   private isResizable(): boolean {
-    return this.hostWidth >= this.mainMinWidth + CardLayout.COLUMN_FOOTPRINT;
+    return (
+      this.hostWidth >=
+      Math.max(
+        this.getMinFlipWidth(),
+        this.mainMinWidth + CardLayout.COLUMN_FOOTPRINT
+      )
+    );
+  }
+
+  /** The widest main view that still leaves the cards their footprint —
+   * the separator's maximum. */
+  private getResizeMax(): number {
+    return this.hostWidth - CardLayout.COLUMN_FOOTPRINT;
+  }
+
+  /** Keep a width inside the range the separator advertises. In tab view
+   * the pane spans more than the widest card-mode fit, so an unclamped
+   * value would fall outside [valuemin, valuemax]. */
+  private clampResizeWidth(width: number): number {
+    return Math.min(Math.max(width, this.mainMinWidth), this.getResizeMax());
+  }
+
+  /** The value the separator announces: the chosen width when there is
+   * one, otherwise the last measured pane width. */
+  private getAnnouncedWidth(): number {
+    return Math.round(
+      this.clampResizeWidth(
+        this.getEffectiveMainWidth() || this.mainPaneWidth || this.mainMinWidth
+      )
+    );
   }
 
   /** Width the main view occupies now — in tab view it fills the layout,
@@ -315,6 +354,9 @@ export class CardLayout extends RapidElement {
       this.hostWidth = width;
       this.narrow = width < this.getFlipWidth();
       this.compactTabs = width < CardLayout.COMPACT_TABS_WIDTH;
+      // keep the separator's announced width current without measuring
+      // on every render
+      this.mainPaneWidth = this.getMainPaneWidth();
     }
   }
 
@@ -349,6 +391,12 @@ export class CardLayout extends RapidElement {
 
   private dragStartX = 0;
   private dragStartWidth = 0;
+  // the chosen width when the drag began, restored if it is cancelled
+  private dragStartMainWidth = 0;
+  // whether the pointer has actually travelled — a click on the handle
+  // (a trackpad tap can fire a zero-delta pointermove) must not commit a
+  // width, which would also turn an automatic width into a chosen one
+  private dragMoved = false;
   // whether the pointer moved far enough to change the width — a click on
   // the handle shouldn't announce a resize or post settings
   private dragChanged = false;
@@ -372,6 +420,8 @@ export class CardLayout extends RapidElement {
     // most of the way back across the column they will occupy
     this.dragStartX = event.clientX;
     this.dragStartWidth = this.getMainPaneWidth();
+    this.dragStartMainWidth = this.mainWidth;
+    this.dragMoved = false;
     this.dragChanged = false;
     this.resizing = true;
     this.previousBodyUserSelect = document.body.style.userSelect;
@@ -383,11 +433,19 @@ export class CardLayout extends RapidElement {
     // the capture and kill the drag — window listeners survive the flip
     window.addEventListener('pointermove', this.handleResizeMove);
     window.addEventListener('pointerup', this.handleResizeEnd);
-    window.addEventListener('pointercancel', this.handleResizeEnd);
+    window.addEventListener('pointercancel', this.handleResizeCancel);
   };
 
   private handleResizeMove = (event: PointerEvent) => {
     event.preventDefault();
+    if (event.clientX !== this.dragStartX) {
+      this.dragMoved = true;
+    }
+    // a press with no travel isn't a resize — leave the width alone (in
+    // particular, don't turn an automatic width into a chosen one)
+    if (!this.dragMoved) {
+      return;
+    }
     const width = this.offsetWidth;
     // the widest chat that still leaves the cards their footprint
     const max = width - CardLayout.COLUMN_FOOTPRINT;
@@ -430,39 +488,55 @@ export class CardLayout extends RapidElement {
     }
   };
 
+  /** A cancelled gesture (the browser or OS taking the pointer away) is
+   * not a resize — put the width back where the drag found it. */
+  private handleResizeCancel = () => {
+    const changed = this.dragChanged;
+    this.releaseResize();
+    if (changed) {
+      this.mainWidth = this.dragStartMainWidth;
+    }
+  };
+
   /** Arrow keys resize in 10px steps (25px with Shift), the keyboard
    * equivalent of dragging the separator. There is no hysteresis here —
-   * the width simply clamps to what fits, so a press from tab mode lands
-   * in card mode at the widest width the cards leave room for. */
+   * the width simply clamps to what fits, so a shrink press from tab mode
+   * lands in card mode at the widest width the cards leave room for. */
   private handleResizeKeydown = (event: KeyboardEvent) => {
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
     event.preventDefault();
     event.stopPropagation();
     const step = event.shiftKey ? 25 : 10;
     const direction = event.key === 'ArrowRight' ? 1 : -1;
-    const max = this.hostWidth - CardLayout.COLUMN_FOOTPRINT;
-    const width = Math.min(
-      Math.max(this.getMainPaneWidth() + direction * step, this.mainMinWidth),
-      max
-    );
+    const current = this.getMainPaneWidth();
+    const width = this.clampResizeWidth(current + direction * step);
 
     (event.currentTarget as HTMLElement).setAttribute(
       'aria-valuenow',
       `${Math.round(width)}`
     );
+
+    // in tab view the pane already spans more than the widest card-mode
+    // fit, so there is nothing to grow into — growing must not shrink the
+    // pane (and pop the cards back out) as a side effect of the clamp
+    if (direction > 0 && width < current) {
+      return;
+    }
+
     if (width !== this.mainWidth) {
       this.mainWidth = width;
+      this.fireCustomEvent(CustomEventType.Resized, { width });
       this.scheduleSave();
     }
   };
 
-  /** The rendered main width isn't known at render time (it may be the
-   * flex basis rather than a set width), so measure it when the separator
+  /** The template binding keeps aria-valuenow live from the last measured
+   * pane width; refine it with a fresh measurement when the separator
    * takes focus and screen readers are about to announce it. */
   private handleResizeFocus = (event: FocusEvent) => {
     (event.currentTarget as HTMLElement).setAttribute(
       'aria-valuenow',
-      `${Math.round(this.getMainPaneWidth())}`
+      `${Math.round(this.clampResizeWidth(this.getMainPaneWidth()))}`
     );
   };
 
@@ -475,7 +549,7 @@ export class CardLayout extends RapidElement {
     document.body.style.cursor = this.previousBodyCursor;
     window.removeEventListener('pointermove', this.handleResizeMove);
     window.removeEventListener('pointerup', this.handleResizeEnd);
-    window.removeEventListener('pointercancel', this.handleResizeEnd);
+    window.removeEventListener('pointercancel', this.handleResizeCancel);
   }
 
   /**
@@ -653,7 +727,8 @@ export class CardLayout extends RapidElement {
         aria-orientation="vertical"
         aria-label="Resize chat"
         aria-valuemin=${this.mainMinWidth}
-        aria-valuemax=${this.hostWidth - CardLayout.COLUMN_FOOTPRINT}
+        aria-valuemax=${this.getResizeMax()}
+        aria-valuenow=${this.getAnnouncedWidth()}
         tabindex="0"
         @pointerdown=${this.handleResizeStart}
         @keydown=${this.handleResizeKeydown}

--- a/test/temba-card-layout.test.ts
+++ b/test/temba-card-layout.test.ts
@@ -22,7 +22,11 @@ const createLayout = async (width: number, def = LAYOUT) => {
   const parentNode = document.createElement('div');
   parentNode.setAttribute('style', `width: ${width}px; display: flex;`);
   const layout = (await fixture(def, { parentNode })) as CardLayout;
-  await waitForCondition(() => layout.narrow === width < 800);
+  // the resize handles only appear once the layout has observed its own
+  // width, so wait for that as well as the mode
+  await waitForCondition(
+    () => layout.hostWidth > 0 && layout.narrow === width < 800
+  );
   await layout.updateComplete;
   return layout;
 };
@@ -222,14 +226,28 @@ describe('temba-card-layout', () => {
   describe('resizing', () => {
     const press = (handle: Element, x: number) => {
       handle.dispatchEvent(
-        new MouseEvent('mousedown', { clientX: x, bubbles: true })
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          clientX: x,
+          cancelable: true,
+          pointerType: 'mouse'
+        })
       );
     };
     const move = (x: number) => {
-      window.dispatchEvent(new MouseEvent('mousemove', { clientX: x }));
+      window.dispatchEvent(
+        new PointerEvent('pointermove', {
+          clientX: x,
+          cancelable: true,
+          pointerType: 'mouse'
+        })
+      );
     };
     const release = () => {
-      window.dispatchEvent(new MouseEvent('mouseup'));
+      window.dispatchEvent(
+        new PointerEvent('pointerup', { pointerType: 'mouse' })
+      );
     };
 
     it('resizes the main view by dragging the divider', async () => {
@@ -324,6 +342,35 @@ describe('temba-card-layout', () => {
       const layout = await createLayout(600);
       expect(layout.narrow).to.be.true;
       expect(layout.shadowRoot.querySelector('.resize-handle')).to.not.exist;
+    });
+
+    it('stops tracking the pointer once the drag is released', async () => {
+      const layout = await createLayout(1000);
+      const handle = layout.shadowRoot.querySelector('.resize-handle');
+
+      press(handle, 600);
+      move(500);
+      await layout.updateComplete;
+      const released = layout.mainWidth;
+
+      release();
+      move(300);
+      await layout.updateComplete;
+      expect(layout.mainWidth).to.equal(released);
+    });
+
+    it('restores the body styles when removed mid-drag', async () => {
+      const layout = await createLayout(1000);
+      const handle = layout.shadowRoot.querySelector('.resize-handle');
+
+      press(handle, 600);
+      move(500);
+      expect(document.body.style.cursor).to.equal('col-resize');
+      expect(document.body.style.userSelect).to.equal('none');
+
+      layout.remove();
+      expect(document.body.style.cursor).to.equal('');
+      expect(document.body.style.userSelect).to.equal('');
     });
   });
 
@@ -445,10 +492,24 @@ describe('temba-card-layout', () => {
       const handle = layout.shadowRoot.querySelector('.resize-handle');
 
       handle.dispatchEvent(
-        new MouseEvent('mousedown', { clientX: 600, bubbles: true })
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          clientX: 600,
+          cancelable: true,
+          pointerType: 'mouse'
+        })
       );
-      window.dispatchEvent(new MouseEvent('mousemove', { clientX: 500 }));
-      window.dispatchEvent(new MouseEvent('mouseup'));
+      window.dispatchEvent(
+        new PointerEvent('pointermove', {
+          clientX: 500,
+          cancelable: true,
+          pointerType: 'mouse'
+        })
+      );
+      window.dispatchEvent(
+        new PointerEvent('pointerup', { pointerType: 'mouse' })
+      );
 
       await waitForCondition(() => newPosts().length > 0);
       expect(newPosts()[0].contact_cards.width).to.equal(layout.mainWidth);

--- a/test/temba-card-layout.test.ts
+++ b/test/temba-card-layout.test.ts
@@ -344,6 +344,190 @@ describe('temba-card-layout', () => {
       expect(layout.shadowRoot.querySelector('.resize-handle')).to.not.exist;
     });
 
+    it('offers no resize when the breakpoint keeps card mode out of reach', async () => {
+      // the layout could fit the chat beside the cards, but the explicit
+      // breakpoint holds it in tabs — a drag could only strand it there
+      const parentNode = document.createElement('div');
+      parentNode.setAttribute('style', 'width: 1000px; display: flex;');
+      const layout = (await fixture(
+        html`
+          <temba-card-layout breakpoint="1200">
+            <div slot="main">main</div>
+            <temba-card id="card-a" label="Alpha"><div>A</div></temba-card>
+          </temba-card-layout>
+        `,
+        { parentNode }
+      )) as CardLayout;
+
+      await waitForCondition(() => layout.hostWidth > 0 && layout.narrow);
+      await layout.updateComplete;
+      expect(layout.shadowRoot.querySelector('.resize-handle')).to.not.exist;
+    });
+
+    it('offers no card-mode resize when the layout is too tight', async () => {
+      // a low breakpoint keeps the cards, but there is no room to drag:
+      // the chat at its minimum plus the column footprint doesn't fit
+      const parentNode = document.createElement('div');
+      parentNode.setAttribute('style', 'width: 700px; display: flex;');
+      const layout = (await fixture(
+        html`
+          <temba-card-layout breakpoint="400">
+            <div slot="main">main</div>
+            <temba-card id="card-a" label="Alpha"><div>A</div></temba-card>
+          </temba-card-layout>
+        `,
+        { parentNode }
+      )) as CardLayout;
+
+      await waitForCondition(() => layout.hostWidth > 0);
+      await layout.updateComplete;
+      expect(layout.narrow).to.be.false;
+      expect(layout.shadowRoot.querySelector('temba-card-stack')).to.exist;
+      expect(layout.shadowRoot.querySelector('.resize-handle')).to.not.exist;
+    });
+
+    it('ignores a press that never moves', async () => {
+      const layout = await createLayout(1000);
+      const handle = layout.shadowRoot.querySelector('.resize-handle');
+      let resized = false;
+      layout.addEventListener(CustomEventType.Resized, () => (resized = true));
+
+      // a trackpad click can fire a pointermove with no travel — it must
+      // not commit a width (which would also fix the automatic width)
+      press(handle, 600);
+      move(600);
+      release();
+      await layout.updateComplete;
+
+      expect(layout.mainWidth).to.equal(0);
+      expect(resized).to.be.false;
+    });
+
+    it('restores the width when a drag is cancelled', async () => {
+      const layout = await createLayout(1000);
+      const handle = layout.shadowRoot.querySelector('.resize-handle');
+      const main = layout.shadowRoot.querySelector('.main') as HTMLElement;
+      const startWidth = main.offsetWidth;
+
+      press(handle, 600);
+      move(500);
+      await layout.updateComplete;
+      expect(layout.mainWidth).to.equal(startWidth - 100);
+
+      window.dispatchEvent(
+        new PointerEvent('pointercancel', { pointerType: 'mouse' })
+      );
+      await layout.updateComplete;
+      expect(layout.mainWidth).to.equal(0);
+    });
+
+    describe('keyboard', () => {
+      const arrow = (handle: Element, key: string, shiftKey = false) => {
+        handle.dispatchEvent(
+          new KeyboardEvent('keydown', { key, shiftKey, bubbles: true })
+        );
+      };
+
+      it('resizes in steps with the arrow keys', async () => {
+        const layout = await createLayout(1000);
+        layout.mainWidth = 500;
+        await layout.updateComplete;
+        const handle = layout.shadowRoot.querySelector('.resize-handle');
+
+        arrow(handle, 'ArrowLeft');
+        await layout.updateComplete;
+        expect(layout.mainWidth).to.equal(490);
+
+        // shift takes bigger bites
+        arrow(handle, 'ArrowLeft', true);
+        await layout.updateComplete;
+        expect(layout.mainWidth).to.equal(465);
+
+        arrow(handle, 'ArrowRight');
+        await layout.updateComplete;
+        expect(layout.mainWidth).to.equal(475);
+      });
+
+      it('grows no further than the widest fit', async () => {
+        const layout = await createLayout(1000);
+        layout.mainWidth = 620;
+        await layout.updateComplete;
+        const handle = layout.shadowRoot.querySelector('.resize-handle');
+
+        arrow(handle, 'ArrowRight', true);
+        await layout.updateComplete;
+        expect(layout.mainWidth).to.equal(1000 - CardLayout.COLUMN_FOOTPRINT);
+        expect(layout.narrow).to.be.false;
+      });
+
+      it('announces keyboard resizes', async () => {
+        const layout = await createLayout(1000);
+        const handle = layout.shadowRoot.querySelector('.resize-handle');
+
+        const resized = oneEvent(layout, CustomEventType.Resized, false);
+        arrow(handle, 'ArrowLeft');
+        const event = await resized;
+        expect(event.detail.width).to.equal(layout.mainWidth);
+      });
+
+      it('never shrinks the chat when growing from tab mode', async () => {
+        const layout = await createLayout(1000);
+        layout.mainWidth = 700;
+        await waitForCondition(() => layout.narrow);
+        await layout.updateComplete;
+
+        const handle = layout.shadowRoot.querySelector('.resize-handle.edge');
+        arrow(handle, 'ArrowRight');
+        await layout.updateComplete;
+
+        // the tab pane is already wider than any card-mode width — the
+        // grow is a no-op rather than a jump back to the cards
+        expect(layout.mainWidth).to.equal(700);
+        expect(layout.narrow).to.be.true;
+      });
+    });
+
+    describe('aria', () => {
+      it('advertises the resize range from the template', async () => {
+        const layout = await createLayout(1000);
+        const handle = layout.shadowRoot.querySelector('.resize-handle');
+        const max = 1000 - CardLayout.COLUMN_FOOTPRINT;
+
+        expect(handle.getAttribute('role')).to.equal('separator');
+        expect(handle.getAttribute('aria-valuemin')).to.equal(
+          `${layout.mainMinWidth}`
+        );
+        expect(handle.getAttribute('aria-valuemax')).to.equal(`${max}`);
+        // announced before any interaction, and kept current afterwards
+        expect(handle.getAttribute('aria-valuenow')).to.equal(`${max}`);
+
+        layout.mainWidth = 500;
+        await layout.updateComplete;
+        expect(
+          layout.shadowRoot
+            .querySelector('.resize-handle')
+            .getAttribute('aria-valuenow')
+        ).to.equal('500');
+      });
+
+      it('keeps the announced width inside the range in tab mode', async () => {
+        const layout = await createLayout(1000);
+        layout.mainWidth = 700;
+        await waitForCondition(() => layout.narrow);
+        await layout.updateComplete;
+
+        const handle = layout.shadowRoot.querySelector('.resize-handle.edge');
+        const max = 1000 - CardLayout.COLUMN_FOOTPRINT;
+        expect(handle.getAttribute('aria-valuemax')).to.equal(`${max}`);
+        // the pane spans the whole layout in tabs — announce the maximum
+        // rather than a value outside the advertised range
+        expect(handle.getAttribute('aria-valuenow')).to.equal(`${max}`);
+
+        handle.dispatchEvent(new FocusEvent('focus'));
+        expect(handle.getAttribute('aria-valuenow')).to.equal(`${max}`);
+      });
+    });
+
     it('stops tracking the pointer once the drag is released', async () => {
       const layout = await createLayout(1000);
       const handle = layout.shadowRoot.querySelector('.resize-handle');

--- a/test/temba-card-layout.test.ts
+++ b/test/temba-card-layout.test.ts
@@ -403,6 +403,32 @@ describe('temba-card-layout', () => {
       expect(resized).to.be.false;
     });
 
+    it('ignores a press that only drifts a pixel', async () => {
+      const layout = await createLayout(1000);
+      const handle = layout.shadowRoot.querySelector('.resize-handle');
+      let resized = false;
+      layout.addEventListener(CustomEventType.Resized, () => (resized = true));
+
+      // a click carries a pixel or two of drift — below the threshold it
+      // stays a click, so the width stays automatic and the flip point
+      // doesn't move
+      press(handle, 600);
+      move(601);
+      move(599);
+      release();
+      await layout.updateComplete;
+
+      expect(layout.mainWidth).to.equal(0);
+      expect(resized).to.be.false;
+
+      // real travel still resizes
+      press(handle, 600);
+      move(590);
+      await layout.updateComplete;
+      expect(layout.mainWidth).to.be.greaterThan(0);
+      release();
+    });
+
     it('restores the width when a drag is cancelled', async () => {
       const layout = await createLayout(1000);
       const handle = layout.shadowRoot.querySelector('.resize-handle');
@@ -553,9 +579,6 @@ describe('temba-card-layout', () => {
         // the pane spans the whole layout in tabs — announce the maximum
         // rather than a value outside the advertised range
         expect(handle.getAttribute('aria-valuenow')).to.equal(`${max}`);
-
-        handle.dispatchEvent(new FocusEvent('focus'));
-        expect(handle.getAttribute('aria-valuenow')).to.equal(`${max}`);
       });
     });
 
@@ -696,6 +719,20 @@ describe('temba-card-layout', () => {
         await createPersistentLayout('{"width": 500}');
       expect(layout.mainWidth).to.equal(500);
       expect(layout.narrow).to.be.false;
+
+      clickHeader(layout.querySelector('#card-a') as Card);
+      await waitForCondition(() => newPosts().length > 0);
+      expect(newPosts()[0].contact_cards.width).to.equal(500);
+    });
+
+    it('keeps the saved width when this page has no chosen width', async () => {
+      // the width is shared across pages like the order and collapsed
+      // lists — a save from a page rendering at the automatic width must
+      // carry the stored width through rather than clearing it
+      const { layout, newPosts } =
+        await createPersistentLayout('{"width": 500}');
+      layout.mainWidth = 0;
+      await layout.updateComplete;
 
       clickHeader(layout.querySelector('#card-a') as Card);
       await waitForCondition(() => newPosts().length > 0);

--- a/test/temba-card-layout.test.ts
+++ b/test/temba-card-layout.test.ts
@@ -485,6 +485,22 @@ describe('temba-card-layout', () => {
         expect(layout.mainWidth).to.equal(700);
         expect(layout.narrow).to.be.true;
       });
+
+      it('shrinks from tab mode straight into card mode', async () => {
+        const layout = await createLayout(1000);
+        layout.mainWidth = 700;
+        await waitForCondition(() => layout.narrow);
+        await layout.updateComplete;
+
+        const handle = layout.shadowRoot.querySelector('.resize-handle.edge');
+        arrow(handle, 'ArrowLeft');
+        await waitForCondition(() => !layout.narrow);
+
+        // one shrink press lands at the widest width the cards leave room
+        // for — the keyboard needs no drag-style hysteresis
+        expect(layout.mainWidth).to.equal(1000 - CardLayout.COLUMN_FOOTPRINT);
+        expect(layout.shadowRoot.querySelector('temba-card-stack')).to.exist;
+      });
     });
 
     describe('aria', () => {

--- a/test/temba-card-layout.test.ts
+++ b/test/temba-card-layout.test.ts
@@ -446,6 +446,14 @@ describe('temba-card-layout', () => {
         arrow(handle, 'ArrowRight');
         await layout.updateComplete;
         expect(layout.mainWidth).to.equal(475);
+
+        // rapid presses in the same task each take a full step — stepping
+        // works from state, not from a measurement that hasn't flushed
+        arrow(handle, 'ArrowLeft');
+        arrow(handle, 'ArrowLeft');
+        arrow(handle, 'ArrowLeft');
+        await layout.updateComplete;
+        expect(layout.mainWidth).to.equal(445);
       });
 
       it('grows no further than the widest fit', async () => {
@@ -495,11 +503,18 @@ describe('temba-card-layout', () => {
         const handle = layout.shadowRoot.querySelector('.resize-handle.edge');
         arrow(handle, 'ArrowLeft');
         await waitForCondition(() => !layout.narrow);
+        await layout.updateComplete;
 
         // one shrink press lands at the widest width the cards leave room
         // for — the keyboard needs no drag-style hysteresis
         expect(layout.mainWidth).to.equal(1000 - CardLayout.COLUMN_FOOTPRINT);
         expect(layout.shadowRoot.querySelector('temba-card-stack')).to.exist;
+
+        // the flip rebuilt the handle from the other template — focus
+        // follows it so the keyboard user isn't stranded
+        expect(layout.shadowRoot.activeElement).to.equal(
+          layout.shadowRoot.querySelector('.resize-handle')
+        );
       });
     });
 

--- a/test/temba-card-layout.test.ts
+++ b/test/temba-card-layout.test.ts
@@ -219,6 +219,114 @@ describe('temba-card-layout', () => {
     expect(layout.shadowRoot.querySelector('temba-tabs')).to.exist;
   });
 
+  describe('resizing', () => {
+    const press = (handle: Element, x: number) => {
+      handle.dispatchEvent(
+        new MouseEvent('mousedown', { clientX: x, bubbles: true })
+      );
+    };
+    const move = (x: number) => {
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: x }));
+    };
+    const release = () => {
+      window.dispatchEvent(new MouseEvent('mouseup'));
+    };
+
+    it('resizes the main view by dragging the divider', async () => {
+      const layout = await createLayout(1000);
+      const handle = layout.shadowRoot.querySelector('.resize-handle');
+      const main = layout.shadowRoot.querySelector('.main') as HTMLElement;
+      const startWidth = main.offsetWidth;
+
+      press(handle, 600);
+      move(500);
+      await layout.updateComplete;
+
+      expect(layout.mainWidth).to.equal(startWidth - 100);
+      expect(layout.narrow).to.be.false;
+
+      // dragging way past the left edge clamps at the main minimum
+      move(-1000);
+      await layout.updateComplete;
+      expect(layout.mainWidth).to.equal(layout.mainMinWidth);
+
+      const resized = oneEvent(layout, CustomEventType.Resized, false);
+      release();
+      const event = await resized;
+      expect(event.detail.width).to.equal(layout.mainMinWidth);
+
+      expect(main.offsetWidth).to.equal(layout.mainMinWidth);
+    });
+
+    it('pins the chat at the widest fit and flips to tabs only after dragging across the cards', async () => {
+      const layout = await createLayout(1000);
+      const handle = layout.shadowRoot.querySelector('.resize-handle');
+      const max = 1000 - CardLayout.COLUMN_FOOTPRINT;
+
+      // past the widest fit the chat pins there instead of flipping
+      press(handle, 600);
+      move(700);
+      await layout.updateComplete;
+      expect(layout.mainWidth).to.equal(max);
+      expect(layout.narrow).to.be.false;
+
+      // ...until the pointer has crossed most of the card column
+      move(920);
+      await waitForCondition(() => layout.narrow);
+      expect(layout.shadowRoot.querySelector('temba-tabs')).to.exist;
+
+      // coming back a little is not enough to bring the cards back
+      move(700);
+      await layout.updateComplete;
+      expect(layout.narrow).to.be.true;
+
+      // but coming back across the card area pops them back out, with
+      // the chat at the widest width that fits them
+      move(690);
+      await waitForCondition(() => !layout.narrow);
+      expect(layout.shadowRoot.querySelector('temba-card-stack')).to.exist;
+      expect(layout.mainWidth).to.equal(max);
+      release();
+    });
+
+    it('leaves tab mode only after dragging back across the cards', async () => {
+      const layout = await createLayout(1000);
+
+      // a saved width too wide for the window forces tab mode
+      layout.mainWidth = 700;
+      await waitForCondition(() => layout.narrow);
+      await layout.updateComplete;
+
+      // wide enough to reach card mode, so the tab view offers a handle
+      const handle = layout.shadowRoot.querySelector('.resize-handle.edge');
+      expect(handle).to.exist;
+
+      // a small movement is not enough to pop out of tab mode
+      press(handle, 995);
+      move(985);
+      await layout.updateComplete;
+      expect(layout.narrow).to.be.true;
+
+      // dragging most of the way back across the card area brings the
+      // cards back, with the chat at the widest width that fits them
+      move(700);
+      await waitForCondition(() => !layout.narrow);
+      expect(layout.mainWidth).to.equal(1000 - CardLayout.COLUMN_FOOTPRINT);
+
+      // and further dragging shrinks the chat from there
+      move(500);
+      await layout.updateComplete;
+      expect(layout.mainWidth).to.equal(505);
+      release();
+    });
+
+    it('offers no tab-mode resize when the window cannot fit card mode', async () => {
+      const layout = await createLayout(600);
+      expect(layout.narrow).to.be.true;
+      expect(layout.shadowRoot.querySelector('.resize-handle')).to.not.exist;
+    });
+  });
+
   describe('settings persistence', () => {
     const SETTINGS_URL = /\/user\/settings\//;
 
@@ -319,6 +427,32 @@ describe('temba-card-layout', () => {
         'card-b',
         'card-a'
       ]);
+    });
+
+    it('seeds the main width from settings and includes it in saves', async () => {
+      const { layout, newPosts } =
+        await createPersistentLayout('{"width": 500}');
+      expect(layout.mainWidth).to.equal(500);
+      expect(layout.narrow).to.be.false;
+
+      clickHeader(layout.querySelector('#card-a') as Card);
+      await waitForCondition(() => newPosts().length > 0);
+      expect(newPosts()[0].contact_cards.width).to.equal(500);
+    });
+
+    it('posts the width after a resize drag', async () => {
+      const { layout, newPosts } = await createPersistentLayout('{}');
+      const handle = layout.shadowRoot.querySelector('.resize-handle');
+
+      handle.dispatchEvent(
+        new MouseEvent('mousedown', { clientX: 600, bubbles: true })
+      );
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: 500 }));
+      window.dispatchEvent(new MouseEvent('mouseup'));
+
+      await waitForCondition(() => newPosts().length > 0);
+      expect(newPosts()[0].contact_cards.width).to.equal(layout.mainWidth);
+      expect(layout.mainWidth).to.be.greaterThan(0);
     });
 
     it('flushes a pending save on disconnect', async () => {

--- a/test/temba-card-layout.test.ts
+++ b/test/temba-card-layout.test.ts
@@ -739,6 +739,44 @@ describe('temba-card-layout', () => {
       expect(newPosts()[0].contact_cards.width).to.equal(500);
     });
 
+    it('renders a sub-floor saved width at the floor without rewriting it', async () => {
+      // a width chosen on a page with a lower main-min-width still renders
+      // at this page's floor, but the stored value must survive a save so
+      // the page it was chosen on keeps it
+      const { layout, newPosts } =
+        await createPersistentLayout('{"width": 300}');
+      expect(layout.mainWidth).to.equal(300);
+      expect(layout.narrow).to.be.false;
+
+      const main = layout.shadowRoot.querySelector('.main') as HTMLElement;
+      expect(main.offsetWidth).to.equal(layout.mainMinWidth);
+
+      clickHeader(layout.querySelector('#card-a') as Card);
+      await waitForCondition(() => newPosts().length > 0);
+      expect(newPosts()[0].contact_cards.width).to.equal(300);
+    });
+
+    it('returns to the automatic width on double-click', async () => {
+      const { layout, newPosts } =
+        await createPersistentLayout('{"width": 500}');
+      expect(layout.mainWidth).to.equal(500);
+
+      const handle = layout.shadowRoot.querySelector('.resize-handle');
+      const resized = oneEvent(layout, CustomEventType.Resized, false);
+      handle.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+
+      const event = await resized;
+      expect(event.detail.width).to.equal(0);
+      expect(layout.mainWidth).to.equal(0);
+      await layout.updateComplete;
+      expect(layout.style.getPropertyValue('--main-width')).to.equal('');
+
+      // an explicit reset clears the stored width rather than carrying
+      // it through
+      await waitForCondition(() => newPosts().length > 0);
+      expect(newPosts()[0].contact_cards.width).to.be.undefined;
+    });
+
     it('posts the width after a resize drag', async () => {
       const { layout, newPosts } = await createPersistentLayout('{}');
       const handle = layout.shadowRoot.querySelector('.resize-handle');


### PR DESCRIPTION
## Summary

Adds a drag handle to `temba-card-layout` so the user can resize the main (chat) pane. The chosen width persists per user alongside card order/collapsed state, participates in the card/tab flip point, and the handle is pointer- and keyboard-operable.

## Changes

**Resizing (`src/layout/CardLayout.ts`)**
- A `role="separator"` drag handle rides the gap between the main pane and the card column; in tab view an edge handle rides the layout's right inset.
- Dragging sets `mainWidth` (0 = automatic). The flip point tracks it — the cards always keep their `COLUMN_FOOTPRINT`, so shrinking the window below the pinned chat + cards flips to tabs.
- Drag hysteresis: growing the chat pins at the widest fit; the pointer must cross 75% of the card column before the layout flips to tabs, and come back past the 25% mark before the cards pop back out. The virtual width stays continuous across mid-drag mode flips (window-level listeners; deliberately no pointer capture since the handle is rebuilt on a flip).
- Pointer events with primary-button guard and `touch-action: none`; `pointercancel` reverts to the pre-drag width; body `user-select`/`cursor` are captured and restored; a press with no travel commits nothing.
- Keyboard: arrow keys step 10px (25px with Shift), clamped to `[main-min-width, widest-fit]`. The keyboard never flips into tab mode (a keyboard-triggered flip would drop focus); a shrink press from tab mode lands in card mode at the widest fit, and focus follows the rebuilt handle across the flip.
- ARIA: `aria-valuemin/max/now` bound in the template, valuenow clamped into the advertised range; label derives from `main-name`.
- Handles only render when the layout is wide enough that card mode is reachable (`max(flip floor, main-min-width + footprint)`), so a drag can never strand the layout in an unrecoverable mode.

**Persistence**
- `width` joins `order`/`collapsed` in the debounced settings save. A page with a higher `main-min-width` renders at its own floor without rewriting the stored value, and saves re-post the raw width rather than clearing it.

## Review notes

Three pre-PR review cycles ran against this branch; substantive items caught and fixed before opening:

- An unrecoverable tab-mode latch when an explicit `breakpoint` (low or high) made card mode unreachable while the handle was still offered — handles now gate on both floors.
- Tab-mode arrow keys originally inverted (a "grow" press shrank the pane by the column footprint) — keyboard stepping now derives from state with mode-flip-safe semantics.
- Zero-travel clicks committed and persisted the automatic width, permanently moving the flip threshold.
- The page min-width floor was written back into the persisted width, clobbering the value chosen on pages with a lower floor.
- Focus was dropped to `<body>` when a keyboard press flipped modes; imperative ARIA writes desynced lit's attribute dirty-check.
- Mouse-only drag (no touch/pen, no cancel handling, any button started a drag) converted to guarded pointer events.

Known limitations, deliberately out of scope: RTL layouts (shared with the existing `Resizer`), and a screen-reader announcement for the mode flip itself.

## Test plan

- [x] 33 tests in `test/temba-card-layout.test.ts` covering drag stepping/clamping, flip hysteresis in both directions, tab-mode recovery, handle gating (default, low- and high-breakpoint), zero-travel presses, cancel revert, listener cleanup on release and disconnect, keyboard stepping/clamping/mode behavior with focus retention, ARIA range/valuenow bindings, and settings seeding/saving of `width`
- [x] Full suite green (2100+ tests), format/build/locales clean