### PR TITLE
Treat zero-value times as unset when rendering dates

### DIFF
--- a/src/display/TembaDate.ts
+++ b/src/display/TembaDate.ts
@@ -48,6 +48,13 @@ export class TembaDate extends RapidElement {
   }
 
   public render(): TemplateResult {
+    // unparseable values and zero-value times (e.g. go's zero time,
+    // 0001-01-01T00:00:00Z, for a contact that has never been seen) aren't
+    // real dates - render nothing rather than something like "2025 years ago"
+    if (this.datetime && !(this.datetime.isValid && this.datetime.year > 1)) {
+      return undefined;
+    }
+
     if (this.datetime && this.store) {
       this.datetime.setLocale(this.store.getLocale());
 

--- a/src/display/TembaDate.ts
+++ b/src/display/TembaDate.ts
@@ -1,4 +1,4 @@
-import { css, html, PropertyValues, TemplateResult } from 'lit';
+import { css, html, nothing, PropertyValues, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 import { RapidElement } from '../RapidElement';
 import { Store } from '../store/Store';
@@ -47,12 +47,12 @@ export class TembaDate extends RapidElement {
     }
   }
 
-  public render(): TemplateResult {
+  public render(): TemplateResult | typeof nothing {
     // unparseable values and zero-value times (e.g. go's zero time,
     // 0001-01-01T00:00:00Z, for a contact that has never been seen) aren't
     // real dates - render nothing rather than something like "2025 years ago"
     if (this.datetime && !(this.datetime.isValid && this.datetime.year > 1)) {
-      return undefined;
+      return nothing;
     }
 
     if (this.datetime && this.store) {

--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -877,9 +877,15 @@ export class ContactChat extends ContactStoreElement {
       return null;
     }
 
+    // unparseable values and zero-value times (e.g. go's zero time for a
+    // contact that has never been seen) mean there's no last seen to show
+    const lastSeen = DateTime.fromISO(lastSeenOn);
+    if (!lastSeen.isValid || lastSeen.year <= 1) {
+      return null;
+    }
+
     // recent activity speaks for itself in the chat - only surface last
     // seen once the contact has been quiet for at least an hour
-    const lastSeen = DateTime.fromISO(lastSeenOn);
     const minutes = DateTime.now().diff(lastSeen, 'minutes').minutes;
     if (minutes < 60) {
       return null;

--- a/test/temba-date.test.ts
+++ b/test/temba-date.test.ts
@@ -75,6 +75,24 @@ describe('temba-date', () => {
     expect(dateString).to.equal('Dec 1');
   });
 
+  it('renders nothing for zero-value times', async () => {
+    // a contact that has never been seen can come through as go's zero time -
+    // that isn't a real date and shouldn't render as "2021 years ago"
+    const date = await getDate({
+      value: '0001-01-01T00:00:00.000000Z',
+      display: 'duration'
+    });
+    expect(date.shadowRoot.querySelector('.date')).to.equal(null);
+  });
+
+  it('renders nothing for unparseable values', async () => {
+    const date = await getDate({
+      value: 'not-a-date',
+      display: 'duration'
+    });
+    expect(date.shadowRoot.querySelector('.date')).to.equal(null);
+  });
+
   it('renders inline', async () => {
     const el: HTMLElement = await fixture(html`
       <span


### PR DESCRIPTION
## Summary

A contact whose `last_seen_on` comes through as a zero-value time (`0001-01-01T00:00:00Z`) showed **"Last seen 2025 years ago"** on the ticket page, since luxon happily parses that as a real date and renders it relatively. Null values were already handled everywhere — only zero/invalid date strings sailed through.

## Changes

- **`src/display/TembaDate.ts`** — `render()` now returns lit's `nothing` for unparseable values and zero-value times (year ≤ 1, e.g. go's zero time), instead of a bogus relative duration or an empty span with an "Invalid DateTime" tooltip. This covers every list that renders dates through `temba-date` (tickets, runs, notifications, contacts).
- **`src/live/ContactChat.ts`** — `getLastSeen()` treats unparseable and zero-value times as never seen and returns null, so no "Last seen …" status line is rendered.
- **`test/temba-date.test.ts`** — new tests asserting that a zero-value time and an unparseable value each render nothing.

## Behavior

| `last_seen_on` value | Before | After |
| --- | --- | --- |
| `null` (never seen) | no status line | no status line (unchanged) |
| `0001-01-01T00:00:00Z` | "Last seen 2025 years ago" | no status line |
| `not-a-date` | empty span with "Invalid DateTime" tooltip | renders nothing |
| valid datetime | relative duration | relative duration (unchanged) |

## Test plan

- [x] New `temba-date` tests for zero-value and unparseable inputs
- [x] Full suite green (2185 tests)
- [x] Verified end-to-end against a dev stack: gave a ticket's contact a zero-value `last_seen_on` — pre-fix the ticket page shows "Last seen 2025 years ago", post-fix it renders nothing