### PR TITLE
Fix simulator phone screen shifting left on Linux

### DIFF
--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -630,6 +630,7 @@ export class Simulator extends RapidElement {
       }
       .message-input input {
         flex: 1;
+        min-width: 0;
         border: 1px solid #c6c6c857;
         border-radius: 20px;
         padding: 8px 15px;


### PR DESCRIPTION
The "Enter Message" input in the simulator has `flex: 1` but no `min-width` override, so as a flex item it could not shrink below its intrinsic default width (`size="20"` characters, computed from the platform's default form-control font). On Linux the wider fallback font made the input row want 281px inside the 258px phone screen — 23px of overflow past the right edge of the frame.

Whenever the input was focused (the simulator focuses it after each sprint, and Playwright's `fill()` also focuses it), the browser scrolled the `overflow: hidden` phone frame to bring it into view, leaving `scrollLeft: 23` on the frame. That shifted the whole chat screen 23px left and exposed 23px of the frame's black background down the right side in e2e screenshots taken on CI.

Adding `min-width: 0` lets the input shrink to fit, making the layout identical on macOS and Linux. Verified in the Linux container: build passes and all simulator tests (including screenshot comparisons) pass.