### PR TITLE
Expand test coverage across message table, flow editor, store and pure logic modules

### DIFF
--- a/test/base-list-editor.test.ts
+++ b/test/base-list-editor.test.ts
@@ -297,7 +297,9 @@ describe('form/BaseListEditor', () => {
   describe('itemsEqual', () => {
     it('compares items structurally', async () => {
       const editor = await createEditor();
-      expect(editor.callItemsEqual({ text: 'a' }, { text: 'a' })).to.equal(true);
+      expect(editor.callItemsEqual({ text: 'a' }, { text: 'a' })).to.equal(
+        true
+      );
       expect(editor.callItemsEqual({ text: 'a' }, { text: 'b' })).to.equal(
         false
       );

--- a/test/base-list-editor.test.ts
+++ b/test/base-list-editor.test.ts
@@ -1,0 +1,306 @@
+import '../temba-modules';
+import { fixture, expect } from '@open-wc/testing';
+import { html, TemplateResult } from 'lit';
+import { BaseListEditor } from '../src/form/BaseListEditor';
+
+interface TextItem {
+  text: string;
+}
+
+/**
+ * A minimal concrete editor so the shared list behaviour can be exercised
+ * directly rather than through one of the richer subclasses.
+ */
+class TestListEditor extends BaseListEditor<TextItem> {
+  public isEmptyItem(item: TextItem): boolean {
+    return !item || !item.text || item.text.trim() === '';
+  }
+
+  public createEmptyItem(): TextItem {
+    return { text: '' };
+  }
+
+  public renderItem(item: TextItem, index: number): TemplateResult {
+    return html`<div class="item" data-index=${index}>${item.text}</div>`;
+  }
+
+  // thin public wrappers so tests can drive the protected surface
+  public get items(): TextItem[] {
+    return (this as any)._items;
+  }
+  public setItems(items: TextItem[]) {
+    (this as any)._items = items;
+  }
+  public callDisplayItems(): TextItem[] {
+    return (this as any).displayItems;
+  }
+  public callAddItem(item?: TextItem) {
+    return (this as any).addItem(item);
+  }
+  public callRemoveItem(index: number) {
+    return (this as any).removeItem(index);
+  }
+  public callCanRemoveItem(index: number) {
+    return (this as any).canRemoveItem(index);
+  }
+  public callHandleItemChange(index: number, item: TextItem) {
+    return (this as any).handleItemChange(index, item);
+  }
+  public callHandleFieldChange(index: number, field: string, value: any) {
+    return (this as any).handleFieldChange(index, field, value);
+  }
+  public callCleanItems(items: TextItem[]) {
+    return (this as any).cleanItems(items);
+  }
+  public callShouldShowAddButton() {
+    return (this as any).shouldShowAddButton();
+  }
+  public callItemsEqual(a: TextItem, b: TextItem) {
+    return (this as any).itemsEqual(a, b);
+  }
+}
+
+customElements.define('test-list-editor', TestListEditor);
+
+const createEditor = async (attrs = ''): Promise<TestListEditor> => {
+  return (await fixture(
+    `<test-list-editor ${attrs}></test-list-editor>`
+  )) as TestListEditor;
+};
+
+// records change events emitted by the editor
+const recordChanges = (editor: TestListEditor) => {
+  const seen: any[] = [];
+  editor.addEventListener('change', (e: any) => seen.push(e.detail.value));
+  return seen;
+};
+
+describe('form/BaseListEditor', () => {
+  describe('displayItems', () => {
+    it('returns the items as-is by default', async () => {
+      const editor = await createEditor();
+      editor.setItems([{ text: 'a' }]);
+      expect(editor.callDisplayItems()).to.deep.equal([{ text: 'a' }]);
+    });
+
+    it('appends a trailing empty item when maintaining one', async () => {
+      const editor = await createEditor('maintainEmptyItem');
+      editor.setItems([{ text: 'a' }]);
+      expect(editor.callDisplayItems()).to.deep.equal([
+        { text: 'a' },
+        { text: '' }
+      ]);
+    });
+
+    it('does not append a second empty item', async () => {
+      const editor = await createEditor('maintainEmptyItem');
+      editor.setItems([{ text: 'a' }, { text: '' }]);
+      expect(editor.callDisplayItems()).to.have.length(2);
+    });
+
+    it('stops appending once maxItems is reached', async () => {
+      const editor = await createEditor('maintainEmptyItem maxItems="2"');
+      editor.setItems([{ text: 'a' }, { text: 'b' }]);
+      expect(editor.callDisplayItems()).to.have.length(2);
+    });
+
+    it('does not mutate the underlying items', async () => {
+      const editor = await createEditor('maintainEmptyItem');
+      const items = [{ text: 'a' }];
+      editor.setItems(items);
+      editor.callDisplayItems();
+      expect(items).to.have.length(1);
+    });
+  });
+
+  describe('addItem', () => {
+    it('appends a new empty item', async () => {
+      const editor = await createEditor();
+      const changes = recordChanges(editor);
+      editor.callAddItem();
+      expect(editor.items).to.deep.equal([{ text: '' }]);
+      expect(changes).to.have.length(1);
+    });
+
+    it('appends a supplied item', async () => {
+      const editor = await createEditor();
+      editor.callAddItem({ text: 'hello' });
+      expect(editor.items).to.deep.equal([{ text: 'hello' }]);
+    });
+
+    it('refuses to go past maxItems', async () => {
+      const editor = await createEditor('maxItems="1"');
+      editor.setItems([{ text: 'a' }]);
+      const changes = recordChanges(editor);
+      editor.callAddItem({ text: 'b' });
+      expect(editor.items).to.have.length(1);
+      expect(changes).to.have.length(0);
+    });
+  });
+
+  describe('removeItem', () => {
+    it('removes the item at the given index', async () => {
+      const editor = await createEditor();
+      editor.setItems([{ text: 'a' }, { text: 'b' }, { text: 'c' }]);
+      editor.callRemoveItem(1);
+      expect(editor.items).to.deep.equal([{ text: 'a' }, { text: 'c' }]);
+    });
+
+    it('refuses to go below minItems', async () => {
+      const editor = await createEditor('minItems="2"');
+      editor.setItems([{ text: 'a' }, { text: 'b' }]);
+      const changes = recordChanges(editor);
+      editor.callRemoveItem(0);
+      expect(editor.items).to.have.length(2);
+      expect(changes).to.have.length(0);
+    });
+  });
+
+  describe('canRemoveItem', () => {
+    it('allows removing an ordinary item', async () => {
+      const editor = await createEditor();
+      editor.setItems([{ text: 'a' }, { text: 'b' }]);
+      expect(editor.callCanRemoveItem(0)).to.equal(true);
+    });
+
+    it('refuses when at the minimum', async () => {
+      const editor = await createEditor('minItems="2"');
+      editor.setItems([{ text: 'a' }, { text: 'b' }]);
+      expect(editor.callCanRemoveItem(0)).to.equal(false);
+    });
+
+    it('refuses to remove the maintained empty item', async () => {
+      const editor = await createEditor('maintainEmptyItem');
+      editor.setItems([{ text: 'a' }, { text: 'b' }]);
+      // index 2 is the auto-appended empty row
+      expect(editor.callCanRemoveItem(2)).to.equal(false);
+      expect(editor.callCanRemoveItem(0)).to.equal(true);
+    });
+  });
+
+  describe('handleItemChange', () => {
+    it('replaces the item and emits the new value', async () => {
+      const editor = await createEditor();
+      editor.setItems([{ text: 'a' }, { text: 'b' }]);
+      const changes = recordChanges(editor);
+      editor.callHandleItemChange(1, { text: 'updated' });
+      expect(editor.items).to.deep.equal([{ text: 'a' }, { text: 'updated' }]);
+      expect(changes[0]).to.deep.equal([{ text: 'a' }, { text: 'updated' }]);
+    });
+  });
+
+  describe('handleFieldChange', () => {
+    it('updates a single field on an existing item', async () => {
+      const editor = await createEditor();
+      editor.setItems([{ text: 'a' }]);
+      editor.callHandleFieldChange(0, 'text', 'changed');
+      expect(editor.items).to.deep.equal([{ text: 'changed' }]);
+    });
+
+    it('extends the list when editing the trailing empty row', async () => {
+      const editor = await createEditor('maintainEmptyItem');
+      editor.setItems([{ text: 'a' }]);
+      editor.callHandleFieldChange(1, 'text', 'new');
+      expect(editor.items).to.deep.equal([{ text: 'a' }, { text: 'new' }]);
+    });
+
+    it('fills any gap with empty items', async () => {
+      const editor = await createEditor();
+      editor.setItems([{ text: 'a' }]);
+      editor.callHandleFieldChange(3, 'text', 'far');
+      expect(editor.items).to.have.length(4);
+      expect(editor.items[1]).to.deep.equal({ text: '' });
+      expect(editor.items[3]).to.deep.equal({ text: 'far' });
+    });
+
+    it('refuses to extend past maxItems', async () => {
+      const editor = await createEditor('maxItems="1"');
+      editor.setItems([{ text: 'a' }]);
+      const changes = recordChanges(editor);
+      editor.callHandleFieldChange(1, 'text', 'new');
+      expect(editor.items).to.have.length(1);
+      expect(changes).to.have.length(0);
+    });
+
+    it('preserves other fields on the item', async () => {
+      const editor = await createEditor();
+      editor.setItems([{ text: 'a', extra: 'keep' } as any]);
+      editor.callHandleFieldChange(0, 'text', 'changed');
+      expect(editor.items[0]).to.deep.equal({ text: 'changed', extra: 'keep' });
+    });
+  });
+
+  describe('cleanItems', () => {
+    it('passes items through untouched by default', async () => {
+      const editor = await createEditor();
+      const items = [{ text: 'a' }, { text: '' }];
+      expect(editor.callCleanItems(items)).to.deep.equal(items);
+    });
+
+    it('strips empty items when maintaining an empty row', async () => {
+      const editor = await createEditor('maintainEmptyItem');
+      expect(
+        editor.callCleanItems([{ text: 'a' }, { text: '  ' }, { text: 'b' }])
+      ).to.deep.equal([{ text: 'a' }, { text: 'b' }]);
+    });
+
+    it('emits the cleaned value on change', async () => {
+      const editor = await createEditor('maintainEmptyItem');
+      const changes = recordChanges(editor);
+      editor.callHandleItemChange(0, { text: '' });
+      expect(changes[0]).to.deep.equal([]);
+    });
+  });
+
+  describe('add button', () => {
+    it('is shown by default', async () => {
+      const editor = await createEditor();
+      expect(editor.callShouldShowAddButton()).to.equal(true);
+      await editor.updateComplete;
+      expect(editor.shadowRoot.querySelector('.add-btn')).to.not.equal(null);
+    });
+
+    it('is hidden once maxItems is reached', async () => {
+      const editor = await createEditor('maxItems="1"');
+      editor.setItems([{ text: 'a' }]);
+      expect(editor.callShouldShowAddButton()).to.equal(false);
+    });
+
+    it('is hidden when an empty row is maintained instead', async () => {
+      const editor = await createEditor('maintainEmptyItem');
+      expect(editor.callShouldShowAddButton()).to.equal(false);
+      await editor.updateComplete;
+      expect(editor.shadowRoot.querySelector('.add-btn')).to.equal(null);
+    });
+
+    it('adds an item when clicked', async () => {
+      const editor = await createEditor();
+      await editor.updateComplete;
+      const button = editor.shadowRoot.querySelector(
+        '.add-btn'
+      ) as HTMLButtonElement;
+      button.click();
+      expect(editor.items).to.have.length(1);
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders a row per display item', async () => {
+      const editor = await createEditor('maintainEmptyItem');
+      editor.setItems([{ text: 'a' }, { text: 'b' }]);
+      await editor.updateComplete;
+      // two real rows plus the maintained empty one
+      expect(editor.shadowRoot.querySelectorAll('.item')).to.have.length(3);
+    });
+  });
+
+  describe('itemsEqual', () => {
+    it('compares items structurally', async () => {
+      const editor = await createEditor();
+      expect(editor.callItemsEqual({ text: 'a' }, { text: 'a' })).to.equal(true);
+      expect(editor.callItemsEqual({ text: 'a' }, { text: 'b' })).to.equal(
+        false
+      );
+    });
+  });
+});

--- a/test/excellent-caret-utils.test.ts
+++ b/test/excellent-caret-utils.test.ts
@@ -1,0 +1,184 @@
+import { expect, fixture } from '@open-wc/testing';
+import {
+  getSelectionFromRoot,
+  getTextFromEditableDiv,
+  getCaretOffset,
+  getCaretEndOffset,
+  setCaretOffset,
+  setCaretRange
+} from '../src/excellent/caret-utils';
+
+// builds a contenteditable div matching the shape our renderer produces
+const editable = async (inner: string): Promise<HTMLElement> => {
+  return (await fixture(
+    `<div contenteditable="true">${inner}</div>`
+  )) as HTMLElement;
+};
+
+const spans = (...texts: string[]) =>
+  texts.map((t) => `<span class="tok">${t}</span>`).join('');
+
+describe('excellent/caret-utils', () => {
+  afterEach(() => {
+    const selection = window.getSelection();
+    if (selection) selection.removeAllRanges();
+  });
+
+  describe('getSelectionFromRoot', () => {
+    it('falls back to the window selection for light DOM elements', async () => {
+      const element = await editable(spans('hello'));
+      expect(getSelectionFromRoot(element)).to.equal(window.getSelection());
+    });
+  });
+
+  describe('getTextFromEditableDiv', () => {
+    it('returns empty string for an empty editable', async () => {
+      const element = await editable('');
+      expect(getTextFromEditableDiv(element)).to.equal('');
+    });
+
+    it('concatenates the text of token spans', async () => {
+      const element = await editable(spans('hello', ' ', 'world'));
+      expect(getTextFromEditableDiv(element)).to.equal('hello world');
+    });
+
+    it('reads newlines held inside token spans', async () => {
+      const element = await editable(spans('a', '\n', 'b'));
+      expect(getTextFromEditableDiv(element)).to.equal('a\nb');
+    });
+
+    it('ignores the trailing sentinel br', async () => {
+      const element = await editable(spans('hello') + '<br data-sentinel>');
+      expect(getTextFromEditableDiv(element)).to.equal('hello');
+    });
+
+    it('translates a browser inserted br into a newline', async () => {
+      const element = await editable(spans('a') + '<br>' + spans('b'));
+      expect(getTextFromEditableDiv(element)).to.equal('a\nb');
+    });
+
+    it('does not prefix a newline before a leading block', async () => {
+      const element = await editable('<div>a</div>');
+      expect(getTextFromEditableDiv(element)).to.equal('a');
+    });
+
+    it('prefixes a newline before blocks that follow content', async () => {
+      const element = await editable('<div>a</div><div>b</div>');
+      expect(getTextFromEditableDiv(element)).to.equal('a\nb');
+    });
+
+    it('prefixes a newline before a block following inline text', async () => {
+      const element = await editable('x<div>b</div>');
+      expect(getTextFromEditableDiv(element)).to.equal('x\nb');
+    });
+
+    it('treats paragraphs as blocks too', async () => {
+      const element = await editable('<p>a</p><p>b</p>');
+      expect(getTextFromEditableDiv(element)).to.equal('a\nb');
+    });
+
+    it('reads text nested inside elements', async () => {
+      const element = await editable('<span><span>deep</span></span>');
+      expect(getTextFromEditableDiv(element)).to.equal('deep');
+    });
+
+    it('skips empty blocks when deciding on the newline prefix', async () => {
+      // the leading empty div contributes nothing, so no newline precedes "a"
+      const element = await editable('<div></div><div>a</div>');
+      expect(getTextFromEditableDiv(element)).to.equal('a');
+    });
+  });
+
+  describe('caret offsets', () => {
+    it('returns zero when there is no selection', async () => {
+      const element = await editable(spans('hello'));
+      window.getSelection().removeAllRanges();
+      expect(getCaretOffset(element)).to.equal(0);
+      expect(getCaretEndOffset(element)).to.equal(0);
+    });
+
+    it('round trips an offset inside a single span', async () => {
+      const element = await editable(spans('hello world'));
+      setCaretOffset(element, 4);
+      expect(getCaretOffset(element)).to.equal(4);
+    });
+
+    it('round trips an offset across several spans', async () => {
+      const element = await editable(spans('hello', ' ', 'world'));
+      for (const offset of [0, 3, 5, 6, 9]) {
+        setCaretOffset(element, offset);
+        expect(getCaretOffset(element), `offset ${offset}`).to.equal(offset);
+      }
+    });
+
+    it('round trips an offset past a newline span', async () => {
+      const element = await editable(spans('ab', '\n', 'cd'));
+      for (const offset of [1, 2, 3, 4]) {
+        setCaretOffset(element, offset);
+        expect(getCaretOffset(element), `offset ${offset}`).to.equal(offset);
+      }
+    });
+
+    it('places the caret at the very end of the content', async () => {
+      const element = await editable(spans('hello'));
+      setCaretOffset(element, 5);
+      expect(getCaretOffset(element)).to.equal(5);
+    });
+
+    it('places the caret before a trailing sentinel br', async () => {
+      const element = await editable(spans('hello') + '<br data-sentinel>');
+      setCaretOffset(element, 5);
+      expect(getCaretOffset(element)).to.equal(5);
+    });
+
+    it('round trips offsets around a browser inserted br', async () => {
+      const element = await editable(spans('ab') + '<br>' + spans('cd'));
+      expect(getTextFromEditableDiv(element)).to.equal('ab\ncd');
+      for (const offset of [2, 3, 4]) {
+        setCaretOffset(element, offset);
+        expect(getCaretOffset(element), `offset ${offset}`).to.equal(offset);
+      }
+    });
+
+    it('leaves the selection alone for an unreachable offset', async () => {
+      const element = await editable(spans('hi'));
+      setCaretOffset(element, 1);
+      // well past the end of the content, so no position can be resolved
+      setCaretOffset(element, 99);
+      expect(getCaretOffset(element)).to.equal(1);
+    });
+  });
+
+  describe('setCaretRange', () => {
+    it('selects a range by plain text offsets', async () => {
+      const element = await editable(spans('hello world'));
+      setCaretRange(element, 2, 7);
+      expect(getCaretOffset(element)).to.equal(2);
+      expect(getCaretEndOffset(element)).to.equal(7);
+      expect(window.getSelection().toString()).to.equal('llo w');
+    });
+
+    it('selects across span boundaries', async () => {
+      const element = await editable(spans('hello', ' ', 'world'));
+      setCaretRange(element, 3, 8);
+      expect(getCaretOffset(element)).to.equal(3);
+      expect(getCaretEndOffset(element)).to.equal(8);
+      expect(window.getSelection().toString()).to.equal('lo wo');
+    });
+
+    it('collapses to a caret when start and end match', async () => {
+      const element = await editable(spans('hello'));
+      setCaretRange(element, 2, 2);
+      expect(getCaretOffset(element)).to.equal(2);
+      expect(getCaretEndOffset(element)).to.equal(2);
+      expect(window.getSelection().toString()).to.equal('');
+    });
+
+    it('leaves the selection alone when an endpoint cannot be resolved', async () => {
+      const element = await editable(spans('hi'));
+      setCaretRange(element, 0, 1);
+      setCaretRange(element, 0, 99);
+      expect(getCaretEndOffset(element)).to.equal(1);
+    });
+  });
+});

--- a/test/excellent-parser.test.ts
+++ b/test/excellent-parser.test.ts
@@ -1,0 +1,262 @@
+import { expect } from '@open-wc/testing';
+import ExcellentParser, { isWordChar } from '../src/excellent/ExcellentParser';
+
+const parser = new ExcellentParser('@', [
+  'contact',
+  'fields',
+  'globals',
+  'urns',
+  'results',
+  'parent',
+  'child'
+]);
+
+describe('excellent/ExcellentParser', () => {
+  describe('isWordChar', () => {
+    it('accepts letters, digits and underscore', () => {
+      for (const ch of 'azAZ09_') {
+        expect(isWordChar(ch), `expected ${ch} to be a word char`).to.equal(
+          true
+        );
+      }
+    });
+
+    it('rejects punctuation', () => {
+      for (const ch of ' .,()@"-') {
+        expect(isWordChar(ch), `expected ${ch} to not be a word char`).to.equal(
+          false
+        );
+      }
+    });
+
+    it('treats the numeric end of input sentinel as a word char', () => {
+      // findExpressions passes 0 for "past the end of the input", which the
+      // '0' <= ch <= '9' comparison coerces numerically and so accepts;
+      // callers guard on nextCh === 0 separately rather than relying on this
+      expect(isWordChar(0)).to.equal(true);
+    });
+  });
+
+  describe('expressionContext', () => {
+    it('returns null when there are no expressions', () => {
+      expect(parser.expressionContext('')).to.equal(null);
+      expect(parser.expressionContext('hello there')).to.equal(null);
+    });
+
+    it('returns the expression being typed, without its prefix', () => {
+      expect(parser.expressionContext('hi @contact')).to.equal('contact');
+      expect(parser.expressionContext('hi @contact.na')).to.equal('contact.na');
+    });
+
+    it('returns null once an identifier expression has ended', () => {
+      // the trailing space terminates the expression, so nothing is being edited
+      expect(parser.expressionContext('hi @contact.name ')).to.equal(null);
+      expect(parser.expressionContext('hi @contact.name and more')).to.equal(
+        null
+      );
+    });
+
+    it('returns an unbalanced parenthesised expression as still open', () => {
+      expect(parser.expressionContext('hi @(1 + ')).to.equal('(1 + ');
+      expect(parser.expressionContext('hi @(upper(')).to.equal('(upper(');
+    });
+
+    it('returns null once parentheses balance and the expression closes', () => {
+      expect(parser.expressionContext('hi @(1 + 2)')).to.equal(null);
+    });
+
+    it('tracks only the last expression in the text', () => {
+      expect(parser.expressionContext('@contact.name said @globa')).to.equal(
+        'globa'
+      );
+    });
+
+    it('ignores escaped prefixes', () => {
+      expect(parser.expressionContext('email me @@ho')).to.equal(null);
+    });
+  });
+
+  describe('autoCompleteContext', () => {
+    it('returns the identifier being completed', () => {
+      expect(parser.autoCompleteContext('contact')).to.equal('contact');
+      expect(parser.autoCompleteContext('contact.na')).to.equal('contact.na');
+    });
+
+    it('returns null inside an open string literal', () => {
+      expect(parser.autoCompleteContext('(upper("cont')).to.equal(null);
+    });
+
+    it('resumes completion after a string literal closes', () => {
+      expect(parser.autoCompleteContext('(upper("abc") & contact')).to.equal(
+        'contact'
+      );
+    });
+
+    it('flags a bare open parenthesis with a leading hash', () => {
+      // '#' marks that a function name is being completed rather than a field
+      expect(parser.autoCompleteContext('(')).to.equal(null);
+      expect(parser.autoCompleteContext('(upper(')).to.equal('#upper');
+    });
+
+    it('offers nothing directly after a closed function call', () => {
+      // the closing paren rewinds past the whole call, leaving no fragment
+      expect(parser.autoCompleteContext('(upper(contact.name)')).to.equal(null);
+    });
+
+    it('resumes completion after a closed function call', () => {
+      expect(
+        parser.autoCompleteContext('(upper(contact.name) & cont')
+      ).to.equal('cont');
+    });
+
+    it('completes the argument after a comma', () => {
+      expect(parser.autoCompleteContext('(split(contact.name, ')).to.equal(
+        '#split'
+      );
+    });
+
+    it('returns null when there is nothing completable', () => {
+      expect(parser.autoCompleteContext('')).to.equal(null);
+      expect(parser.autoCompleteContext('1 + 2')).to.equal(null);
+    });
+
+    it('stops at a non word, non period character', () => {
+      expect(parser.autoCompleteContext('1+contact.name')).to.equal(
+        'contact.name'
+      );
+    });
+  });
+
+  describe('functionContext', () => {
+    it('returns the enclosing function name', () => {
+      expect(parser.functionContext('(upper(')).to.equal('upper');
+      expect(parser.functionContext('(split(contact.name, ')).to.equal('split');
+    });
+
+    it('returns empty when not inside a function call', () => {
+      expect(parser.functionContext('')).to.equal('');
+      expect(parser.functionContext('contact.name')).to.equal('');
+    });
+
+    it('stops at an expression prefix', () => {
+      expect(parser.functionContext('@contact')).to.equal('');
+    });
+
+    it('ignores parentheses inside string literals', () => {
+      expect(parser.functionContext('(upper("a(b", ')).to.equal('upper');
+    });
+  });
+
+  describe('getContactFields', () => {
+    it('returns an empty list when there are no expressions', () => {
+      expect(parser.getContactFields('')).to.deep.equal([]);
+      expect(parser.getContactFields('just some text')).to.deep.equal([]);
+    });
+
+    it('finds a bare fields reference', () => {
+      expect(parser.getContactFields('hi @fields.age')).to.deep.equal(['age']);
+    });
+
+    it('finds a contact prefixed fields reference', () => {
+      expect(parser.getContactFields('hi @contact.fields.age')).to.deep.equal([
+        'age'
+      ]);
+    });
+
+    it('finds fields inside a parenthesised expression', () => {
+      expect(
+        parser.getContactFields('@(upper(contact.fields.first_name))')
+      ).to.deep.equal(['first_name']);
+    });
+
+    it('collects several distinct fields', () => {
+      const found = parser.getContactFields(
+        'hi @contact.fields.age you live in @fields.state'
+      );
+      expect(found.sort()).to.deep.equal(['age', 'state']);
+    });
+
+    it('de-duplicates repeated references to the same field', () => {
+      expect(
+        parser.getContactFields('@fields.age and again @contact.fields.age')
+      ).to.deep.equal(['age']);
+    });
+
+    it('handles parent and child scoped fields', () => {
+      expect(
+        parser.getContactFields('@parent.contact.fields.age')
+      ).to.deep.equal(['age']);
+    });
+
+    it('ignores non field references', () => {
+      expect(parser.getContactFields('@contact.name @globals.org')).to.deep.equal(
+        []
+      );
+    });
+  });
+
+  describe('findExpressions', () => {
+    it('returns nothing for text without expressions', () => {
+      expect(parser.findExpressions('')).to.have.length(0);
+      expect(parser.findExpressions('hello there')).to.have.length(0);
+    });
+
+    it('locates a simple identifier expression', () => {
+      const found = parser.findExpressions('hi @contact.name there');
+      expect(found).to.have.length(1);
+      expect(found[0].text).to.equal('@contact.name');
+      expect(found[0].start).to.equal(3);
+      expect(found[0].end).to.equal(16);
+      expect(found[0].closed).to.equal(false);
+    });
+
+    it('marks a balanced parenthesised expression as closed', () => {
+      const found = parser.findExpressions('@(1 + 2)');
+      expect(found).to.have.length(1);
+      expect(found[0].text).to.equal('@(1 + 2)');
+      expect(found[0].closed).to.equal(true);
+    });
+
+    it('does not treat an unbalanced expression as closed', () => {
+      const found = parser.findExpressions('@(1 + 2');
+      expect(found).to.have.length(1);
+      expect(found[0].closed).to.equal(false);
+    });
+
+    it('ignores parentheses inside string literals', () => {
+      const found = parser.findExpressions('@("a)b")');
+      expect(found).to.have.length(1);
+      expect(found[0].text).to.equal('@("a)b")');
+      expect(found[0].closed).to.equal(true);
+    });
+
+    it('skips expressions with a disallowed top level', () => {
+      expect(parser.findExpressions('hi @nonsense.foo there')).to.have.length(0);
+    });
+
+    it('allows an incomplete top level at the end of the input', () => {
+      // "cont" is a prefix of the allowed "contact" so it is offered while typing
+      const found = parser.findExpressions('hi @cont');
+      expect(found).to.have.length(1);
+      expect(found[0].text).to.equal('@cont');
+    });
+
+    it('ignores an escaped prefix', () => {
+      expect(parser.findExpressions('email me @@contact')).to.have.length(0);
+    });
+
+    it('finds several expressions in one string', () => {
+      const found = parser.findExpressions('@contact.name lives in @fields.state');
+      expect(found.map((e) => e.text)).to.deep.equal([
+        '@contact.name',
+        '@fields.state'
+      ]);
+    });
+
+    it('terminates an identifier at a trailing period', () => {
+      const found = parser.findExpressions('call @contact. now');
+      expect(found).to.have.length(1);
+      expect(found[0].text).to.equal('@contact');
+    });
+  });
+});

--- a/test/excellent-parser.test.ts
+++ b/test/excellent-parser.test.ts
@@ -189,9 +189,9 @@ describe('excellent/ExcellentParser', () => {
     });
 
     it('ignores non field references', () => {
-      expect(parser.getContactFields('@contact.name @globals.org')).to.deep.equal(
-        []
-      );
+      expect(
+        parser.getContactFields('@contact.name @globals.org')
+      ).to.deep.equal([]);
     });
   });
 
@@ -231,7 +231,9 @@ describe('excellent/ExcellentParser', () => {
     });
 
     it('skips expressions with a disallowed top level', () => {
-      expect(parser.findExpressions('hi @nonsense.foo there')).to.have.length(0);
+      expect(parser.findExpressions('hi @nonsense.foo there')).to.have.length(
+        0
+      );
     });
 
     it('allows an incomplete top level at the end of the input', () => {
@@ -246,7 +248,9 @@ describe('excellent/ExcellentParser', () => {
     });
 
     it('finds several expressions in one string', () => {
-      const found = parser.findExpressions('@contact.name lives in @fields.state');
+      const found = parser.findExpressions(
+        '@contact.name lives in @fields.state'
+      );
       expect(found.map((e) => e.text)).to.deep.equal([
         '@contact.name',
         '@fields.state'

--- a/test/flow-audio-player.test.ts
+++ b/test/flow-audio-player.test.ts
@@ -1,0 +1,216 @@
+import { expect, fixture } from '@open-wc/testing';
+import { render } from 'lit-html';
+import { renderAudioPlayer } from '../src/flow/actions/audio-player';
+
+// a stand-in for HTMLAudioElement that lets tests drive playback events
+class FakeAudio {
+  public static created: FakeAudio[] = [];
+
+  public src: string;
+  public paused = true;
+  public currentTime = 0;
+  public duration = 0;
+  public playCalls = 0;
+  public pauseCalls = 0;
+  public playRejects = false;
+
+  private listeners: Record<string, (() => void)[]> = {};
+
+  constructor(url: string) {
+    this.src = url;
+    FakeAudio.created.push(this);
+  }
+
+  public addEventListener(type: string, handler: () => void) {
+    (this.listeners[type] ??= []).push(handler);
+  }
+
+  public play(): Promise<void> {
+    this.playCalls++;
+    if (this.playRejects) {
+      return Promise.reject(new Error('blocked'));
+    }
+    this.paused = false;
+    return Promise.resolve();
+  }
+
+  public pause() {
+    this.pauseCalls++;
+    this.paused = true;
+  }
+
+  public fire(type: string) {
+    (this.listeners[type] || []).forEach((handler) => handler());
+  }
+}
+
+const mount = async (url: string): Promise<HTMLElement> => {
+  const host = (await fixture('<div></div>')) as HTMLElement;
+  render(renderAudioPlayer(url), host);
+  return host.querySelector('.audio-player') as HTMLElement;
+};
+
+const playButton = (player: HTMLElement) =>
+  player.querySelector('.audio-play-btn') as HTMLElement;
+
+const progressBar = (player: HTMLElement) =>
+  player.querySelector('.audio-progress') as HTMLElement;
+
+const isPauseIcon = (player: HTMLElement) =>
+  playButton(player).innerHTML.includes('<rect');
+
+const click = (element: HTMLElement) =>
+  element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+describe('flow/actions/audio-player', () => {
+  let originalAudio: any;
+
+  beforeEach(() => {
+    originalAudio = (window as any).Audio;
+    (window as any).Audio = FakeAudio;
+    FakeAudio.created = [];
+  });
+
+  afterEach(() => {
+    (window as any).Audio = originalAudio;
+  });
+
+  describe('rendering', () => {
+    it('renders the player with its url and controls', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      expect(player.dataset.url).to.equal('http://example.com/clip.mp3');
+      expect(playButton(player)).to.not.equal(null);
+      expect(progressBar(player)).to.not.equal(null);
+      expect(progressBar(player).style.width).to.equal('0%');
+    });
+
+    it('starts with the play icon', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      expect(playButton(player).querySelector('polygon')).to.not.equal(null);
+      expect(isPauseIcon(player)).to.equal(false);
+    });
+
+    it('stops mouse events from reaching the canvas underneath', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      let bubbled = 0;
+      document.addEventListener('mousedown', () => bubbled++);
+      player.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      expect(bubbled).to.equal(0);
+    });
+  });
+
+  describe('playback', () => {
+    it('creates an audio element for the url and starts playing', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      click(playButton(player));
+      expect(FakeAudio.created).to.have.length(1);
+      expect(FakeAudio.created[0].src).to.equal('http://example.com/clip.mp3');
+      expect(FakeAudio.created[0].playCalls).to.equal(1);
+      expect(isPauseIcon(player)).to.equal(true);
+    });
+
+    it('pauses when clicked while playing', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      click(playButton(player));
+      click(playButton(player));
+      expect(FakeAudio.created).to.have.length(1);
+      expect(FakeAudio.created[0].pauseCalls).to.equal(1);
+      expect(isPauseIcon(player)).to.equal(false);
+    });
+
+    it('restarts after being paused', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      click(playButton(player));
+      click(playButton(player));
+      click(playButton(player));
+      // a fresh audio element is created for the restart
+      expect(FakeAudio.created).to.have.length(2);
+      expect(isPauseIcon(player)).to.equal(true);
+    });
+
+    it('does nothing without a url', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      delete player.dataset.url;
+      click(playButton(player));
+      expect(FakeAudio.created).to.have.length(0);
+    });
+
+    it('advances the progress bar as the clip plays', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      click(playButton(player));
+      const audio = FakeAudio.created[0];
+      audio.duration = 10;
+      audio.currentTime = 2.5;
+      audio.fire('timeupdate');
+      expect(progressBar(player).style.width).to.equal('25%');
+    });
+
+    it('leaves the progress bar alone when the duration is unknown', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      click(playButton(player));
+      FakeAudio.created[0].fire('timeupdate');
+      expect(progressBar(player).style.width).to.equal('0%');
+    });
+  });
+
+  describe('resetting', () => {
+    it('resets when the clip ends', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      click(playButton(player));
+      const audio = FakeAudio.created[0];
+      audio.duration = 10;
+      audio.currentTime = 5;
+      audio.fire('timeupdate');
+      expect(progressBar(player).style.width).to.equal('50%');
+
+      audio.fire('ended');
+      expect(isPauseIcon(player)).to.equal(false);
+      expect(progressBar(player).style.width).to.equal('0%');
+    });
+
+    it('resets when the clip errors', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      click(playButton(player));
+      FakeAudio.created[0].fire('error');
+      expect(isPauseIcon(player)).to.equal(false);
+      expect(progressBar(player).style.width).to.equal('0%');
+    });
+
+    it('resets when playback is refused', async () => {
+      const player = await mount('http://example.com/clip.mp3');
+      (window as any).Audio = class extends FakeAudio {
+        public playRejects = true;
+      };
+      click(playButton(player));
+      // let the rejected play promise settle
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(isPauseIcon(player)).to.equal(false);
+      expect(progressBar(player).style.width).to.equal('0%');
+    });
+  });
+
+  describe('single active player', () => {
+    it('stops the previous clip when another starts', async () => {
+      const first = await mount('http://example.com/one.mp3');
+      const second = await mount('http://example.com/two.mp3');
+
+      click(playButton(first));
+      const firstAudio = FakeAudio.created[0];
+      firstAudio.duration = 10;
+      firstAudio.currentTime = 5;
+      firstAudio.fire('timeupdate');
+      expect(progressBar(first).style.width).to.equal('50%');
+
+      click(playButton(second));
+
+      expect(firstAudio.pauseCalls).to.equal(1);
+      expect(firstAudio.currentTime).to.equal(0);
+      // the first player is returned to its resting state
+      expect(isPauseIcon(first)).to.equal(false);
+      expect(progressBar(first).style.width).to.equal('0%');
+      // and the second is now playing
+      expect(isPauseIcon(second)).to.equal(true);
+    });
+  });
+});

--- a/test/flow-plumber-overlays.test.ts
+++ b/test/flow-plumber-overlays.test.ts
@@ -1,0 +1,342 @@
+import '../temba-modules';
+import { fixture, expect } from '@open-wc/testing';
+import { Plumber } from '../src/flow/Plumber';
+import { mockPOST, clearMockPosts } from './utils.test';
+
+// fetchRecentContacts calls fetch with only an AbortSignal, so the shared
+// fetch mock (which keys off options.method) looks the request up in its
+// non-GET list - hence mockPOST here for what is really a GET
+const mockRecentContacts = (body: any, status = '200') =>
+  mockPOST(/recent_contacts/, body, {}, status);
+
+const FLOW_UUID = 'flow-uuid-1';
+
+const createPlumber = async (editor: any = {}) => {
+  const canvas = (await fixture('<div class="canvas"></div>')) as HTMLElement;
+  return new Plumber(canvas, editor);
+};
+
+const withDefinition = () => ({ definition: { uuid: FLOW_UUID } });
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+describe('flow/Plumber overlays', () => {
+  afterEach(() => {
+    clearMockPosts();
+    document
+      .querySelectorAll('.recent-contacts-popup')
+      .forEach((el) => el.remove());
+  });
+
+  describe('getFlowUuid', () => {
+    it('reads the uuid from the editor definition', async () => {
+      const plumber = await createPlumber(withDefinition());
+      expect((plumber as any).getFlowUuid()).to.equal(FLOW_UUID);
+    });
+
+    it('returns null without a definition', async () => {
+      const plumber = await createPlumber({});
+      expect((plumber as any).getFlowUuid()).to.equal(null);
+    });
+
+    it('returns null without an editor', async () => {
+      const plumber = await createPlumber(null);
+      expect((plumber as any).getFlowUuid()).to.equal(null);
+    });
+  });
+
+  describe('createOverlayElement', () => {
+    it('renders the activity count', async () => {
+      const plumber = await createPlumber(withDefinition());
+      const overlay = (plumber as any).createOverlayElement(5, 'exit-1:node-2');
+      expect(overlay.className).to.equal('activity-overlay');
+      expect(overlay.textContent).to.equal('5');
+      expect(overlay.getAttribute('data-activity-key')).to.equal(
+        'exit-1:node-2'
+      );
+    });
+
+    it('formats large counts with separators', async () => {
+      const plumber = await createPlumber(withDefinition());
+      const overlay = (plumber as any).createOverlayElement(
+        12345,
+        'exit-1:node-2'
+      );
+      expect(overlay.textContent).to.equal((12345).toLocaleString());
+    });
+  });
+
+  describe('findOverlayForActivityKey', () => {
+    it('finds the overlay carrying the key', async () => {
+      const plumber = await createPlumber(withDefinition());
+      const first = (plumber as any).createOverlayElement(1, 'exit-1:node-2');
+      const second = (plumber as any).createOverlayElement(2, 'exit-3:node-4');
+      (plumber as any).overlays.set('exit-1', first);
+      (plumber as any).overlays.set('exit-3', second);
+
+      expect(
+        (plumber as any).findOverlayForActivityKey('exit-3:node-4')
+      ).to.equal(second);
+    });
+
+    it('returns null when no overlay matches', async () => {
+      const plumber = await createPlumber(withDefinition());
+      expect(
+        (plumber as any).findOverlayForActivityKey('nonsense')
+      ).to.equal(null);
+    });
+  });
+
+  describe('fetchRecentContacts', () => {
+    const ACTIVITY_KEY = 'exit-1:node-2';
+
+    it('caches the contacts it fetches', async () => {
+      mockRecentContacts([
+        { contact: { uuid: 'c1', name: 'Ann' }, operand: 'red', time: null }
+      ]);
+      const plumber = await createPlumber(withDefinition());
+
+      await (plumber as any).fetchRecentContacts(ACTIVITY_KEY, FLOW_UUID);
+
+      expect((plumber as any).recentContactsCache[ACTIVITY_KEY]).to.have.length(
+        1
+      );
+      expect(
+        (plumber as any).recentContactsCache[ACTIVITY_KEY][0].contact.name
+      ).to.equal('Ann');
+    });
+
+    it('does not refetch what it already has', async () => {
+      const plumber = await createPlumber(withDefinition());
+      (plumber as any).recentContactsCache[ACTIVITY_KEY] = ['cached'];
+
+      // no mock is registered, so a real fetch would fail the test
+      await (plumber as any).fetchRecentContacts(ACTIVITY_KEY, FLOW_UUID);
+      expect((plumber as any).recentContactsCache[ACTIVITY_KEY]).to.deep.equal([
+        'cached'
+      ]);
+    });
+
+    it('clears the pending marker once done', async () => {
+      mockRecentContacts([]);
+      const plumber = await createPlumber(withDefinition());
+      await (plumber as any).fetchRecentContacts(ACTIVITY_KEY, FLOW_UUID);
+      expect((plumber as any).pendingFetches[ACTIVITY_KEY]).to.equal(undefined);
+    });
+
+    it('survives a failed request', async () => {
+      mockRecentContacts({ detail: 'boom' }, '500');
+      const plumber = await createPlumber(withDefinition());
+
+      await (plumber as any).fetchRecentContacts(ACTIVITY_KEY, FLOW_UUID);
+
+      expect((plumber as any).recentContactsCache[ACTIVITY_KEY]).to.equal(
+        undefined
+      );
+      expect((plumber as any).pendingFetches[ACTIVITY_KEY]).to.equal(undefined);
+    });
+  });
+
+  describe('renderRecentContactsPopup', () => {
+    const popupFor = async (contacts: any[]) => {
+      const plumber = await createPlumber(withDefinition());
+      const popup = document.createElement('div');
+      (plumber as any).recentContactsPopup = popup;
+      (plumber as any).renderRecentContactsPopup(contacts);
+      return popup;
+    };
+
+    it('reports when there is nothing to show', async () => {
+      const popup = await popupFor([]);
+      expect(popup.innerHTML).to.contain('No Recent Contacts');
+    });
+
+    it('lists each contact', async () => {
+      const popup = await popupFor([
+        { contact: { uuid: 'c1', name: 'Ann' } },
+        { contact: { uuid: 'c2', name: 'Bo' } }
+      ]);
+      expect(popup.querySelectorAll('.contact-row')).to.have.length(2);
+      expect(popup.textContent).to.contain('Ann');
+      expect(popup.textContent).to.contain('Bo');
+      expect(
+        popup.querySelector('.contact-name').getAttribute('data-uuid')
+      ).to.equal('c1');
+    });
+
+    it('shows the matching operand when there is one', async () => {
+      const popup = await popupFor([
+        { contact: { uuid: 'c1', name: 'Ann' }, operand: 'red' }
+      ]);
+      expect(popup.querySelector('.contact-operand').textContent).to.equal(
+        'red'
+      );
+    });
+
+    it('omits the operand when there is none', async () => {
+      const popup = await popupFor([{ contact: { uuid: 'c1', name: 'Ann' } }]);
+      expect(popup.querySelector('.contact-operand')).to.equal(null);
+    });
+
+    it('describes recent times in minutes', async () => {
+      const popup = await popupFor([
+        {
+          contact: { uuid: 'c1', name: 'Ann' },
+          time: new Date(Date.now() - 5 * 60000).toISOString()
+        }
+      ]);
+      expect(popup.querySelector('.contact-time').textContent).to.equal(
+        '5m ago'
+      );
+    });
+
+    it('describes very recent times as just now', async () => {
+      const popup = await popupFor([
+        {
+          contact: { uuid: 'c1', name: 'Ann' },
+          time: new Date().toISOString()
+        }
+      ]);
+      expect(popup.querySelector('.contact-time').textContent).to.equal(
+        'just now'
+      );
+    });
+
+    it('describes older times in hours and days', async () => {
+      const hours = await popupFor([
+        {
+          contact: { uuid: 'c1', name: 'Ann' },
+          time: new Date(Date.now() - 3 * 3600000).toISOString()
+        }
+      ]);
+      expect(hours.querySelector('.contact-time').textContent).to.equal(
+        '3h ago'
+      );
+
+      const days = await popupFor([
+        {
+          contact: { uuid: 'c1', name: 'Ann' },
+          time: new Date(Date.now() - 2 * 86400000).toISOString()
+        }
+      ]);
+      expect(days.querySelector('.contact-time').textContent).to.equal(
+        '2d ago'
+      );
+    });
+
+    it('does nothing without a popup element', async () => {
+      const plumber = await createPlumber(withDefinition());
+      // no throw is the assertion here
+      (plumber as any).renderRecentContactsPopup([]);
+    });
+  });
+
+  describe('showRecentContacts', () => {
+    const ACTIVITY_KEY = 'exit-1:node-2';
+
+    it('does nothing when there is no matching overlay', async () => {
+      const plumber = await createPlumber(withDefinition());
+      await (plumber as any).showRecentContacts(ACTIVITY_KEY, FLOW_UUID);
+      expect((plumber as any).recentContactsPopup).to.equal(null);
+    });
+
+    it('creates and positions a popup beneath the overlay', async () => {
+      mockRecentContacts([{ contact: { uuid: 'c1', name: 'Ann' } }]);
+      const plumber = await createPlumber(withDefinition());
+
+      const overlay = (plumber as any).createOverlayElement(3, ACTIVITY_KEY);
+      document.body.appendChild(overlay);
+      (plumber as any).overlays.set('exit-1', overlay);
+
+      try {
+        await (plumber as any).fetchRecentContacts(ACTIVITY_KEY, FLOW_UUID);
+        await (plumber as any).showRecentContacts(ACTIVITY_KEY, FLOW_UUID);
+        await settle();
+
+        const popup = (plumber as any).recentContactsPopup as HTMLElement;
+        expect(popup).to.not.equal(null);
+        expect(popup.className).to.contain('recent-contacts-popup');
+        expect(popup.style.position).to.equal('absolute');
+        expect(popup.textContent).to.contain('Ann');
+        expect((plumber as any).hoveredActivityKey).to.equal(ACTIVITY_KEY);
+      } finally {
+        overlay.remove();
+      }
+    });
+  });
+
+  describe('positionPopup', () => {
+    it('places the popup just below the overlay', async () => {
+      const plumber = await createPlumber(withDefinition());
+      const popup = document.createElement('div');
+      (plumber as any).recentContactsPopup = popup;
+      document.body.appendChild(popup);
+
+      const overlay = document.createElement('div');
+      overlay.style.position = 'absolute';
+      overlay.style.left = '40px';
+      overlay.style.top = '60px';
+      overlay.style.width = '20px';
+      overlay.style.height = '10px';
+      document.body.appendChild(overlay);
+
+      try {
+        (plumber as any).positionPopup(overlay);
+        const rect = overlay.getBoundingClientRect();
+        expect(popup.style.left).to.equal(`${rect.left + window.scrollX}px`);
+        expect(popup.style.top).to.equal(
+          `${rect.bottom + window.scrollY + 5}px`
+        );
+        expect(popup.classList.contains('show')).to.equal(true);
+      } finally {
+        overlay.remove();
+        popup.remove();
+      }
+    });
+
+    it('does nothing without a popup', async () => {
+      const plumber = await createPlumber(withDefinition());
+      // no throw is the assertion here
+      (plumber as any).positionPopup(document.createElement('div'));
+    });
+  });
+
+  describe('removeAllEndpoints', () => {
+    it('unregisters the source for each exit of a node', async () => {
+      const plumber = await createPlumber(withDefinition());
+
+      const nodeEl = document.createElement('div');
+      nodeEl.id = 'node-1';
+      const exitOne = document.createElement('div');
+      exitOne.className = 'exit';
+      exitOne.id = 'exit-1';
+      const exitTwo = document.createElement('div');
+      exitTwo.className = 'exit';
+      exitTwo.id = 'exit-2';
+      nodeEl.appendChild(exitOne);
+      nodeEl.appendChild(exitTwo);
+      document.body.appendChild(nodeEl);
+
+      const cleaned: string[] = [];
+      (plumber as any).sources.set('exit-1', () => cleaned.push('exit-1'));
+      (plumber as any).sources.set('exit-2', () => cleaned.push('exit-2'));
+      (plumber as any).sources.set('other', () => cleaned.push('other'));
+
+      try {
+        plumber.removeAllEndpoints('node-1');
+
+        expect(cleaned.sort()).to.deep.equal(['exit-1', 'exit-2']);
+        expect((plumber as any).sources.has('exit-1')).to.equal(false);
+        expect((plumber as any).sources.has('other')).to.equal(true);
+      } finally {
+        nodeEl.remove();
+      }
+    });
+
+    it('does nothing for a node that is not on the page', async () => {
+      const plumber = await createPlumber(withDefinition());
+      // no throw is the assertion here
+      plumber.removeAllEndpoints('missing-node');
+    });
+  });
+});

--- a/test/flow-plumber-overlays.test.ts
+++ b/test/flow-plumber-overlays.test.ts
@@ -81,9 +81,9 @@ describe('flow/Plumber overlays', () => {
 
     it('returns null when no overlay matches', async () => {
       const plumber = await createPlumber(withDefinition());
-      expect(
-        (plumber as any).findOverlayForActivityKey('nonsense')
-      ).to.equal(null);
+      expect((plumber as any).findOverlayForActivityKey('nonsense')).to.equal(
+        null
+      );
     });
   });
 

--- a/test/flow-shared-rules.test.ts
+++ b/test/flow-shared-rules.test.ts
@@ -1,0 +1,500 @@
+import { expect } from '@open-wc/testing';
+import {
+  getOperatorValue,
+  isEmptyRuleItem,
+  createRuleItemChangeHandler,
+  value1VisibilityCondition,
+  value2VisibilityCondition,
+  createRulesItemConfig,
+  createRulesArrayConfig,
+  extractUserRules,
+  casesToFormRules
+} from '../src/flow/nodes/shared-rules';
+import { zustand } from '../src/store/AppState';
+
+// a rule that passes every emptiness check
+const validRule = (overrides: any = {}) => ({
+  operator: 'has_any_word',
+  value1: 'red',
+  value2: '',
+  category: 'Red',
+  ...overrides
+});
+
+describe('flow/nodes/shared-rules', () => {
+  describe('getOperatorValue', () => {
+    it('reads a plain string operator', () => {
+      expect(getOperatorValue('has_any_word')).to.equal('has_any_word');
+    });
+
+    it('trims surrounding whitespace', () => {
+      expect(getOperatorValue('  has_text  ')).to.equal('has_text');
+    });
+
+    it('reads the value from an object operator', () => {
+      expect(getOperatorValue({ value: 'has_text', name: 'has some text' })).to.equal(
+        'has_text'
+      );
+    });
+
+    it('reads the value from the first entry of an array operator', () => {
+      expect(
+        getOperatorValue([{ value: 'has_phrase', name: 'has the phrase' }])
+      ).to.equal('has_phrase');
+    });
+
+    it('returns empty for missing or unusable operators', () => {
+      expect(getOperatorValue(undefined)).to.equal('');
+      expect(getOperatorValue(null)).to.equal('');
+      expect(getOperatorValue('')).to.equal('');
+      expect(getOperatorValue([])).to.equal('');
+      expect(getOperatorValue({})).to.equal('');
+      expect(getOperatorValue([{ name: 'no value' }])).to.equal('');
+    });
+  });
+
+  describe('isEmptyRuleItem', () => {
+    it('treats a fully specified rule as non-empty', () => {
+      expect(isEmptyRuleItem(validRule())).to.equal(false);
+    });
+
+    it('treats a missing operator or category as empty', () => {
+      expect(isEmptyRuleItem(validRule({ operator: '' }))).to.equal(true);
+      expect(isEmptyRuleItem(validRule({ category: '' }))).to.equal(true);
+      expect(isEmptyRuleItem(validRule({ category: '   ' }))).to.equal(true);
+    });
+
+    it('requires value1 for a single operand operator', () => {
+      expect(isEmptyRuleItem(validRule({ value1: '' }))).to.equal(true);
+      expect(isEmptyRuleItem(validRule({ value1: '   ' }))).to.equal(true);
+    });
+
+    it('requires both values for a two operand operator', () => {
+      const between = {
+        operator: 'has_number_between',
+        category: 'Teens',
+        value1: '13',
+        value2: '19'
+      };
+      expect(isEmptyRuleItem(between)).to.equal(false);
+      expect(isEmptyRuleItem({ ...between, value2: '' })).to.equal(true);
+      expect(isEmptyRuleItem({ ...between, value1: '' })).to.equal(true);
+    });
+
+    it('requires no value for a zero operand operator', () => {
+      expect(
+        isEmptyRuleItem({
+          operator: 'has_text',
+          category: 'Has Text',
+          value1: ''
+        })
+      ).to.equal(false);
+    });
+
+    it('treats an unknown operator with a category as non-empty', () => {
+      expect(
+        isEmptyRuleItem({ operator: 'has_nonsense', category: 'Something' })
+      ).to.equal(false);
+    });
+  });
+
+  describe('createRuleItemChangeHandler', () => {
+    const onChange = createRuleItemChangeHandler();
+
+    it('does not mutate the items it is given', () => {
+      const items = [validRule()];
+      const result = onChange(0, 'value1', 'blue', items);
+      expect(result).to.not.equal(items);
+      expect(items[0].value1).to.equal('red');
+      expect(result[0].value1).to.equal('blue');
+    });
+
+    it('auto-populates an empty category from the new value', () => {
+      const items = [{ operator: 'has_any_word', value1: '', category: '' }];
+      const result = onChange(0, 'value1', 'blue', items);
+      expect(result[0].category).to.equal('Blue');
+    });
+
+    it('updates a category that still matches the old default', () => {
+      const items = [validRule()];
+      const result = onChange(0, 'value1', 'blue', items);
+      expect(result[0].category).to.equal('Blue');
+    });
+
+    it('leaves a user customized category alone', () => {
+      const items = [validRule({ category: 'Favourite Colour' })];
+      const result = onChange(0, 'value1', 'blue', items);
+      expect(result[0].category).to.equal('Favourite Colour');
+    });
+
+    it('sets the fixed category name when switching to a zero operand operator', () => {
+      const items = [validRule()];
+      const result = onChange(0, 'operator', 'has_text', items);
+      expect(result[0].category).to.equal('Has Text');
+    });
+
+    it('only touches the item at the given index', () => {
+      const items = [validRule(), validRule({ category: 'Second' })];
+      const result = onChange(0, 'value1', 'blue', items);
+      expect(result[1].category).to.equal('Second');
+      expect(result).to.have.length(2);
+    });
+  });
+
+  describe('value visibility conditions', () => {
+    it('shows value1 for operators taking at least one operand', () => {
+      expect(value1VisibilityCondition({ operator: 'has_any_word' })).to.equal(
+        true
+      );
+      expect(
+        value1VisibilityCondition({ operator: 'has_number_between' })
+      ).to.equal(true);
+    });
+
+    it('hides value1 for zero operand operators', () => {
+      expect(value1VisibilityCondition({ operator: 'has_text' })).to.equal(
+        false
+      );
+    });
+
+    it('shows value2 only for two operand operators', () => {
+      expect(
+        value2VisibilityCondition({ operator: 'has_number_between' })
+      ).to.equal(true);
+      expect(value2VisibilityCondition({ operator: 'has_any_word' })).to.equal(
+        false
+      );
+      expect(value2VisibilityCondition({ operator: 'has_text' })).to.equal(
+        false
+      );
+    });
+
+    it('defaults to showing value1 and hiding value2 for unknown operators', () => {
+      expect(value1VisibilityCondition({ operator: 'has_nonsense' })).to.equal(
+        true
+      );
+      expect(value2VisibilityCondition({ operator: 'has_nonsense' })).to.equal(
+        false
+      );
+    });
+  });
+
+  describe('createRulesItemConfig', () => {
+    it('labels the location operands for has_ward', () => {
+      const config = createRulesItemConfig();
+      expect(config.value1.placeholder({ operator: 'has_ward' })).to.equal(
+        'State'
+      );
+      expect(config.value2.placeholder({ operator: 'has_ward' })).to.equal(
+        'District'
+      );
+    });
+
+    it('labels the first operand for has_district', () => {
+      const config = createRulesItemConfig();
+      expect(config.value1.placeholder({ operator: 'has_district' })).to.equal(
+        'State'
+      );
+      expect(config.value2.placeholder({ operator: 'has_district' })).to.equal(
+        ''
+      );
+    });
+
+    it('uses no placeholder for ordinary operators', () => {
+      const config = createRulesItemConfig();
+      expect(config.value1.placeholder({ operator: 'has_any_word' })).to.equal(
+        ''
+      );
+      expect(config.value2.placeholder({ operator: 'has_any_word' })).to.equal(
+        ''
+      );
+    });
+
+    it('caps the category name length', () => {
+      expect(createRulesItemConfig().category.maxLength).to.equal(36);
+    });
+  });
+
+  describe('extractUserRules', () => {
+    it('returns an empty list when there are no rules', () => {
+      expect(extractUserRules({} as any)).to.deep.equal([]);
+      expect(extractUserRules({ rules: [] } as any)).to.deep.equal([]);
+    });
+
+    it('keeps a complete rule and carries the value across', () => {
+      const result = extractUserRules({
+        rules: [validRule()]
+      } as any);
+      expect(result).to.deep.equal([
+        {
+          operator: 'has_any_word',
+          value: 'red',
+          value1: 'red',
+          value2: '',
+          category: 'Red'
+        }
+      ]);
+    });
+
+    it('trims whitespace from values and category', () => {
+      const result = extractUserRules({
+        rules: [validRule({ value1: '  red  ', category: '  Red  ' })]
+      } as any);
+      expect(result[0].value1).to.equal('red');
+      expect(result[0].category).to.equal('Red');
+    });
+
+    it('drops rules missing an operator or category', () => {
+      const result = extractUserRules({
+        rules: [
+          validRule({ operator: '' }),
+          validRule({ category: '   ' }),
+          validRule()
+        ]
+      } as any);
+      expect(result).to.have.length(1);
+    });
+
+    it('drops a single operand rule with no value', () => {
+      const result = extractUserRules({
+        rules: [validRule({ value1: '  ' })]
+      } as any);
+      expect(result).to.have.length(0);
+    });
+
+    it('drops a two operand rule missing its second value', () => {
+      const result = extractUserRules({
+        rules: [
+          {
+            operator: 'has_number_between',
+            value1: '13',
+            value2: '',
+            category: 'Teens'
+          }
+        ]
+      } as any);
+      expect(result).to.have.length(0);
+    });
+
+    it('leaves value empty for two operand operators', () => {
+      const result = extractUserRules({
+        rules: [
+          {
+            operator: 'has_number_between',
+            value1: '13',
+            value2: '19',
+            category: 'Teens'
+          }
+        ]
+      } as any);
+      expect(result[0].value).to.equal('');
+      expect(result[0].value1).to.equal('13');
+      expect(result[0].value2).to.equal('19');
+    });
+
+    it('keeps a zero operand rule with no values', () => {
+      const result = extractUserRules({
+        rules: [{ operator: 'has_text', category: 'Has Text' }]
+      } as any);
+      expect(result).to.have.length(1);
+      expect(result[0].value).to.equal('');
+    });
+  });
+
+  describe('casesToFormRules', () => {
+    it('returns an empty list when the node has no router', () => {
+      expect(casesToFormRules({})).to.deep.equal([]);
+      expect(casesToFormRules({ router: {} })).to.deep.equal([]);
+    });
+
+    it('converts a single operand case', () => {
+      const rules = casesToFormRules({
+        router: {
+          cases: [
+            {
+              type: 'has_any_word',
+              arguments: ['red'],
+              category_uuid: 'cat-1'
+            }
+          ],
+          categories: [{ uuid: 'cat-1', name: 'Red' }]
+        }
+      });
+      expect(rules).to.have.length(1);
+      expect(rules[0].operator).to.deep.equal({
+        value: 'has_any_word',
+        name: 'has any of the words'
+      });
+      expect(rules[0].value1).to.equal('red');
+      expect(rules[0].value2).to.equal('');
+      expect(rules[0].category).to.equal('Red');
+    });
+
+    it('joins multiple arguments for a single operand case', () => {
+      const rules = casesToFormRules({
+        router: {
+          cases: [
+            {
+              type: 'has_any_word',
+              arguments: ['red', 'blue'],
+              category_uuid: 'cat-1'
+            }
+          ],
+          categories: [{ uuid: 'cat-1', name: 'Colours' }]
+        }
+      });
+      expect(rules[0].value1).to.equal('red blue');
+    });
+
+    it('splits the arguments of a two operand case', () => {
+      const rules = casesToFormRules({
+        router: {
+          cases: [
+            {
+              type: 'has_number_between',
+              arguments: ['13', '19'],
+              category_uuid: 'cat-1'
+            }
+          ],
+          categories: [{ uuid: 'cat-1', name: 'Teens' }]
+        }
+      });
+      expect(rules[0].value1).to.equal('13');
+      expect(rules[0].value2).to.equal('19');
+    });
+
+    it('leaves both values empty for a zero operand case', () => {
+      const rules = casesToFormRules({
+        router: {
+          cases: [
+            { type: 'has_text', arguments: [], category_uuid: 'cat-1' }
+          ],
+          categories: [{ uuid: 'cat-1', name: 'Has Text' }]
+        }
+      });
+      expect(rules[0].value1).to.equal('');
+      expect(rules[0].value2).to.equal('');
+    });
+
+    it('skips cases pointing at system categories', () => {
+      const rules = casesToFormRules({
+        router: {
+          cases: [
+            { type: 'has_any_word', arguments: ['red'], category_uuid: 'cat-1' },
+            { type: 'has_text', arguments: [], category_uuid: 'cat-other' }
+          ],
+          categories: [
+            { uuid: 'cat-1', name: 'Red' },
+            { uuid: 'cat-other', name: 'Other' }
+          ]
+        }
+      });
+      expect(rules).to.have.length(1);
+      expect(rules[0].category).to.equal('Red');
+    });
+
+    it('skips cases whose category is missing', () => {
+      const rules = casesToFormRules({
+        router: {
+          cases: [
+            { type: 'has_any_word', arguments: ['red'], category_uuid: 'gone' }
+          ],
+          categories: [{ uuid: 'cat-1', name: 'Red' }]
+        }
+      });
+      expect(rules).to.have.length(0);
+    });
+
+    it('falls back to the raw type for an unknown operator', () => {
+      const rules = casesToFormRules({
+        router: {
+          cases: [
+            {
+              type: 'has_nonsense',
+              arguments: ['a', 'b'],
+              category_uuid: 'cat-1'
+            }
+          ],
+          categories: [{ uuid: 'cat-1', name: 'Odd' }]
+        }
+      });
+      expect(rules[0].operator).to.deep.equal({
+        value: 'has_nonsense',
+        name: 'has_nonsense'
+      });
+      expect(rules[0].value1).to.equal('a b');
+    });
+  });
+
+  describe('createRulesArrayConfig', () => {
+    const originalFeatures = zustand.getState().features;
+
+    afterEach(() => {
+      zustand.setState({ features: originalFeatures });
+    });
+
+    it('exposes the shared emptiness and change behaviour', () => {
+      const config = createRulesArrayConfig([]);
+      expect(config.type).to.equal('array');
+      expect(config.isEmptyItem).to.equal(isEmptyRuleItem);
+      expect(config.maxItems).to.equal(100);
+      expect(config.sortable).to.equal(true);
+    });
+
+    it('uses the supplied help text', () => {
+      expect(createRulesArrayConfig([], 'Custom help').helpText).to.equal(
+        'Custom help'
+      );
+      expect(createRulesArrayConfig([]).helpText).to.equal(
+        'Define rules to categorize responses'
+      );
+    });
+
+    it('passes the operator options through to the item config', () => {
+      const options = [{ value: 'has_any_word', name: 'has any of the words' }];
+      const config = createRulesArrayConfig(options);
+      expect(config.itemConfig.operator.options).to.equal(options);
+    });
+
+    it('seeds a new item with the first non-location operator', () => {
+      zustand.setState({ features: [] });
+      const config = createRulesArrayConfig([]);
+      const created: any = config.createEmptyItem([]);
+      expect(created.operator[0].value).to.equal('has_any_word');
+    });
+
+    it('repeats the operator of the last rule that takes an operand', () => {
+      zustand.setState({ features: [] });
+      const config = createRulesArrayConfig([]);
+      const created: any = config.createEmptyItem([
+        { operator: 'has_any_word' },
+        { operator: 'has_phrase' }
+      ]);
+      expect(created.operator[0].value).to.equal('has_phrase');
+    });
+
+    it('ignores zero operand operators when picking the default', () => {
+      zustand.setState({ features: [] });
+      const config = createRulesArrayConfig([]);
+      const created: any = config.createEmptyItem([
+        { operator: 'has_phrase' },
+        { operator: 'has_text' }
+      ]);
+      expect(created.operator[0].value).to.equal('has_phrase');
+    });
+
+    it('never seeds a new item with a location operator', () => {
+      zustand.setState({ features: ['locations'] });
+      const config = createRulesArrayConfig([]);
+      // even though has_district takes an operand and was used last, it is
+      // not repeated - a fresh rule falls back to the first non-location option
+      const created: any = config.createEmptyItem([
+        { operator: 'has_district' }
+      ]);
+      expect(created.operator[0].value).to.equal('has_any_word');
+
+      const fresh: any = config.createEmptyItem([]);
+      expect(fresh.operator[0].value).to.equal('has_any_word');
+    });
+  });
+});

--- a/test/flow-shared-rules.test.ts
+++ b/test/flow-shared-rules.test.ts
@@ -32,9 +32,9 @@ describe('flow/nodes/shared-rules', () => {
     });
 
     it('reads the value from an object operator', () => {
-      expect(getOperatorValue({ value: 'has_text', name: 'has some text' })).to.equal(
-        'has_text'
-      );
+      expect(
+        getOperatorValue({ value: 'has_text', name: 'has some text' })
+      ).to.equal('has_text');
     });
 
     it('reads the value from the first entry of an array operator', () => {
@@ -366,9 +366,7 @@ describe('flow/nodes/shared-rules', () => {
     it('leaves both values empty for a zero operand case', () => {
       const rules = casesToFormRules({
         router: {
-          cases: [
-            { type: 'has_text', arguments: [], category_uuid: 'cat-1' }
-          ],
+          cases: [{ type: 'has_text', arguments: [], category_uuid: 'cat-1' }],
           categories: [{ uuid: 'cat-1', name: 'Has Text' }]
         }
       });
@@ -380,7 +378,11 @@ describe('flow/nodes/shared-rules', () => {
       const rules = casesToFormRules({
         router: {
           cases: [
-            { type: 'has_any_word', arguments: ['red'], category_uuid: 'cat-1' },
+            {
+              type: 'has_any_word',
+              arguments: ['red'],
+              category_uuid: 'cat-1'
+            },
             { type: 'has_text', arguments: [], category_uuid: 'cat-other' }
           ],
           categories: [

--- a/test/sms-splitter.test.ts
+++ b/test/sms-splitter.test.ts
@@ -32,9 +32,10 @@ describe('gsmvalidator', () => {
 
   it('rejects characters outside the alphabet', () => {
     for (const char of '`”…’çÿ✓') {
-      expect(validateCharacter(char), `expected ${char} to be non-GSM`).to.equal(
-        false
-      );
+      expect(
+        validateCharacter(char),
+        `expected ${char} to be non-GSM`
+      ).to.equal(false);
     }
   });
 

--- a/test/sms-splitter.test.ts
+++ b/test/sms-splitter.test.ts
@@ -1,0 +1,294 @@
+import { expect } from '@open-wc/testing';
+import { splitSMS, GSM, UNICODE } from '../src/display/sms/index';
+import { gsmSplit } from '../src/display/sms/gsmsplitter';
+import { unicodeSplit } from '../src/display/sms/unicodesplitter';
+import {
+  validateCharacter,
+  validateMessage,
+  validateExtendedCharacter
+} from '../src/display/sms/gsmvalidator';
+
+// GSM extended characters occupy two septets each
+const EXTENDED = ['\f', '^', '{', '}', '\\', '[', '~', ']', '|', '€'];
+
+const repeat = (char: string, count: number) => new Array(count + 1).join(char);
+
+describe('gsmvalidator', () => {
+  it('accepts characters in the GSM 03.38 alphabet', () => {
+    for (const char of 'abcXYZ019 !?@$#%&*()-+.,/:;<=>') {
+      expect(validateCharacter(char), `expected ${char} to be GSM`).to.equal(
+        true
+      );
+    }
+  });
+
+  it('accepts the accented and greek characters in the alphabet', () => {
+    for (const char of '£¥èéùìòÇØøÅåÆæßÉÄÖÑÜ§¿äöñüàΔΦΓΛΩΠΨΣΘΞ') {
+      expect(validateCharacter(char), `expected ${char} to be GSM`).to.equal(
+        true
+      );
+    }
+  });
+
+  it('rejects characters outside the alphabet', () => {
+    for (const char of '`”…’çÿ✓') {
+      expect(validateCharacter(char), `expected ${char} to be non-GSM`).to.equal(
+        false
+      );
+    }
+  });
+
+  it('identifies the extended (two septet) characters', () => {
+    for (const char of EXTENDED) {
+      expect(
+        validateExtendedCharacter(char),
+        `expected ${char} to be extended`
+      ).to.equal(true);
+    }
+    // ordinary GSM characters are not extended
+    expect(validateExtendedCharacter('a')).to.equal(false);
+    expect(validateExtendedCharacter('£')).to.equal(false);
+  });
+
+  it('validates a whole message only when every character is GSM', () => {
+    expect(validateMessage('')).to.equal(true);
+    expect(validateMessage('Hello there')).to.equal(true);
+    expect(validateMessage('Cost is 5€')).to.equal(true);
+    expect(validateMessage('Hello “there”')).to.equal(false);
+    expect(validateMessage('Hi 😀')).to.equal(false);
+  });
+});
+
+describe('gsmSplit', () => {
+  it('returns a single empty part for an empty message', () => {
+    const result = gsmSplit('', {});
+    expect(result.parts).to.have.length(1);
+    expect(result.parts[0].content).to.equal('');
+    expect(result.parts[0].length).to.equal(0);
+    expect(result.parts[0].bytes).to.equal(0);
+    expect(result.totalLength).to.equal(0);
+    expect(result.totalBytes).to.equal(0);
+  });
+
+  it('counts one septet per ordinary character', () => {
+    const result = gsmSplit('hello', {});
+    expect(result.parts).to.have.length(1);
+    expect(result.totalLength).to.equal(5);
+    expect(result.totalBytes).to.equal(5);
+    expect(result.parts[0].content).to.equal('hello');
+  });
+
+  it('counts two septets for each extended character', () => {
+    const result = gsmSplit('5€', {});
+    expect(result.totalLength).to.equal(2);
+    expect(result.totalBytes).to.equal(3);
+  });
+
+  it('keeps 160 septets in a single part', () => {
+    const result = gsmSplit(repeat('a', 160), {});
+    expect(result.parts).to.have.length(1);
+    expect(result.totalLength).to.equal(160);
+    expect(result.totalBytes).to.equal(160);
+  });
+
+  it('splits at 153 septets once the message exceeds a single part', () => {
+    const result = gsmSplit(repeat('a', 161), {});
+    expect(result.parts).to.have.length(2);
+    expect(result.parts[0].bytes).to.equal(153);
+    expect(result.parts[0].length).to.equal(153);
+    expect(result.parts[1].bytes).to.equal(8);
+    expect(result.parts[1].length).to.equal(8);
+    expect(result.totalBytes).to.equal(161);
+    expect(result.totalLength).to.equal(161);
+  });
+
+  it('splits into three parts past two segments', () => {
+    const result = gsmSplit(repeat('a', 307), {});
+    expect(result.parts).to.have.length(3);
+    expect(result.parts.map((p) => p.bytes)).to.deep.equal([153, 153, 1]);
+    expect(result.totalBytes).to.equal(307);
+  });
+
+  it('never splits an extended character across two parts', () => {
+    // 81 euro signs is 162 septets, so it genuinely spans two parts; the
+    // boundary falls at 152 rather than 153 so the 77th euro stays whole
+    const result = gsmSplit(repeat('€', 81), {});
+    expect(result.parts).to.have.length(2);
+    expect(result.parts[0].bytes).to.equal(152);
+    expect(result.parts[0].length).to.equal(76);
+    expect(result.parts[1].bytes).to.equal(10);
+    expect(result.parts[1].length).to.equal(5);
+    // each part holds only whole characters
+    expect(result.parts[0].content).to.equal(repeat('€', 76));
+    expect(result.parts[1].content).to.equal(repeat('€', 5));
+  });
+
+  it('rejoins a two part split that still fits a single segment', () => {
+    // 77 euro signs is 154 septets: banked as two parts internally, but
+    // reported as one because it fits inside a single 160 septet message
+    const result = gsmSplit(repeat('€', 77), {});
+    expect(result.parts).to.have.length(1);
+    expect(result.totalBytes).to.equal(154);
+    expect(result.totalLength).to.equal(77);
+    expect(result.parts[0].content).to.equal(repeat('€', 77));
+  });
+
+  it('fits 80 extended characters into a single 160 septet part', () => {
+    const result = gsmSplit(repeat('€', 80), {});
+    expect(result.parts).to.have.length(1);
+    expect(result.totalBytes).to.equal(160);
+    expect(result.totalLength).to.equal(80);
+  });
+
+  it('replaces non-GSM characters with a space', () => {
+    const result = gsmSplit('hi ✓', {});
+    expect(result.parts[0].content).to.equal('hi  ');
+    expect(result.totalLength).to.equal(4);
+    expect(result.totalBytes).to.equal(4);
+  });
+
+  it('collapses a surrogate pair into a single replacement space', () => {
+    const result = gsmSplit('hi 😀', {});
+    // the emoji is two code units but counts once
+    expect(result.parts[0].content).to.equal('hi  ');
+    expect(result.totalLength).to.equal(4);
+  });
+
+  it('omits content when summarizing', () => {
+    const result = gsmSplit(repeat('a', 200), { summary: true });
+    expect(result.parts).to.have.length(2);
+    expect(result.parts[0].content).to.equal(undefined);
+    expect(result.parts[1].content).to.equal(undefined);
+    // counts are still reported
+    expect(result.totalBytes).to.equal(200);
+  });
+});
+
+describe('unicodeSplit', () => {
+  it('returns a single empty part for an empty message', () => {
+    const result = unicodeSplit('', {});
+    expect(result.parts).to.have.length(1);
+    expect(result.parts[0].content).to.equal('');
+    expect(result.totalBytes).to.equal(0);
+  });
+
+  it('counts two bytes per character', () => {
+    const result = unicodeSplit('héllo', {});
+    expect(result.totalLength).to.equal(5);
+    expect(result.totalBytes).to.equal(10);
+  });
+
+  it('keeps 70 characters (140 bytes) in a single part', () => {
+    const result = unicodeSplit(repeat('ü', 70), {});
+    expect(result.parts).to.have.length(1);
+    expect(result.totalLength).to.equal(70);
+    expect(result.totalBytes).to.equal(140);
+  });
+
+  it('splits at 67 characters once the message exceeds a single part', () => {
+    const result = unicodeSplit(repeat('ü', 71), {});
+    expect(result.parts).to.have.length(2);
+    expect(result.parts[0].bytes).to.equal(134);
+    expect(result.parts[0].length).to.equal(67);
+    expect(result.parts[1].bytes).to.equal(8);
+    expect(result.parts[1].length).to.equal(4);
+    expect(result.totalBytes).to.equal(142);
+  });
+
+  it('preserves the original text across part boundaries', () => {
+    const message = repeat('ü', 71);
+    const result = unicodeSplit(message, {});
+    expect(result.parts.map((p) => p.content).join('')).to.equal(message);
+  });
+
+  it('counts a surrogate pair as one character of four bytes', () => {
+    const result = unicodeSplit('😀', {});
+    expect(result.parts).to.have.length(1);
+    expect(result.totalLength).to.equal(1);
+    expect(result.totalBytes).to.equal(4);
+  });
+
+  it('never splits a surrogate pair across parts', () => {
+    // 36 emoji is 144 bytes, so it genuinely spans two parts; the boundary
+    // falls at 132 rather than 134 so the 34th emoji stays whole
+    const result = unicodeSplit(repeat('😀', 36), {});
+    expect(result.parts).to.have.length(2);
+    expect(result.parts[0].bytes).to.equal(132);
+    expect(result.parts[0].length).to.equal(33);
+    // the trailing part carries whole emoji only
+    expect(result.parts[1].content).to.equal(repeat('😀', 3));
+    expect(result.parts[1].bytes).to.equal(12);
+    expect(result.totalBytes).to.equal(144);
+  });
+
+  it('rejoins a two part split that still fits a single segment', () => {
+    // 34 emoji is 136 bytes, which fits inside a single 140 byte message
+    const result = unicodeSplit(repeat('😀', 34), {});
+    expect(result.parts).to.have.length(1);
+    expect(result.totalBytes).to.equal(136);
+    expect(result.totalLength).to.equal(34);
+  });
+
+  it('omits content when summarizing', () => {
+    const result = unicodeSplit(repeat('ü', 100), { summary: true });
+    expect(result.parts[0].content).to.equal(undefined);
+    expect(result.totalBytes).to.equal(200);
+  });
+});
+
+describe('splitSMS', () => {
+  it('detects a GSM message and reports the remaining allowance', () => {
+    const result = splitSMS('hello');
+    expect(result.characterSet).to.equal(GSM);
+    expect(result.parts).to.have.length(1);
+    expect(result.length).to.equal(5);
+    expect(result.bytes).to.equal(5);
+    // a single GSM part holds 160 septets
+    expect(result.remainingInPart).to.equal(155);
+  });
+
+  it('detects a unicode message', () => {
+    const result = splitSMS('hello “there”');
+    expect(result.characterSet).to.equal(UNICODE);
+    expect(result.length).to.equal(13);
+    expect(result.bytes).to.equal(26);
+    // a single unicode part holds 70 characters
+    expect(result.remainingInPart).to.equal(57);
+  });
+
+  it('reports the remaining allowance against the concatenated limit', () => {
+    const result = splitSMS(repeat('a', 161));
+    expect(result.characterSet).to.equal(GSM);
+    expect(result.parts).to.have.length(2);
+    // second part has 8 of its 153 septets used
+    expect(result.remainingInPart).to.equal(145);
+  });
+
+  it('honours a forced GSM character set', () => {
+    // “ is not GSM, but forcing GSM encodes it as a space rather than switching
+    const result = splitSMS('hello “there”', { characterset: GSM });
+    expect(result.characterSet).to.equal(GSM);
+    expect(result.bytes).to.equal(13);
+  });
+
+  it('honours a forced unicode character set', () => {
+    const result = splitSMS('hello', { characterset: UNICODE });
+    expect(result.characterSet).to.equal(UNICODE);
+    expect(result.bytes).to.equal(10);
+  });
+
+  it('treats an emoji message as unicode', () => {
+    const result = splitSMS('hi 😀');
+    expect(result.characterSet).to.equal(UNICODE);
+    expect(result.length).to.equal(4);
+    expect(result.bytes).to.equal(10);
+  });
+
+  it('handles an empty message', () => {
+    const result = splitSMS('');
+    expect(result.characterSet).to.equal(GSM);
+    expect(result.parts).to.have.length(1);
+    expect(result.length).to.equal(0);
+    expect(result.remainingInPart).to.equal(160);
+  });
+});

--- a/test/temba-appstate-actions.test.ts
+++ b/test/temba-appstate-actions.test.ts
@@ -95,8 +95,18 @@ describe('store/AppState actions', () => {
       state().setFlowInfo(
         info({
           issues: [
-            { type: 'a', node_uuid: 'node-1', action_uuid: null, description: '' },
-            { type: 'b', node_uuid: 'node-1', action_uuid: null, description: '' }
+            {
+              type: 'a',
+              node_uuid: 'node-1',
+              action_uuid: null,
+              description: ''
+            },
+            {
+              type: 'b',
+              node_uuid: 'node-1',
+              action_uuid: null,
+              description: ''
+            }
           ]
         })
       );
@@ -123,7 +133,12 @@ describe('store/AppState actions', () => {
       zustand.setState({
         flowInfo: info({
           results: [
-            { key: 'colour', name: 'Colour', categories: ['Red'], node_uuids: [] },
+            {
+              key: 'colour',
+              name: 'Colour',
+              categories: ['Red'],
+              node_uuids: []
+            },
             { key: 'size', name: 'Size', categories: ['Big'], node_uuids: [] }
           ]
         })
@@ -146,7 +161,8 @@ describe('store/AppState actions', () => {
   describe('getLanguage', () => {
     it('resolves the code to a display name', () => {
       zustand.setState({ languageCode: 'spa' } as any);
-      const language = state().getLanguage();
+      // getLanguage is on the store but not declared on the AppState type
+      const language = (state() as any).getLanguage();
       expect(language.code).to.equal('spa');
       expect(language.name).to.be.a('string');
       expect(language.name.length).to.be.greaterThan(0);
@@ -224,7 +240,12 @@ describe('store/AppState actions', () => {
       zustand.setState({
         flowDefinition: definition({
           _ui: {
-            nodes: { 'node-1': { type: 'wait_for_response', position: { left: 0, top: 0 } } },
+            nodes: {
+              'node-1': {
+                type: 'wait_for_response',
+                position: { left: 0, top: 0 }
+              }
+            },
             languages: []
           }
         })
@@ -272,9 +293,24 @@ describe('store/AppState actions', () => {
             nodes: {},
             languages: [],
             stickies: {
-              'sticky-1': { title: 'One', body: '', position: { left: 0, top: 0 }, color: 'yellow' },
-              'sticky-2': { title: 'Two', body: '', position: { left: 0, top: 0 }, color: 'blue' },
-              'sticky-3': { title: 'Three', body: '', position: { left: 0, top: 0 }, color: 'gray' }
+              'sticky-1': {
+                title: 'One',
+                body: '',
+                position: { left: 0, top: 0 },
+                color: 'yellow'
+              },
+              'sticky-2': {
+                title: 'Two',
+                body: '',
+                position: { left: 0, top: 0 },
+                color: 'blue'
+              },
+              'sticky-3': {
+                title: 'Three',
+                body: '',
+                position: { left: 0, top: 0 },
+                color: 'gray'
+              }
             }
           }
         })
@@ -289,16 +325,16 @@ describe('store/AppState actions', () => {
 
     it('removes several notes at once', () => {
       state().removeStickyNotes(['sticky-1', 'sticky-3']);
-      expect(
-        Object.keys(state().flowDefinition._ui.stickies)
-      ).to.deep.equal(['sticky-2']);
+      expect(Object.keys(state().flowDefinition._ui.stickies)).to.deep.equal([
+        'sticky-2'
+      ]);
     });
 
     it('ignores unknown uuids', () => {
       state().removeStickyNotes(['nonsense']);
-      expect(
-        Object.keys(state().flowDefinition._ui.stickies)
-      ).to.have.length(3);
+      expect(Object.keys(state().flowDefinition._ui.stickies)).to.have.length(
+        3
+      );
     });
 
     it('copes with a flow that has no stickies', () => {
@@ -336,7 +372,9 @@ describe('store/AppState actions', () => {
     });
 
     it('ignores a flow with no ui', () => {
-      zustand.setState({ flowDefinition: { ...definition(), _ui: null } } as any);
+      zustand.setState({
+        flowDefinition: { ...definition(), _ui: null }
+      } as any);
       // no throw is the assertion here
       state().setTranslationFilters({ categories: true });
     });

--- a/test/temba-appstate-actions.test.ts
+++ b/test/temba-appstate-actions.test.ts
@@ -1,0 +1,412 @@
+import { expect } from '@open-wc/testing';
+import { zustand } from '../src/store/AppState';
+import { mockGET, clearMockGets } from './utils.test';
+
+const definition = (overrides: any = {}) => ({
+  uuid: 'flow-1',
+  name: 'Test Flow',
+  language: 'eng',
+  type: 'messaging' as const,
+  revision: 1,
+  spec_version: '14.3',
+  localization: {},
+  nodes: [],
+  _ui: { nodes: {}, languages: [] },
+  ...overrides
+});
+
+const info = (overrides: any = {}) => ({
+  results: [],
+  dependencies: [],
+  counts: { nodes: 0, languages: 1 },
+  locals: [],
+  ...overrides
+});
+
+const nodeWithExit = (uuid: string, exitUuid: string) => ({
+  uuid,
+  actions: [],
+  exits: [{ uuid: exitUuid, destination_uuid: null }]
+});
+
+describe('store/AppState actions', () => {
+  const pristine = zustand.getState();
+
+  beforeEach(() => {
+    zustand.setState({
+      flowDefinition: null,
+      flowInfo: null,
+      languageCode: '',
+      isTranslating: false,
+      activity: null,
+      activityEndpoint: null,
+      viewingRevision: false
+    } as any);
+  });
+
+  afterEach(() => {
+    clearMockGets();
+    zustand.setState(pristine as any);
+  });
+
+  const state = () => zustand.getState();
+
+  describe('setFlowInfo', () => {
+    it('records the info', () => {
+      state().setFlowInfo(info({ counts: { nodes: 3, languages: 2 } }));
+      expect(state().flowInfo.counts.nodes).to.equal(3);
+    });
+
+    it('indexes an action issue by its action', () => {
+      state().setFlowInfo(
+        info({
+          issues: [
+            {
+              type: 'missing_dependency',
+              node_uuid: 'node-1',
+              action_uuid: 'action-1',
+              description: 'missing'
+            }
+          ]
+        })
+      );
+      expect(state().issuesByAction.get('action-1')).to.have.length(1);
+      // an action issue is filed under the action rather than the node
+      expect(state().issuesByNode.get('node-1')).to.equal(undefined);
+    });
+
+    it('indexes a node issue by its node', () => {
+      state().setFlowInfo(
+        info({
+          issues: [
+            {
+              type: 'missing_dependency',
+              node_uuid: 'node-1',
+              action_uuid: null,
+              description: 'missing'
+            }
+          ]
+        })
+      );
+      expect(state().issuesByNode.get('node-1')).to.have.length(1);
+    });
+
+    it('groups several issues on the same node', () => {
+      state().setFlowInfo(
+        info({
+          issues: [
+            { type: 'a', node_uuid: 'node-1', action_uuid: null, description: '' },
+            { type: 'b', node_uuid: 'node-1', action_uuid: null, description: '' }
+          ]
+        })
+      );
+      expect(state().issuesByNode.get('node-1')).to.have.length(2);
+    });
+
+    it('clears the issue maps when there are no issues', () => {
+      state().setFlowInfo(info({ issues: [] }));
+      expect(state().issuesByNode.size).to.equal(0);
+      expect(state().issuesByAction.size).to.equal(0);
+    });
+  });
+
+  describe('setRevision', () => {
+    it('updates the revision on the definition', () => {
+      zustand.setState({ flowDefinition: definition() } as any);
+      state().setRevision(42);
+      expect(state().flowDefinition.revision).to.equal(42);
+    });
+  });
+
+  describe('getFlowResults and getResultByKey', () => {
+    beforeEach(() => {
+      zustand.setState({
+        flowInfo: info({
+          results: [
+            { key: 'colour', name: 'Colour', categories: ['Red'], node_uuids: [] },
+            { key: 'size', name: 'Size', categories: ['Big'], node_uuids: [] }
+          ]
+        })
+      } as any);
+    });
+
+    it('returns every result', () => {
+      expect(state().getFlowResults()).to.have.length(2);
+    });
+
+    it('finds a result by its key', () => {
+      expect(state().getResultByKey('size').name).to.equal('Size');
+    });
+
+    it('returns nothing for an unknown key', () => {
+      expect(state().getResultByKey('nonsense')).to.equal(undefined);
+    });
+  });
+
+  describe('getLanguage', () => {
+    it('resolves the code to a display name', () => {
+      zustand.setState({ languageCode: 'spa' } as any);
+      const language = state().getLanguage();
+      expect(language.code).to.equal('spa');
+      expect(language.name).to.be.a('string');
+      expect(language.name.length).to.be.greaterThan(0);
+    });
+  });
+
+  describe('activity', () => {
+    it('records the activity endpoint', () => {
+      state().setActivityEndpoint('/flow/activity/flow-1/');
+      expect(state().activityEndpoint).to.equal('/flow/activity/flow-1/');
+    });
+
+    it('replaces the current activity', () => {
+      const activity = { nodes: { 'node-1': 3 }, segments: {} } as any;
+      state().updateActivity(activity);
+      expect(state().activity).to.deep.equal(activity);
+    });
+
+    it('reports simulator activity while the simulator is active', () => {
+      const live = { nodes: { 'node-1': 1 }, segments: {} } as any;
+      const simulated = { nodes: { 'node-2': 9 }, segments: {} } as any;
+      state().updateActivity(live);
+      state().updateSimulatorActivity(simulated);
+
+      state().setSimulatorActive(false);
+      expect(state().getCurrentActivity()).to.deep.equal(live);
+
+      state().setSimulatorActive(true);
+      expect(state().getCurrentActivity()).to.deep.equal(simulated);
+    });
+  });
+
+  describe('updateConnection', () => {
+    beforeEach(() => {
+      zustand.setState({
+        flowDefinition: definition({
+          nodes: [nodeWithExit('node-1', 'exit-1')]
+        })
+      } as any);
+    });
+
+    it('points an exit at a destination', () => {
+      state().updateConnection('node-1', 'exit-1', 'node-2');
+      expect(
+        state().flowDefinition.nodes[0].exits[0].destination_uuid
+      ).to.equal('node-2');
+      expect(state().dirtyDate).to.not.equal(null);
+    });
+
+    it('clears a destination', () => {
+      state().updateConnection('node-1', 'exit-1', 'node-2');
+      state().updateConnection('node-1', 'exit-1', null);
+      expect(
+        state().flowDefinition.nodes[0].exits[0].destination_uuid
+      ).to.equal(null);
+    });
+
+    it('ignores an unknown node', () => {
+      state().updateConnection('nonsense', 'exit-1', 'node-2');
+      expect(
+        state().flowDefinition.nodes[0].exits[0].destination_uuid
+      ).to.equal(null);
+    });
+
+    it('ignores an unknown exit', () => {
+      state().updateConnection('node-1', 'nonsense', 'node-2');
+      expect(
+        state().flowDefinition.nodes[0].exits[0].destination_uuid
+      ).to.equal(null);
+    });
+  });
+
+  describe('updateNodeUIConfig', () => {
+    beforeEach(() => {
+      zustand.setState({
+        flowDefinition: definition({
+          _ui: {
+            nodes: { 'node-1': { type: 'wait_for_response', position: { left: 0, top: 0 } } },
+            languages: []
+          }
+        })
+      } as any);
+    });
+
+    it('creates the config when there is none', () => {
+      state().updateNodeUIConfig('node-1', { localizeRules: true });
+      expect(
+        state().flowDefinition._ui.nodes['node-1'].config.localizeRules
+      ).to.equal(true);
+    });
+
+    it('merges into an existing config', () => {
+      state().updateNodeUIConfig('node-1', { localizeRules: true });
+      state().updateNodeUIConfig('node-1', { localizeCategories: true });
+      const config = state().flowDefinition._ui.nodes['node-1'].config;
+      expect(config.localizeRules).to.equal(true);
+      expect(config.localizeCategories).to.equal(true);
+    });
+
+    it('updates the node type separately from the config', () => {
+      state().updateNodeUIConfig('node-1', {
+        type: 'split_by_expression',
+        localizeRules: true
+      });
+      const nodeUI = state().flowDefinition._ui.nodes['node-1'];
+      expect(nodeUI.type).to.equal('split_by_expression');
+      expect(nodeUI.config.localizeRules).to.equal(true);
+      // the type is not duplicated into the config
+      expect(nodeUI.config.type).to.equal(undefined);
+    });
+
+    it('ignores an unknown node', () => {
+      state().updateNodeUIConfig('nonsense', { localizeRules: true });
+      expect(state().flowDefinition._ui.nodes['nonsense']).to.equal(undefined);
+    });
+  });
+
+  describe('removeStickyNotes', () => {
+    beforeEach(() => {
+      zustand.setState({
+        flowDefinition: definition({
+          _ui: {
+            nodes: {},
+            languages: [],
+            stickies: {
+              'sticky-1': { title: 'One', body: '', position: { left: 0, top: 0 }, color: 'yellow' },
+              'sticky-2': { title: 'Two', body: '', position: { left: 0, top: 0 }, color: 'blue' },
+              'sticky-3': { title: 'Three', body: '', position: { left: 0, top: 0 }, color: 'gray' }
+            }
+          }
+        })
+      } as any);
+    });
+
+    it('removes a single note', () => {
+      state().removeStickyNotes(['sticky-2']);
+      const stickies = state().flowDefinition._ui.stickies;
+      expect(Object.keys(stickies)).to.deep.equal(['sticky-1', 'sticky-3']);
+    });
+
+    it('removes several notes at once', () => {
+      state().removeStickyNotes(['sticky-1', 'sticky-3']);
+      expect(
+        Object.keys(state().flowDefinition._ui.stickies)
+      ).to.deep.equal(['sticky-2']);
+    });
+
+    it('ignores unknown uuids', () => {
+      state().removeStickyNotes(['nonsense']);
+      expect(
+        Object.keys(state().flowDefinition._ui.stickies)
+      ).to.have.length(3);
+    });
+
+    it('copes with a flow that has no stickies', () => {
+      zustand.setState({ flowDefinition: definition() } as any);
+      state().removeStickyNotes(['sticky-1']);
+      expect(state().flowDefinition._ui.stickies).to.equal(undefined);
+    });
+  });
+
+  describe('setTranslationFilters', () => {
+    beforeEach(() => {
+      zustand.setState({ flowDefinition: definition() } as any);
+    });
+
+    it('turns the category filter on', () => {
+      state().setTranslationFilters({ categories: true });
+      expect(
+        state().flowDefinition._ui.translation_filters.categories
+      ).to.equal(true);
+    });
+
+    it('turns the category filter back off', () => {
+      state().setTranslationFilters({ categories: true });
+      state().setTranslationFilters({ categories: false });
+      expect(
+        state().flowDefinition._ui.translation_filters.categories
+      ).to.equal(false);
+    });
+
+    it('does nothing when the filter is unchanged', () => {
+      state().setTranslationFilters({ categories: true });
+      const before = state().dirtyDate;
+      state().setTranslationFilters({ categories: true });
+      expect(state().dirtyDate).to.equal(before);
+    });
+
+    it('ignores a flow with no ui', () => {
+      zustand.setState({ flowDefinition: { ...definition(), _ui: null } } as any);
+      // no throw is the assertion here
+      state().setTranslationFilters({ categories: true });
+    });
+  });
+
+  describe('fetchRevision', () => {
+    const REVISION_URL = '/flow/revisions/flow-1';
+
+    const mockRevision = (overrides: any = {}) => {
+      clearMockGets();
+      mockGET(/\/flow\/revisions\/flow-1\//, {
+        definition: definition({ language: 'fra' }),
+        info: info({ counts: { nodes: 1, languages: 1 } }),
+        ...overrides
+      });
+    };
+
+    it('loads the latest revision by default', async () => {
+      mockRevision();
+      await state().fetchRevision(REVISION_URL);
+      expect(state().flowDefinition.uuid).to.equal('flow-1');
+      expect(state().viewingRevision).to.equal(false);
+    });
+
+    it('adopts the language of the loaded flow', async () => {
+      mockRevision();
+      await state().fetchRevision(REVISION_URL);
+      expect(state().languageCode).to.equal('fra');
+      expect(state().isTranslating).to.equal(false);
+    });
+
+    it('marks an explicit revision as being viewed', async () => {
+      mockRevision();
+      await state().fetchRevision(REVISION_URL, '12345');
+      expect(state().viewingRevision).to.equal(true);
+    });
+
+    it('does not treat "latest" as viewing an older revision', async () => {
+      mockRevision();
+      await state().fetchRevision(REVISION_URL, 'latest');
+      expect(state().viewingRevision).to.equal(false);
+    });
+
+    it('indexes any issues that come back', async () => {
+      mockRevision({
+        info: info({
+          issues: [
+            {
+              type: 'missing_dependency',
+              node_uuid: 'node-9',
+              action_uuid: null,
+              description: 'missing'
+            }
+          ]
+        })
+      });
+      await state().fetchRevision(REVISION_URL);
+      expect(state().issuesByNode.get('node-9')).to.have.length(1);
+    });
+
+    it('raises when the request fails', async () => {
+      clearMockGets();
+      mockGET(/\/flow\/revisions\/flow-1\//, { detail: 'boom' }, {}, '500');
+      let raised = false;
+      try {
+        await state().fetchRevision(REVISION_URL);
+      } catch (error) {
+        raised = true;
+      }
+      expect(raised).to.equal(true);
+    });
+  });
+});

--- a/test/temba-flow-node-actions.test.ts
+++ b/test/temba-flow-node-actions.test.ts
@@ -33,6 +33,9 @@ const fakePlumber = () => ({
 
 describe('temba-flow-node actions', () => {
   let node: CanvasNode;
+  // CanvasNode declares node/ui/plumber private, so tests wire them up
+  // through a loosely typed alias for the same element
+  let inner: any;
   let plumber: any;
   let updateNode: any;
 
@@ -46,9 +49,10 @@ describe('temba-flow-node actions', () => {
     zustand.setState({ updateNode } as any);
 
     node = (await fixture('<temba-flow-node></temba-flow-node>')) as CanvasNode;
-    node.node = flowNode() as any;
-    node.ui = { type: 'execute_actions', position: { left: 0, top: 0 } } as any;
-    node.plumber = plumber as any;
+    inner = node as any;
+    inner.node = flowNode() as any;
+    inner.ui = { type: 'execute_actions', position: { left: 0, top: 0 } } as any;
+    inner.plumber = plumber as any;
     await node.updateComplete;
   });
 
@@ -66,7 +70,7 @@ describe('temba-flow-node actions', () => {
 
   describe('disconnectExit', () => {
     it('clears the destination and tells the plumber', () => {
-      (node as any).disconnectExit(node.node.exits[0]);
+      (node as any).disconnectExit(inner.node.exits[0]);
 
       expect(plumber.removeExitConnection.calledWith('exit-1')).to.equal(true);
       expect(updateNode.calledOnce).to.equal(true);
@@ -78,7 +82,7 @@ describe('temba-flow-node actions', () => {
 
     it('clears any pending removal state', () => {
       (node as any).exitRemovingState.add('exit-1');
-      (node as any).disconnectExit(node.node.exits[0]);
+      (node as any).disconnectExit(inner.node.exits[0]);
       expect((node as any).exitRemovingState.has('exit-1')).to.equal(false);
       expect(
         plumber.setConnectionRemovingState.calledWith('exit-1', false)
@@ -86,13 +90,13 @@ describe('temba-flow-node actions', () => {
     });
 
     it('leaves the other exits untouched', () => {
-      node.node = flowNode({
+      inner.node = flowNode({
         exits: [
           { uuid: 'exit-1', destination_uuid: 'node-2' },
           { uuid: 'exit-2', destination_uuid: 'node-3' }
         ]
       }) as any;
-      (node as any).disconnectExit(node.node.exits[0]);
+      (node as any).disconnectExit(inner.node.exits[0]);
       const updated = updateNode.firstCall.args[1];
       expect(updated.exits[1].destination_uuid).to.equal('node-3');
     });
@@ -100,11 +104,11 @@ describe('temba-flow-node actions', () => {
 
   describe('removeAction', () => {
     it('removes one action of several', () => {
-      node.node = flowNode({
+      inner.node = flowNode({
         actions: [sendMsg('action-1'), sendMsg('action-2')]
       }) as any;
 
-      (node as any).removeAction(node.node.actions[0], 0);
+      (node as any).removeAction(inner.node.actions[0], 0);
 
       expect(updateNode.calledOnce).to.equal(true);
       const updated = updateNode.firstCall.args[1];
@@ -114,7 +118,7 @@ describe('temba-flow-node actions', () => {
 
     it('deletes the whole node when the last action goes', () => {
       const deleted = events(CustomEventType.NodeDeleted);
-      (node as any).removeAction(node.node.actions[0], 0);
+      (node as any).removeAction(inner.node.actions[0], 0);
 
       expect(deleted).to.have.length(1);
       expect(deleted[0].uuid).to.equal('node-1');
@@ -122,11 +126,11 @@ describe('temba-flow-node actions', () => {
     });
 
     it('clears any pending removal state', () => {
-      node.node = flowNode({
+      inner.node = flowNode({
         actions: [sendMsg('action-1'), sendMsg('action-2')]
       }) as any;
       (node as any).actionRemovingState.add('action-1');
-      (node as any).removeAction(node.node.actions[0], 0);
+      (node as any).removeAction(inner.node.actions[0], 0);
       expect((node as any).actionRemovingState.has('action-1')).to.equal(false);
     });
   });
@@ -186,7 +190,7 @@ describe('temba-flow-node actions', () => {
 
     it('requests editing of the clicked action', () => {
       const requested = events(CustomEventType.ActionEditRequested);
-      (node as any).handleActionClick(clickOn(), node.node.actions[0]);
+      (node as any).handleActionClick(clickOn(), inner.node.actions[0]);
       expect(requested).to.have.length(1);
       expect(requested[0].action.uuid).to.equal('action-1');
       expect(requested[0].nodeUuid).to.equal('node-1');
@@ -196,14 +200,14 @@ describe('temba-flow-node actions', () => {
       const requested = events(CustomEventType.ActionEditRequested);
       const button = document.createElement('div');
       button.className = 'remove-button';
-      (node as any).handleActionClick(clickOn(button), node.node.actions[0]);
+      (node as any).handleActionClick(clickOn(button), inner.node.actions[0]);
       expect(requested).to.have.length(0);
     });
 
     it('ignores clicks while the action is being removed', () => {
       const requested = events(CustomEventType.ActionEditRequested);
       (node as any).actionRemovingState.add('action-1');
-      (node as any).handleActionClick(clickOn(), node.node.actions[0]);
+      (node as any).handleActionClick(clickOn(), inner.node.actions[0]);
       expect(requested).to.have.length(0);
     });
   });
@@ -226,7 +230,7 @@ describe('temba-flow-node actions', () => {
     });
 
     it('opens the node editor for a router with no actions', () => {
-      node.node = flowNode({
+      inner.node = flowNode({
         actions: [],
         router: { type: 'switch', categories: [] }
       }) as any;
@@ -237,7 +241,7 @@ describe('temba-flow-node actions', () => {
     });
 
     it('opens the action editor for a router with exactly one action', () => {
-      node.node = flowNode({
+      inner.node = flowNode({
         actions: [sendMsg('action-1')],
         router: { type: 'switch', categories: [] }
       }) as any;
@@ -250,7 +254,7 @@ describe('temba-flow-node actions', () => {
     });
 
     it('opens the node editor for a router with several actions', () => {
-      node.node = flowNode({
+      inner.node = flowNode({
         actions: [sendMsg('action-1'), sendMsg('action-2')],
         router: { type: 'switch', categories: [] }
       }) as any;
@@ -260,7 +264,7 @@ describe('temba-flow-node actions', () => {
     });
 
     it('ignores clicks on the remove button', () => {
-      node.node = flowNode({
+      inner.node = flowNode({
         actions: [],
         router: { type: 'switch', categories: [] }
       }) as any;
@@ -279,8 +283,10 @@ describe('temba-flow-node actions', () => {
     const watchSortable = () => {
       const calls: boolean[] = [];
       const sortable = node.querySelector('temba-sortable-list');
-      expect(sortable, 'expected the node to render a sortable list').to.not
-        .equal(null);
+      expect(
+        sortable,
+        'expected the node to render a sortable list'
+      ).to.not.equal(null);
       (sortable as any).setOriginalVisible = (visible: boolean) =>
         calls.push(visible);
       return calls;
@@ -306,7 +312,7 @@ describe('temba-flow-node actions', () => {
     });
 
     it('leaves the placeholder off when other actions remain', async () => {
-      node.node = flowNode({
+      inner.node = flowNode({
         actions: [sendMsg('action-1'), sendMsg('action-2')]
       }) as any;
       await node.updateComplete;

--- a/test/temba-flow-node-actions.test.ts
+++ b/test/temba-flow-node-actions.test.ts
@@ -1,0 +1,343 @@
+import '../temba-modules';
+import { fixture, expect } from '@open-wc/testing';
+import { stub, useFakeTimers } from 'sinon';
+import { CanvasNode } from '../src/flow/CanvasNode';
+import { CustomEventType } from '../src/interfaces';
+import { zustand } from '../src/store/AppState';
+import { loadStore } from './utils.test';
+
+const sendMsg = (uuid: string, text = 'Hello') => ({
+  uuid,
+  type: 'send_msg',
+  text
+});
+
+const flowNode = (overrides: any = {}) => ({
+  uuid: 'node-1',
+  actions: [sendMsg('action-1')],
+  exits: [{ uuid: 'exit-1', destination_uuid: 'node-2' }],
+  ...overrides
+});
+
+// a plumber that records the calls made against it
+const fakePlumber = () => ({
+  makeTarget: stub(),
+  makeSource: stub(),
+  connectIds: stub(),
+  forgetNode: stub(),
+  revalidate: stub(),
+  removeNodeConnections: stub(),
+  removeExitConnection: stub(),
+  setConnectionRemovingState: stub()
+});
+
+describe('temba-flow-node actions', () => {
+  let node: CanvasNode;
+  let plumber: any;
+  let updateNode: any;
+
+  // updateNode is swapped for a spy, so keep the real one to put back
+  const realUpdateNode = zustand.getState().updateNode;
+
+  beforeEach(async () => {
+    await loadStore();
+    plumber = fakePlumber();
+    updateNode = stub();
+    zustand.setState({ updateNode } as any);
+
+    node = (await fixture('<temba-flow-node></temba-flow-node>')) as CanvasNode;
+    node.node = flowNode() as any;
+    node.ui = { type: 'execute_actions', position: { left: 0, top: 0 } } as any;
+    node.plumber = plumber as any;
+    await node.updateComplete;
+  });
+
+  afterEach(() => {
+    // note: no sinon restore() here, it would tear down the shared
+    // window.fetch stub that utils.test installs for the whole run
+    zustand.setState({ updateNode: realUpdateNode } as any);
+  });
+
+  const events = (type: CustomEventType) => {
+    const seen: any[] = [];
+    node.addEventListener(type, (e: any) => seen.push(e.detail));
+    return seen;
+  };
+
+  describe('disconnectExit', () => {
+    it('clears the destination and tells the plumber', () => {
+      (node as any).disconnectExit(node.node.exits[0]);
+
+      expect(plumber.removeExitConnection.calledWith('exit-1')).to.equal(true);
+      expect(updateNode.calledOnce).to.equal(true);
+
+      const [uuid, updated] = updateNode.firstCall.args;
+      expect(uuid).to.equal('node-1');
+      expect(updated.exits[0].destination_uuid).to.equal(null);
+    });
+
+    it('clears any pending removal state', () => {
+      (node as any).exitRemovingState.add('exit-1');
+      (node as any).disconnectExit(node.node.exits[0]);
+      expect((node as any).exitRemovingState.has('exit-1')).to.equal(false);
+      expect(
+        plumber.setConnectionRemovingState.calledWith('exit-1', false)
+      ).to.equal(true);
+    });
+
+    it('leaves the other exits untouched', () => {
+      node.node = flowNode({
+        exits: [
+          { uuid: 'exit-1', destination_uuid: 'node-2' },
+          { uuid: 'exit-2', destination_uuid: 'node-3' }
+        ]
+      }) as any;
+      (node as any).disconnectExit(node.node.exits[0]);
+      const updated = updateNode.firstCall.args[1];
+      expect(updated.exits[1].destination_uuid).to.equal('node-3');
+    });
+  });
+
+  describe('removeAction', () => {
+    it('removes one action of several', () => {
+      node.node = flowNode({
+        actions: [sendMsg('action-1'), sendMsg('action-2')]
+      }) as any;
+
+      (node as any).removeAction(node.node.actions[0], 0);
+
+      expect(updateNode.calledOnce).to.equal(true);
+      const updated = updateNode.firstCall.args[1];
+      expect(updated.actions).to.have.length(1);
+      expect(updated.actions[0].uuid).to.equal('action-2');
+    });
+
+    it('deletes the whole node when the last action goes', () => {
+      const deleted = events(CustomEventType.NodeDeleted);
+      (node as any).removeAction(node.node.actions[0], 0);
+
+      expect(deleted).to.have.length(1);
+      expect(deleted[0].uuid).to.equal('node-1');
+      expect(updateNode.called).to.equal(false);
+    });
+
+    it('clears any pending removal state', () => {
+      node.node = flowNode({
+        actions: [sendMsg('action-1'), sendMsg('action-2')]
+      }) as any;
+      (node as any).actionRemovingState.add('action-1');
+      (node as any).removeAction(node.node.actions[0], 0);
+      expect((node as any).actionRemovingState.has('action-1')).to.equal(false);
+    });
+  });
+
+  describe('removeNode', () => {
+    it('fires a node deleted event', () => {
+      const deleted = events(CustomEventType.NodeDeleted);
+      (node as any).removeNode();
+      expect(deleted).to.have.length(1);
+      expect(deleted[0].uuid).to.equal('node-1');
+    });
+  });
+
+  describe('handleNodeRemoveClick', () => {
+    const clickEvent = () =>
+      new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    it('arms removal on the first click without deleting', () => {
+      const deleted = events(CustomEventType.NodeDeleted);
+      (node as any).handleNodeRemoveClick(clickEvent());
+      expect((node as any).actionRemovingState.has('node-1')).to.equal(true);
+      expect(deleted).to.have.length(0);
+    });
+
+    it('deletes on the second click', () => {
+      const deleted = events(CustomEventType.NodeDeleted);
+      (node as any).handleNodeRemoveClick(clickEvent());
+      (node as any).handleNodeRemoveClick(clickEvent());
+      expect(deleted).to.have.length(1);
+    });
+
+    it('disarms after a second of inactivity', () => {
+      const clock = useFakeTimers();
+      try {
+        (node as any).handleNodeRemoveClick(clickEvent());
+        expect((node as any).actionRemovingState.has('node-1')).to.equal(true);
+        clock.tick(1000);
+        expect((node as any).actionRemovingState.has('node-1')).to.equal(false);
+      } finally {
+        clock.restore();
+      }
+    });
+  });
+
+  describe('handleActionClick', () => {
+    const clickOn = (target?: HTMLElement) => {
+      const event = new MouseEvent('click', { bubbles: true });
+      if (target) {
+        Object.defineProperty(event, 'target', { value: target });
+      } else {
+        Object.defineProperty(event, 'target', {
+          value: document.createElement('div')
+        });
+      }
+      return event;
+    };
+
+    it('requests editing of the clicked action', () => {
+      const requested = events(CustomEventType.ActionEditRequested);
+      (node as any).handleActionClick(clickOn(), node.node.actions[0]);
+      expect(requested).to.have.length(1);
+      expect(requested[0].action.uuid).to.equal('action-1');
+      expect(requested[0].nodeUuid).to.equal('node-1');
+    });
+
+    it('ignores clicks on the remove button', () => {
+      const requested = events(CustomEventType.ActionEditRequested);
+      const button = document.createElement('div');
+      button.className = 'remove-button';
+      (node as any).handleActionClick(clickOn(button), node.node.actions[0]);
+      expect(requested).to.have.length(0);
+    });
+
+    it('ignores clicks while the action is being removed', () => {
+      const requested = events(CustomEventType.ActionEditRequested);
+      (node as any).actionRemovingState.add('action-1');
+      (node as any).handleActionClick(clickOn(), node.node.actions[0]);
+      expect(requested).to.have.length(0);
+    });
+  });
+
+  describe('handleNodeEditClick', () => {
+    const clickEvent = () => {
+      const event = new MouseEvent('click', { bubbles: true });
+      Object.defineProperty(event, 'target', {
+        value: document.createElement('div')
+      });
+      return event;
+    };
+
+    it('does nothing for a node with no router', () => {
+      const nodeEvents = events(CustomEventType.NodeEditRequested);
+      const actionEvents = events(CustomEventType.ActionEditRequested);
+      (node as any).handleNodeEditClick(clickEvent());
+      expect(nodeEvents).to.have.length(0);
+      expect(actionEvents).to.have.length(0);
+    });
+
+    it('opens the node editor for a router with no actions', () => {
+      node.node = flowNode({
+        actions: [],
+        router: { type: 'switch', categories: [] }
+      }) as any;
+      const nodeEvents = events(CustomEventType.NodeEditRequested);
+      (node as any).handleNodeEditClick(clickEvent());
+      expect(nodeEvents).to.have.length(1);
+      expect(nodeEvents[0].node.uuid).to.equal('node-1');
+    });
+
+    it('opens the action editor for a router with exactly one action', () => {
+      node.node = flowNode({
+        actions: [sendMsg('action-1')],
+        router: { type: 'switch', categories: [] }
+      }) as any;
+      const actionEvents = events(CustomEventType.ActionEditRequested);
+      const nodeEvents = events(CustomEventType.NodeEditRequested);
+      (node as any).handleNodeEditClick(clickEvent());
+      expect(actionEvents).to.have.length(1);
+      expect(actionEvents[0].action.uuid).to.equal('action-1');
+      expect(nodeEvents).to.have.length(0);
+    });
+
+    it('opens the node editor for a router with several actions', () => {
+      node.node = flowNode({
+        actions: [sendMsg('action-1'), sendMsg('action-2')],
+        router: { type: 'switch', categories: [] }
+      }) as any;
+      const nodeEvents = events(CustomEventType.NodeEditRequested);
+      (node as any).handleNodeEditClick(clickEvent());
+      expect(nodeEvents).to.have.length(1);
+    });
+
+    it('ignores clicks on the remove button', () => {
+      node.node = flowNode({
+        actions: [],
+        router: { type: 'switch', categories: [] }
+      }) as any;
+      const nodeEvents = events(CustomEventType.NodeEditRequested);
+      const event = new MouseEvent('click', { bubbles: true });
+      const button = document.createElement('div');
+      button.className = 'remove-button';
+      Object.defineProperty(event, 'target', { value: button });
+      (node as any).handleNodeEditClick(event);
+      expect(nodeEvents).to.have.length(0);
+    });
+  });
+
+  describe('drag ghost and original', () => {
+    // the node renders its own sortable list, so record calls on that one
+    const watchSortable = () => {
+      const calls: boolean[] = [];
+      const sortable = node.querySelector('temba-sortable-list');
+      expect(sortable, 'expected the node to render a sortable list').to.not
+        .equal(null);
+      (sortable as any).setOriginalVisible = (visible: boolean) =>
+        calls.push(visible);
+      return calls;
+    };
+
+    it('toggles the original through the sortable list', () => {
+      const calls = watchSortable();
+
+      node.dispatchEvent(new CustomEvent('action-show-original'));
+      node.dispatchEvent(new CustomEvent('action-hide-original'));
+
+      expect(calls).to.deep.equal([true, false]);
+    });
+
+    it('restores the placeholder when hiding the only action', () => {
+      watchSortable();
+
+      node.dispatchEvent(new CustomEvent('action-show-original'));
+      expect((node as any).showLastActionPlaceholder).to.equal(false);
+
+      node.dispatchEvent(new CustomEvent('action-hide-original'));
+      expect((node as any).showLastActionPlaceholder).to.equal(true);
+    });
+
+    it('leaves the placeholder off when other actions remain', async () => {
+      node.node = flowNode({
+        actions: [sendMsg('action-1'), sendMsg('action-2')]
+      }) as any;
+      await node.updateComplete;
+      watchSortable();
+
+      node.dispatchEvent(new CustomEvent('action-hide-original'));
+      expect((node as any).showLastActionPlaceholder).to.equal(false);
+    });
+
+    it('shows and hides the drag ghost', () => {
+      const ghost = document.createElement('div');
+      ghost.className = 'ghost';
+      ghost.style.display = 'none';
+      document.body.appendChild(ghost);
+
+      try {
+        node.dispatchEvent(new CustomEvent('action-show-ghost'));
+        expect(ghost.style.display).to.equal('block');
+
+        node.dispatchEvent(new CustomEvent('action-hide-ghost'));
+        expect(ghost.style.display).to.equal('none');
+      } finally {
+        ghost.remove();
+      }
+    });
+
+    it('copes with no ghost element on the page', () => {
+      expect(document.querySelector('.ghost')).to.equal(null);
+      // no throw is the assertion here
+      node.dispatchEvent(new CustomEvent('action-show-ghost'));
+      node.dispatchEvent(new CustomEvent('action-hide-ghost'));
+    });
+  });
+});

--- a/test/temba-flow-node-actions.test.ts
+++ b/test/temba-flow-node-actions.test.ts
@@ -51,7 +51,10 @@ describe('temba-flow-node actions', () => {
     node = (await fixture('<temba-flow-node></temba-flow-node>')) as CanvasNode;
     inner = node as any;
     inner.node = flowNode() as any;
-    inner.ui = { type: 'execute_actions', position: { left: 0, top: 0 } } as any;
+    inner.ui = {
+      type: 'execute_actions',
+      position: { left: 0, top: 0 }
+    } as any;
     inner.plumber = plumber as any;
     await node.updateComplete;
   });

--- a/test/temba-flow-search-table.test.ts
+++ b/test/temba-flow-search-table.test.ts
@@ -66,7 +66,11 @@ describe('temba-flow-search table scope', () => {
     it('reports where in the text the match falls', async () => {
       const element = await createSearch(
         definition([
-          { uuid: 'node-1', actions: [sendMsg('a1', 'Well hello there')], exits: [] }
+          {
+            uuid: 'node-1',
+            actions: [sendMsg('a1', 'Well hello there')],
+            exits: []
+          }
         ])
       );
       const results = await search(element, 'hello');
@@ -241,8 +245,7 @@ describe('temba-flow-search table scope', () => {
 
     // stickies live on the canvas rather than the message table, so they are
     // only searched in flow scope
-    const createFlowSearch = (def: any) =>
-      createSearch(def, { scope: 'flow' });
+    const createFlowSearch = (def: any) => createSearch(def, { scope: 'flow' });
 
     it('are not searched in table scope', async () => {
       const element = await createSearch(

--- a/test/temba-flow-search-table.test.ts
+++ b/test/temba-flow-search-table.test.ts
@@ -1,0 +1,348 @@
+import '../temba-modules';
+import { fixture, expect } from '@open-wc/testing';
+import { FlowSearch } from '../src/flow/FlowSearch';
+
+const SPANISH = 'spa';
+
+const sendMsg = (uuid: string, text: string, extra: any = {}) => ({
+  uuid,
+  type: 'send_msg',
+  text,
+  ...extra
+});
+
+const definition = (nodes: any[], overrides: any = {}) => ({
+  uuid: 'flow-1',
+  name: 'Test Flow',
+  language: 'eng',
+  type: 'messaging' as const,
+  revision: 1,
+  spec_version: '14.3',
+  localization: {},
+  nodes,
+  _ui: { nodes: {}, languages: [] },
+  ...overrides
+});
+
+const createSearch = async (
+  def: any,
+  { scope = 'table', languageCode = '' } = {}
+): Promise<FlowSearch> => {
+  const search = (await fixture(
+    '<temba-flow-search></temba-flow-search>'
+  )) as FlowSearch;
+  search.definition = def;
+  search.scope = scope as any;
+  search.languageCode = languageCode;
+  await search.updateComplete;
+  return search;
+};
+
+// runs a query through the component's own search path
+const search = async (element: FlowSearch, query: string) => {
+  (element as any).searchQuery = query;
+  (element as any).performSearch();
+  await element.updateComplete;
+  return (element as any).results;
+};
+
+describe('temba-flow-search table scope', () => {
+  describe('matching message text', () => {
+    it('finds an action by its text', async () => {
+      const element = await createSearch(
+        definition([
+          { uuid: 'node-1', actions: [sendMsg('a1', 'Hello there')], exits: [] }
+        ])
+      );
+      const results = await search(element, 'hello');
+      expect(results).to.have.length(1);
+      expect(results[0].nodeUuid).to.equal('node-1');
+      expect(results[0].action.uuid).to.equal('a1');
+      expect(results[0].fullText).to.equal('Hello there');
+      expect(results[0].matchStart).to.equal(0);
+      expect(results[0].matchLength).to.equal(5);
+    });
+
+    it('reports where in the text the match falls', async () => {
+      const element = await createSearch(
+        definition([
+          { uuid: 'node-1', actions: [sendMsg('a1', 'Well hello there')], exits: [] }
+        ])
+      );
+      const results = await search(element, 'hello');
+      expect(results[0].matchStart).to.equal(5);
+    });
+
+    it('matches case insensitively', async () => {
+      const element = await createSearch(
+        definition([
+          { uuid: 'node-1', actions: [sendMsg('a1', 'HELLO')], exits: [] }
+        ])
+      );
+      expect(await search(element, 'hello')).to.have.length(1);
+    });
+
+    it('returns nothing for an unmatched query', async () => {
+      const element = await createSearch(
+        definition([
+          { uuid: 'node-1', actions: [sendMsg('a1', 'Hello')], exits: [] }
+        ])
+      );
+      expect(await search(element, 'nonsense')).to.have.length(0);
+    });
+
+    it('returns nothing for an empty query', async () => {
+      const element = await createSearch(
+        definition([
+          { uuid: 'node-1', actions: [sendMsg('a1', 'Hello')], exits: [] }
+        ])
+      );
+      expect(await search(element, '   ')).to.have.length(0);
+    });
+
+    it('returns nothing without a definition', async () => {
+      const element = await createSearch(null);
+      expect(await search(element, 'hello')).to.have.length(0);
+    });
+
+    it('finds matches across several nodes', async () => {
+      const element = await createSearch(
+        definition([
+          { uuid: 'node-1', actions: [sendMsg('a1', 'Hello one')], exits: [] },
+          { uuid: 'node-2', actions: [sendMsg('a2', 'Hello two')], exits: [] }
+        ])
+      );
+      const results = await search(element, 'hello');
+      expect(results.map((r: any) => r.nodeUuid)).to.deep.equal([
+        'node-1',
+        'node-2'
+      ]);
+    });
+
+    it('reports one result per action', async () => {
+      const element = await createSearch(
+        definition([
+          {
+            uuid: 'node-1',
+            actions: [sendMsg('a1', 'hello hello hello')],
+            exits: []
+          }
+        ])
+      );
+      expect(await search(element, 'hello')).to.have.length(1);
+    });
+  });
+
+  describe('localizable fields', () => {
+    it('searches quick replies', async () => {
+      const element = await createSearch(
+        definition([
+          {
+            uuid: 'node-1',
+            actions: [
+              sendMsg('a1', 'Pick one', { quick_replies: ['Yes', 'Maybe'] })
+            ],
+            exits: []
+          }
+        ])
+      );
+      const results = await search(element, 'maybe');
+      expect(results).to.have.length(1);
+      expect(results[0].fullText).to.equal('Maybe');
+    });
+
+    it('searches every localizable text field of an action', async () => {
+      const element = await createSearch(
+        definition([
+          {
+            uuid: 'node-1',
+            actions: [
+              {
+                uuid: 'a1',
+                type: 'send_email',
+                subject: 'Invoice attached',
+                body: 'Please see the attachment'
+              }
+            ],
+            exits: []
+          }
+        ])
+      );
+      expect(await search(element, 'invoice')).to.have.length(1);
+      expect(await search(element, 'attachment')).to.have.length(1);
+    });
+
+    it('skips actions with nothing localizable', async () => {
+      const element = await createSearch(
+        definition([
+          {
+            uuid: 'node-1',
+            actions: [
+              { uuid: 'a1', type: 'set_contact_name', name: 'Hello Bob' }
+            ],
+            exits: []
+          }
+        ])
+      );
+      expect(await search(element, 'hello')).to.have.length(0);
+    });
+
+    it('ignores blank field values', async () => {
+      const element = await createSearch(
+        definition([
+          {
+            uuid: 'node-1',
+            actions: [sendMsg('a1', '   ', { quick_replies: ['', '  '] })],
+            exits: []
+          }
+        ])
+      );
+      expect(await search(element, ' ')).to.have.length(0);
+    });
+  });
+
+  describe('translations', () => {
+    const translated = definition(
+      [{ uuid: 'node-1', actions: [sendMsg('a1', 'Hello')], exits: [] }],
+      { localization: { [SPANISH]: { a1: { text: ['Hola amigo'] } } } }
+    );
+
+    it('searches the translation while translating', async () => {
+      const element = await createSearch(translated, {
+        languageCode: SPANISH
+      });
+      const results = await search(element, 'amigo');
+      expect(results).to.have.length(1);
+      expect(results[0].fullText).to.equal('Hola amigo');
+    });
+
+    it('still matches the base text while translating', async () => {
+      const element = await createSearch(translated, {
+        languageCode: SPANISH
+      });
+      expect(await search(element, 'hello')).to.have.length(1);
+    });
+
+    it('does not search translations in the base language', async () => {
+      const element = await createSearch(translated, { languageCode: 'eng' });
+      expect(await search(element, 'amigo')).to.have.length(0);
+    });
+  });
+
+  describe('sticky notes', () => {
+    const withSticky = (sticky: any) =>
+      definition([], {
+        _ui: {
+          nodes: {},
+          languages: [],
+          stickies: { 'sticky-1': sticky }
+        }
+      });
+
+    // stickies live on the canvas rather than the message table, so they are
+    // only searched in flow scope
+    const createFlowSearch = (def: any) =>
+      createSearch(def, { scope: 'flow' });
+
+    it('are not searched in table scope', async () => {
+      const element = await createSearch(
+        withSticky({
+          title: 'Remember this',
+          body: '',
+          position: { left: 0, top: 0 },
+          color: 'yellow'
+        })
+      );
+      expect(await search(element, 'remember')).to.have.length(0);
+    });
+
+    it('matches a sticky title', async () => {
+      const element = await createFlowSearch(
+        withSticky({
+          title: 'Remember this',
+          body: '',
+          position: { left: 0, top: 0 },
+          color: 'yellow'
+        })
+      );
+      const results = await search(element, 'remember');
+      expect(results).to.have.length(1);
+      expect(results[0].typeName).to.equal('Sticky Note');
+      expect(results[0].stickyField).to.equal('title');
+      expect(results[0].nodeUuid).to.equal('sticky-1');
+    });
+
+    it('matches a sticky body', async () => {
+      const element = await createFlowSearch(
+        withSticky({
+          title: 'Note',
+          body: 'Check the numbers',
+          position: { left: 0, top: 0 },
+          color: 'blue'
+        })
+      );
+      const results = await search(element, 'numbers');
+      expect(results[0].stickyField).to.equal('body');
+    });
+
+    it('prefers the title when both match', async () => {
+      const element = await createFlowSearch(
+        withSticky({
+          title: 'Check this',
+          body: 'Check that',
+          position: { left: 0, top: 0 },
+          color: 'yellow'
+        })
+      );
+      const results = await search(element, 'check');
+      expect(results).to.have.length(1);
+      expect(results[0].stickyField).to.equal('title');
+    });
+
+    it('falls back to yellow for an unknown colour', async () => {
+      const element = await createFlowSearch(
+        withSticky({
+          title: 'Remember',
+          body: '',
+          position: { left: 0, top: 0 },
+          color: 'chartreuse'
+        })
+      );
+      const results = await search(element, 'remember');
+      expect(results[0].color).to.be.a('string');
+    });
+  });
+
+  describe('rendering results', () => {
+    it('lists the matches', async () => {
+      const element = await createSearch(
+        definition([
+          { uuid: 'node-1', actions: [sendMsg('a1', 'Hello one')], exits: [] },
+          { uuid: 'node-2', actions: [sendMsg('a2', 'Hello two')], exits: [] }
+        ])
+      );
+      element.open = true;
+      await search(element, 'hello');
+      await element.updateComplete;
+      const rendered = element.shadowRoot.textContent;
+      expect(rendered).to.contain('Hello one');
+      expect(rendered).to.contain('Hello two');
+    });
+
+    it('fires an event when a result is selected', async () => {
+      const element = await createSearch(
+        definition([
+          { uuid: 'node-1', actions: [sendMsg('a1', 'Hello')], exits: [] }
+        ])
+      );
+      const selected: any[] = [];
+      element.addEventListener('temba-search-result-selected', (e: any) =>
+        selected.push(e.detail)
+      );
+      const results = await search(element, 'hello');
+      (element as any).selectResult(results[0]);
+      expect(selected).to.have.length(1);
+      expect(selected[0].nodeUuid).to.equal('node-1');
+    });
+  });
+});

--- a/test/temba-image-picker.test.ts
+++ b/test/temba-image-picker.test.ts
@@ -185,7 +185,9 @@ describe('temba-image-picker', () => {
       await openCropper(picker);
       expect(picker.showCroppie).to.equal(true);
 
-      (picker.shadowRoot.querySelector('.controls .close') as HTMLElement).click();
+      (
+        picker.shadowRoot.querySelector('.controls .close') as HTMLElement
+      ).click();
       await picker.updateComplete;
 
       expect(picker.showCroppie).to.equal(false);
@@ -200,9 +202,9 @@ describe('temba-image-picker', () => {
       const picker = await createPicker();
       await openCropper(picker);
 
-      (picker.shadowRoot.querySelector(
-        '.controls .submit'
-      ) as HTMLElement).click();
+      (
+        picker.shadowRoot.querySelector('.controls .submit') as HTMLElement
+      ).click();
 
       // let the croppie result promise settle
       await new Promise((resolve) => setTimeout(resolve, 0));

--- a/test/temba-image-picker.test.ts
+++ b/test/temba-image-picker.test.ts
@@ -1,0 +1,225 @@
+import '../temba-modules';
+import { fixture, expect } from '@open-wc/testing';
+import { ImagePicker } from '../src/form/ImagePicker';
+
+// a stand-in for the croppie widget, which needs a real canvas otherwise
+class FakeCroppie {
+  public static instances: FakeCroppie[] = [];
+
+  public element: HTMLElement;
+  public options: any;
+  public bound: any = null;
+  public resultOptions: any = null;
+  public resultBlob = new Blob(['image'], { type: 'image/webp' });
+
+  constructor(element: HTMLElement, options: any) {
+    this.element = element;
+    this.options = options;
+    FakeCroppie.instances.push(this);
+  }
+
+  public bind(options: any) {
+    this.bound = options;
+  }
+
+  public result(options: any): Promise<Blob> {
+    this.resultOptions = options;
+    return Promise.resolve(this.resultBlob);
+  }
+}
+
+const createPicker = async (attrs = ''): Promise<ImagePicker> => {
+  const picker = (await fixture(
+    `<temba-image-picker name="avatar" ${attrs}></temba-image-picker>`
+  )) as ImagePicker;
+  await picker.updateComplete;
+  return picker;
+};
+
+const toggle = (picker: ImagePicker) =>
+  picker.shadowRoot.querySelector('.toggle') as HTMLElement;
+
+const fileInput = (picker: ImagePicker) =>
+  picker.shadowRoot.querySelector('#file') as HTMLInputElement;
+
+describe('temba-image-picker', () => {
+  let originalCroppie: any;
+
+  beforeEach(() => {
+    originalCroppie = (window as any).Croppie;
+    (window as any).Croppie = FakeCroppie;
+    FakeCroppie.instances = [];
+  });
+
+  afterEach(() => {
+    (window as any).Croppie = originalCroppie;
+  });
+
+  describe('rendering', () => {
+    it('renders a toggle and a hidden file input', async () => {
+      const picker = await createPicker();
+      expect(toggle(picker)).to.not.equal(null);
+      expect(fileInput(picker)).to.not.equal(null);
+      expect(fileInput(picker).getAttribute('accept')).to.equal('image/*');
+    });
+
+    it('shows a placeholder background with no image set', async () => {
+      const picker = await createPicker();
+      expect(toggle(picker).style.background).to.contain('rgba(0, 0, 0, 0.1)');
+      expect(toggle(picker).classList.contains('set')).to.equal(false);
+    });
+
+    it('shows the image once a url is set', async () => {
+      const picker = await createPicker();
+      picker.url = 'http://example.com/avatar.png';
+      await picker.updateComplete;
+      expect(toggle(picker).classList.contains('set')).to.equal(true);
+      expect(toggle(picker).style.background).to.contain(
+        'http://example.com/avatar.png'
+      );
+    });
+
+    it('mirrors the url onto the host attribute', async () => {
+      const picker = await createPicker();
+      picker.url = 'http://example.com/avatar.png';
+      await picker.updateComplete;
+      expect(picker.getAttribute('url')).to.equal(
+        'http://example.com/avatar.png'
+      );
+    });
+
+    it('defaults to a square viewport shape', async () => {
+      const picker = await createPicker();
+      expect(picker.shape).to.equal('square');
+      expect(
+        picker.shadowRoot.querySelector('.wrapper').classList.contains('square')
+      ).to.equal(true);
+    });
+
+    it('honours a circle shape', async () => {
+      const picker = await createPicker('shape="circle"');
+      expect(
+        picker.shadowRoot.querySelector('.wrapper').classList.contains('circle')
+      ).to.equal(true);
+    });
+  });
+
+  describe('choosing a file', () => {
+    it('opens the file dialog when the toggle is clicked', async () => {
+      const picker = await createPicker();
+      let clicked = false;
+      fileInput(picker).click = () => {
+        clicked = true;
+      };
+      toggle(picker).click();
+      expect(clicked).to.equal(true);
+    });
+
+    it('reads the chosen file and opens the cropper', async () => {
+      const picker = await createPicker();
+      const input = fileInput(picker);
+      const transfer = new DataTransfer();
+      transfer.items.add(
+        new File([new Blob(['img'])], 'avatar.png', { type: 'image/png' })
+      );
+      input.files = transfer.files;
+
+      const opened = new Promise<void>((resolve) => {
+        const original = picker.uploadReader.onload;
+        picker.uploadReader.onload = function (this: any, ev: any) {
+          (original as any).call(this, ev);
+          resolve();
+        };
+      });
+
+      input.dispatchEvent(new Event('change'));
+      await opened;
+      await picker.updateComplete;
+
+      expect(FakeCroppie.instances).to.have.length(1);
+      expect(picker.showCroppie).to.equal(true);
+      // the reader hands croppie a data url for the chosen file
+      expect(FakeCroppie.instances[0].bound.url).to.contain('data:');
+      // the input is cleared so the same file can be picked again
+      expect(input.value).to.equal('');
+    });
+
+    it('ignores a change event with no file', async () => {
+      const picker = await createPicker();
+      fileInput(picker).dispatchEvent(new Event('change'));
+      await picker.updateComplete;
+      expect(FakeCroppie.instances).to.have.length(0);
+      expect(picker.showCroppie).to.equal(false);
+    });
+  });
+
+  describe('cropping', () => {
+    // opens the cropper directly rather than going through the file reader
+    const openCropper = async (picker: ImagePicker) => {
+      (picker as any).launchCroppie('data:image/png;base64,abc');
+      await picker.updateComplete;
+    };
+
+    it('builds the cropper with the configured shape', async () => {
+      const picker = await createPicker('shape="circle"');
+      await openCropper(picker);
+      const croppie = FakeCroppie.instances[0];
+      expect(croppie.options.viewport.type).to.equal('circle');
+      expect(croppie.options.viewport.width).to.equal(300);
+      expect(croppie.options.enableExif).to.equal(true);
+    });
+
+    it('replaces any previous cropper', async () => {
+      const picker = await createPicker();
+      await openCropper(picker);
+      await openCropper(picker);
+      expect(FakeCroppie.instances).to.have.length(2);
+      // only one embedded widget remains
+      expect(
+        picker.shadowRoot.querySelectorAll('.croppie .embed > div')
+      ).to.have.length(1);
+    });
+
+    it('closes without saving', async () => {
+      const picker = await createPicker();
+      await openCropper(picker);
+      expect(picker.showCroppie).to.equal(true);
+
+      (picker.shadowRoot.querySelector('.controls .close') as HTMLElement).click();
+      await picker.updateComplete;
+
+      expect(picker.showCroppie).to.equal(false);
+      expect(
+        picker.shadowRoot.querySelectorAll('.croppie .embed > div')
+      ).to.have.length(0);
+      // nothing was captured, so the field value is left untouched
+      expect(picker.value).to.not.be.instanceOf(FormData);
+    });
+
+    it('saves the cropped result as form data', async () => {
+      const picker = await createPicker();
+      await openCropper(picker);
+
+      (picker.shadowRoot.querySelector(
+        '.controls .submit'
+      ) as HTMLElement).click();
+
+      // let the croppie result promise settle
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await picker.updateComplete;
+
+      const croppie = FakeCroppie.instances[0];
+      expect(croppie.resultOptions.format).to.equal('webp');
+      expect(croppie.resultOptions.type).to.equal('blob');
+
+      expect(picker.value).to.be.instanceOf(FormData);
+      const saved = (picker.value as any).get('avatar');
+      expect(saved).to.not.equal(null);
+      expect(saved.name).to.equal('filename.webp');
+
+      // the preview switches to the newly cropped image and the editor closes
+      expect(picker.url).to.contain('blob:');
+      expect(picker.showCroppie).to.equal(false);
+    });
+  });
+});

--- a/test/temba-media-picker.test.ts
+++ b/test/temba-media-picker.test.ts
@@ -156,8 +156,9 @@ describe('temba-media-picker', () => {
     });
 
     it('accepts any of a comma separated list', async () => {
-      expect(await uploadOne('image/png, application/pdf', 'application/pdf'))
-        .to.equal(1);
+      expect(
+        await uploadOne('image/png, application/pdf', 'application/pdf')
+      ).to.equal(1);
     });
 
     it('rejects a type outside the list', async () => {
@@ -217,12 +218,7 @@ describe('temba-media-picker', () => {
 
   describe('upload failures', () => {
     it('reports a validation error without attaching', async () => {
-      mockPOST(
-        MEDIA_ENDPOINT,
-        { file: ['Unsupported file type'] },
-        {},
-        '400'
-      );
+      mockPOST(MEDIA_ENDPOINT, { file: ['Unsupported file type'] }, {}, '400');
       const picker = await createPicker();
       picker.uploadFiles([file('bad.exe', 'application/octet-stream')]);
       await settle();
@@ -287,7 +283,9 @@ describe('temba-media-picker', () => {
       const single = await createPicker('max="1"');
       await single.updateComplete;
       expect(
-        single.shadowRoot.querySelector('#upload-input').hasAttribute('multiple')
+        single.shadowRoot
+          .querySelector('#upload-input')
+          .hasAttribute('multiple')
       ).to.equal(false);
 
       const multi = await createPicker('max="3"');

--- a/test/temba-media-picker.test.ts
+++ b/test/temba-media-picker.test.ts
@@ -1,0 +1,329 @@
+import '../temba-modules';
+import { fixture, expect } from '@open-wc/testing';
+import { MediaPicker } from '../src/form/MediaPicker';
+import { Attachment, CustomEventType } from '../src/interfaces';
+import { mockPOST, clearMockPosts } from './utils.test';
+
+const MEDIA_ENDPOINT = /\/api\/v2\/media\.json/;
+
+const file = (name: string, type: string, size = 100): File => {
+  const blob = new Blob(['x'.repeat(size)], { type });
+  return new File([blob], name, { type });
+};
+
+const attachment = (url: string, filename = 'a.jpg'): Attachment =>
+  ({
+    uuid: `uuid-${url}`,
+    url,
+    filename,
+    content_type: 'image/jpeg',
+    size: 100
+  }) as Attachment;
+
+// a DragEvent carrying the given files
+const dragEvent = (type: string, files: File[] = []): DragEvent => {
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true
+  }) as DragEvent;
+  Object.defineProperty(event, 'dataTransfer', {
+    value: { files }
+  });
+  return event;
+};
+
+const createPicker = async (attrs = ''): Promise<MediaPicker> => {
+  return (await fixture(
+    `<temba-media-picker ${attrs}></temba-media-picker>`
+  )) as MediaPicker;
+};
+
+// the drag handlers live on the container inside the shadow root, so events
+// have to be dispatched there rather than on the host
+const drag = async (picker: MediaPicker, type: string, files: File[] = []) => {
+  await picker.updateComplete;
+  const container = picker.shadowRoot.querySelector('.container');
+  container.dispatchEvent(dragEvent(type, files));
+};
+
+// waits for the post promise chain plus the deferred change event
+const settle = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+describe('temba-media-picker', () => {
+  afterEach(() => {
+    clearMockPosts();
+  });
+
+  describe('canAcceptAttachments', () => {
+    it('accepts while below the maximum', async () => {
+      const picker = await createPicker('max="2"');
+      expect(picker.canAcceptAttachments()).to.equal(true);
+      picker.attachments = [attachment('one')];
+      expect(picker.canAcceptAttachments()).to.equal(true);
+    });
+
+    it('refuses once the maximum is reached', async () => {
+      const picker = await createPicker('max="2"');
+      picker.attachments = [attachment('one'), attachment('two')];
+      expect(picker.canAcceptAttachments()).to.equal(false);
+    });
+  });
+
+  describe('drag and drop', () => {
+    it('highlights on drag enter and over', async () => {
+      const picker = await createPicker();
+      await drag(picker, 'dragenter');
+      expect(picker.pendingDrop).to.equal(true);
+
+      picker.pendingDrop = false;
+      await drag(picker, 'dragover');
+      expect(picker.pendingDrop).to.equal(true);
+    });
+
+    it('clears the highlight on drag leave', async () => {
+      const picker = await createPicker();
+      await drag(picker, 'dragenter');
+      await drag(picker, 'dragleave');
+      expect(picker.pendingDrop).to.equal(false);
+    });
+
+    it('does not highlight once full', async () => {
+      const picker = await createPicker('max="1"');
+      picker.attachments = [attachment('one')];
+      await drag(picker, 'dragenter');
+      expect(picker.pendingDrop).to.not.equal(true);
+    });
+
+    it('ignores drag events entirely when told to', async () => {
+      const picker = await createPicker('ignoreDrops');
+      await drag(picker, 'dragenter');
+      expect(picker.pendingDrop).to.not.equal(true);
+    });
+
+    it('uploads acceptable files on drop', async () => {
+      mockPOST(MEDIA_ENDPOINT, attachment('dropped', 'photo.jpg'));
+      const picker = await createPicker();
+      await drag(picker, 'drop', [file('photo.jpg', 'image/jpeg')]);
+      await settle();
+      expect(picker.attachments).to.have.length(1);
+      expect(picker.attachments[0].url).to.equal('dropped');
+    });
+
+    it('filters dropped files against the accept list', async () => {
+      mockPOST(MEDIA_ENDPOINT, attachment('dropped'));
+      const picker = await createPicker('accept="image/png"');
+      await drag(picker, 'drop', [
+        file('photo.jpg', 'image/jpeg'),
+        file('shot.png', 'image/png')
+      ]);
+      await settle();
+      expect(picker.attachments).to.have.length(1);
+    });
+
+    it('ignores a drop when told to ignore drops', async () => {
+      mockPOST(MEDIA_ENDPOINT, attachment('dropped'));
+      const picker = await createPicker('ignoreDrops');
+      await drag(picker, 'drop', [file('photo.jpg', 'image/jpeg')]);
+      await settle();
+      expect(picker.attachments).to.have.length(0);
+    });
+
+    it('ignores a drop once full', async () => {
+      mockPOST(MEDIA_ENDPOINT, attachment('dropped'));
+      const picker = await createPicker('max="1"');
+      picker.attachments = [attachment('one')];
+      await drag(picker, 'drop', [file('photo.jpg', 'image/jpeg')]);
+      await settle();
+      expect(picker.attachments).to.have.length(1);
+    });
+  });
+
+  describe('accept matching', () => {
+    const uploadOne = async (accept: string, type: string) => {
+      mockPOST(MEDIA_ENDPOINT, attachment('uploaded'));
+      const picker = await createPicker(`accept="${accept}"`);
+      picker.uploadFiles([file('f', type)]);
+      await settle();
+      return picker.attachments.length;
+    };
+
+    it('accepts an exact content type match', async () => {
+      expect(await uploadOne('image/png', 'image/png')).to.equal(1);
+    });
+
+    it('accepts a wildcard subtype match', async () => {
+      expect(await uploadOne('image/*', 'image/jpeg')).to.equal(1);
+    });
+
+    it('accepts any of a comma separated list', async () => {
+      expect(await uploadOne('image/png, application/pdf', 'application/pdf'))
+        .to.equal(1);
+    });
+
+    it('rejects a type outside the list', async () => {
+      expect(await uploadOne('image/png', 'application/pdf')).to.equal(0);
+    });
+
+    it('accepts anything when no accept is configured', async () => {
+      expect(await uploadOne('', 'application/octet-stream')).to.equal(1);
+    });
+  });
+
+  describe('uploadFiles', () => {
+    it('skips files already attached with the same name and size', async () => {
+      mockPOST(MEDIA_ENDPOINT, attachment('uploaded'));
+      const picker = await createPicker();
+      picker.attachments = [
+        { ...attachment('one'), filename: 'photo.jpg', size: 100 } as Attachment
+      ];
+      picker.uploadFiles([file('photo.jpg', 'image/jpeg', 100)]);
+      await settle();
+      expect(picker.attachments).to.have.length(1);
+    });
+
+    it('uploads a file whose name matches but size differs', async () => {
+      mockPOST(MEDIA_ENDPOINT, attachment('uploaded'));
+      const picker = await createPicker();
+      picker.attachments = [
+        { ...attachment('one'), filename: 'photo.jpg', size: 100 } as Attachment
+      ];
+      picker.uploadFiles([file('photo.jpg', 'image/jpeg', 200)]);
+      await settle();
+      expect(picker.attachments).to.have.length(2);
+    });
+
+    it('does not add beyond the maximum', async () => {
+      mockPOST(MEDIA_ENDPOINT, attachment('uploaded'));
+      const picker = await createPicker('max="1"');
+      picker.attachments = [attachment('one')];
+      picker.uploadFiles([file('photo.jpg', 'image/jpeg')]);
+      await settle();
+      expect(picker.attachments).to.have.length(1);
+    });
+
+    it('reports loading state while uploading', async () => {
+      mockPOST(MEDIA_ENDPOINT, attachment('uploaded'));
+      const picker = await createPicker();
+      const loadingStates: boolean[] = [];
+      picker.addEventListener(CustomEventType.Loading, (e: any) =>
+        loadingStates.push(e.detail.loading)
+      );
+      picker.uploadFiles([file('photo.jpg', 'image/jpeg')]);
+      await settle();
+      expect(loadingStates).to.deep.equal([true, false]);
+      expect(picker.uploading).to.equal(false);
+    });
+  });
+
+  describe('upload failures', () => {
+    it('reports a validation error without attaching', async () => {
+      mockPOST(
+        MEDIA_ENDPOINT,
+        { file: ['Unsupported file type'] },
+        {},
+        '400'
+      );
+      const picker = await createPicker();
+      picker.uploadFiles([file('bad.exe', 'application/octet-stream')]);
+      await settle();
+      expect(picker.attachments).to.have.length(0);
+      expect(picker.uploading).to.equal(false);
+    });
+
+    it('recovers from a server failure', async () => {
+      mockPOST(MEDIA_ENDPOINT, { detail: 'boom' }, {}, '500');
+      const picker = await createPicker();
+      picker.uploadFiles([file('photo.jpg', 'image/jpeg')]);
+      await settle();
+      expect(picker.attachments).to.have.length(0);
+      expect(picker.uploading).to.equal(false);
+    });
+  });
+
+  describe('removing attachments', () => {
+    it('removes the attachment matching the clicked icon', async () => {
+      const picker = await createPicker();
+      picker.attachments = [attachment('one'), attachment('two')];
+      await picker.updateComplete;
+
+      const remove = picker.shadowRoot.querySelector(
+        'temba-icon[id="one"]'
+      ) as HTMLElement;
+      expect(remove).to.not.equal(null);
+      remove.click();
+      await picker.updateComplete;
+
+      expect(picker.attachments).to.have.length(1);
+      expect(picker.attachments[0].url).to.equal('two');
+    });
+  });
+
+  describe('rendering', () => {
+    it('offers the upload input while there is room', async () => {
+      const picker = await createPicker('max="2"');
+      await picker.updateComplete;
+      expect(picker.shadowRoot.querySelector('#upload-input')).to.not.equal(
+        null
+      );
+    });
+
+    it('hides the upload input once full', async () => {
+      const picker = await createPicker('max="1"');
+      picker.attachments = [attachment('one')];
+      await picker.updateComplete;
+      expect(picker.shadowRoot.querySelector('#upload-input')).to.equal(null);
+    });
+
+    it('shows a loading indicator while uploading', async () => {
+      const picker = await createPicker();
+      picker.uploading = true;
+      await picker.updateComplete;
+      expect(picker.shadowRoot.querySelector('temba-loading')).to.not.equal(
+        null
+      );
+    });
+
+    it('allows multiple selection only when more than one is allowed', async () => {
+      const single = await createPicker('max="1"');
+      await single.updateComplete;
+      expect(
+        single.shadowRoot.querySelector('#upload-input').hasAttribute('multiple')
+      ).to.equal(false);
+
+      const multi = await createPicker('max="3"');
+      await multi.updateComplete;
+      expect(
+        multi.shadowRoot.querySelector('#upload-input').hasAttribute('multiple')
+      ).to.equal(true);
+    });
+
+    it('renders a thumbnail per attachment', async () => {
+      const picker = await createPicker();
+      picker.attachments = [attachment('one'), attachment('two')];
+      await picker.updateComplete;
+      expect(
+        picker.shadowRoot.querySelectorAll('temba-thumbnail')
+      ).to.have.length(2);
+    });
+  });
+
+  describe('file input', () => {
+    it('uploads files chosen through the input', async () => {
+      mockPOST(MEDIA_ENDPOINT, attachment('chosen'));
+      const picker = await createPicker();
+      await picker.updateComplete;
+
+      const input = picker.shadowRoot.querySelector(
+        '#upload-input'
+      ) as HTMLInputElement;
+      const transfer = new DataTransfer();
+      transfer.items.add(file('photo.jpg', 'image/jpeg'));
+      input.files = transfer.files;
+      input.dispatchEvent(new Event('change'));
+
+      await settle();
+      expect(picker.attachments).to.have.length(1);
+      expect(picker.attachments[0].url).to.equal('chosen');
+    });
+  });
+});

--- a/test/temba-message-table.test.ts
+++ b/test/temba-message-table.test.ts
@@ -285,9 +285,9 @@ describe('temba-message-table', () => {
 
     it('returns an empty list when not translating', async () => {
       const table = await createTable(withReplies(['Si']));
-      expect((table as any).getTranslatedQuickReplies('action-1')).to.deep.equal(
-        []
-      );
+      expect(
+        (table as any).getTranslatedQuickReplies('action-1')
+      ).to.deep.equal([]);
     });
 
     it('returns the localized replies', async () => {
@@ -295,9 +295,9 @@ describe('temba-message-table', () => {
         languageCode: SPANISH,
         isTranslating: true
       });
-      expect((table as any).getTranslatedQuickReplies('action-1')).to.deep.equal(
-        ['Si', 'No']
-      );
+      expect(
+        (table as any).getTranslatedQuickReplies('action-1')
+      ).to.deep.equal(['Si', 'No']);
     });
 
     it('trims and drops blank replies', async () => {
@@ -305,9 +305,9 @@ describe('temba-message-table', () => {
         languageCode: SPANISH,
         isTranslating: true
       });
-      expect((table as any).getTranslatedQuickReplies('action-1')).to.deep.equal(
-        ['Si']
-      );
+      expect(
+        (table as any).getTranslatedQuickReplies('action-1')
+      ).to.deep.equal(['Si']);
     });
 
     it('ignores non string entries', async () => {
@@ -315,9 +315,9 @@ describe('temba-message-table', () => {
         languageCode: SPANISH,
         isTranslating: true
       });
-      expect((table as any).getTranslatedQuickReplies('action-1')).to.deep.equal(
-        ['Si']
-      );
+      expect(
+        (table as any).getTranslatedQuickReplies('action-1')
+      ).to.deep.equal(['Si']);
     });
 
     it('returns an empty list when the field is not an array', async () => {
@@ -325,9 +325,9 @@ describe('temba-message-table', () => {
         languageCode: SPANISH,
         isTranslating: true
       });
-      expect((table as any).getTranslatedQuickReplies('action-1')).to.deep.equal(
-        []
-      );
+      expect(
+        (table as any).getTranslatedQuickReplies('action-1')
+      ).to.deep.equal([]);
     });
   });
 
@@ -373,7 +373,9 @@ describe('temba-message-table', () => {
         languageCode: SPANISH,
         isTranslating: true
       });
-      expect((missing as any).getTranslatedCategoryName('cat-1')).to.equal(null);
+      expect((missing as any).getTranslatedCategoryName('cat-1')).to.equal(
+        null
+      );
     });
   });
 
@@ -400,18 +402,18 @@ describe('temba-message-table', () => {
         withEmail({ [SPANISH]: { 'action-email': { subject: ['Hola'] } } }),
         { languageCode: SPANISH, isTranslating: true }
       );
-      expect((table as any).getTranslatedField('action-email', 'subject')).to.equal(
-        'Hola'
-      );
+      expect(
+        (table as any).getTranslatedField('action-email', 'subject')
+      ).to.equal('Hola');
     });
 
     it('returns null when not translating', async () => {
       const table = await createTable(
         withEmail({ [SPANISH]: { 'action-email': { subject: ['Hola'] } } })
       );
-      expect((table as any).getTranslatedField('action-email', 'subject')).to.equal(
-        null
-      );
+      expect(
+        (table as any).getTranslatedField('action-email', 'subject')
+      ).to.equal(null);
     });
 
     it('returns the whole array for an array field', async () => {
@@ -495,9 +497,9 @@ describe('temba-message-table', () => {
   describe('usesPairedRows and getPairedFields', () => {
     it('pairs rows for actions with more than one text field', async () => {
       const table = await createTable(definition([node()]));
-      expect(
-        (table as any).usesPairedRows({ type: 'send_email' })
-      ).to.equal(true);
+      expect((table as any).usesPairedRows({ type: 'send_email' })).to.equal(
+        true
+      );
     });
 
     it('does not pair rows for a single text field action', async () => {
@@ -559,7 +561,8 @@ describe('temba-message-table', () => {
   describe('stripLeadingLineBreaks', () => {
     it('removes leading newlines only', async () => {
       const table = await createTable(definition([node()]));
-      const strip = (text: string) => (table as any).stripLeadingLineBreaks(text);
+      const strip = (text: string) =>
+        (table as any).stripLeadingLineBreaks(text);
       expect(strip('\n\nhello')).to.equal('hello');
       expect(strip('\r\nhello')).to.equal('hello');
       expect(strip('hello\n\n')).to.equal('hello\n\n');
@@ -603,7 +606,11 @@ describe('temba-message-table', () => {
         kind: 'localization-group',
         node: node(),
         rules: [
-          { uuid: 'case-1', type: 'has_any_word', arguments: ['red', 'crimson'] }
+          {
+            uuid: 'case-1',
+            type: 'has_any_word',
+            arguments: ['red', 'crimson']
+          }
         ],
         categories: [],
         nodeIndex: 1

--- a/test/temba-message-table.test.ts
+++ b/test/temba-message-table.test.ts
@@ -1,0 +1,817 @@
+import '../temba-modules';
+import { fixture, expect } from '@open-wc/testing';
+import { MessageTable } from '../src/flow/MessageTable';
+import { zustand } from '../src/store/AppState';
+import { CustomEventType } from '../src/interfaces';
+
+const SPANISH = 'spa';
+
+// a send_msg action with optional localizable extras
+const sendMsg = (overrides: any = {}) => ({
+  uuid: 'action-1',
+  type: 'send_msg',
+  text: 'Hello there',
+  ...overrides
+});
+
+const node = (overrides: any = {}) => ({
+  uuid: 'node-1',
+  actions: [],
+  exits: [{ uuid: 'exit-1' }],
+  ...overrides
+});
+
+// builds a flow definition around the given nodes
+const definition = (nodes: any[], overrides: any = {}) => ({
+  uuid: 'flow-1',
+  name: 'Test Flow',
+  language: 'eng',
+  type: 'messaging' as const,
+  revision: 1,
+  spec_version: '14.3',
+  localization: {},
+  nodes,
+  _ui: { nodes: {}, languages: [] },
+  ...overrides
+});
+
+const createTable = async (
+  def: any,
+  { languageCode = '', isTranslating = false } = {}
+): Promise<MessageTable> => {
+  zustand.setState({
+    flowDefinition: def,
+    languageCode,
+    isTranslating
+  } as any);
+  return (await fixture(
+    '<temba-message-table></temba-message-table>'
+  )) as MessageTable;
+};
+
+describe('temba-message-table', () => {
+  const initial = zustand.getState();
+
+  afterEach(() => {
+    zustand.setState({
+      flowDefinition: initial.flowDefinition,
+      languageCode: initial.languageCode,
+      isTranslating: initial.isTranslating
+    } as any);
+  });
+
+  describe('getEntries', () => {
+    it('returns nothing for a flow with no nodes', async () => {
+      const table = await createTable(definition([]));
+      expect((table as any).getEntries()).to.have.length(0);
+    });
+
+    it('includes send_msg actions', async () => {
+      const table = await createTable(
+        definition([node({ actions: [sendMsg()] })])
+      );
+      const entries = (table as any).getEntries();
+      expect(entries).to.have.length(1);
+      expect(entries[0].kind).to.equal('message');
+      expect(entries[0].action.uuid).to.equal('action-1');
+      expect(entries[0].nodeIndex).to.equal(1);
+    });
+
+    it('includes other localizable actions', async () => {
+      const table = await createTable(
+        definition([
+          node({
+            actions: [
+              {
+                uuid: 'action-email',
+                type: 'send_email',
+                subject: 'Hi',
+                body: 'Body'
+              }
+            ]
+          })
+        ])
+      );
+      const entries = (table as any).getEntries();
+      expect(entries).to.have.length(1);
+      expect(entries[0].action.type).to.equal('send_email');
+    });
+
+    it('excludes actions with nothing localizable', async () => {
+      const table = await createTable(
+        definition([
+          node({
+            actions: [
+              { uuid: 'action-name', type: 'set_contact_name', name: 'Bob' }
+            ]
+          })
+        ])
+      );
+      expect((table as any).getEntries()).to.have.length(0);
+    });
+
+    it('numbers nodes in definition order', async () => {
+      const table = await createTable(
+        definition([
+          node({ uuid: 'node-1', actions: [sendMsg({ uuid: 'a1' })] }),
+          node({ uuid: 'node-2', actions: [sendMsg({ uuid: 'a2' })] })
+        ])
+      );
+      const entries = (table as any).getEntries();
+      expect(entries.map((e: any) => e.nodeIndex)).to.deep.equal([1, 2]);
+    });
+
+    it('skips localization groups when not translating', async () => {
+      const def = definition(
+        [
+          node({
+            router: {
+              cases: [
+                { uuid: 'case-1', type: 'has_any_word', arguments: ['red'] }
+              ],
+              categories: [{ uuid: 'cat-1', name: 'Red' }]
+            }
+          })
+        ],
+        {
+          _ui: {
+            nodes: { 'node-1': { type: 'wait_for_response', config: {} } },
+            languages: []
+          }
+        }
+      );
+      const table = await createTable(def, { isTranslating: false });
+      expect((table as any).getEntries()).to.have.length(0);
+    });
+
+    it('includes rules flagged for localization when translating', async () => {
+      const def = definition(
+        [
+          node({
+            router: {
+              cases: [
+                { uuid: 'case-1', type: 'has_any_word', arguments: ['red'] }
+              ],
+              categories: [{ uuid: 'cat-1', name: 'Red' }]
+            }
+          })
+        ],
+        {
+          _ui: {
+            nodes: {
+              'node-1': {
+                type: 'wait_for_response',
+                config: { localizeRules: true }
+              }
+            },
+            languages: []
+          }
+        }
+      );
+      const table = await createTable(def, {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      const entries = (table as any).getEntries();
+      expect(entries).to.have.length(1);
+      expect(entries[0].kind).to.equal('localization-group');
+      expect(entries[0].rules).to.have.length(1);
+      expect(entries[0].rules[0].uuid).to.equal('case-1');
+    });
+
+    it('includes rules that already carry a translation', async () => {
+      const def = definition(
+        [
+          node({
+            router: {
+              cases: [
+                { uuid: 'case-1', type: 'has_any_word', arguments: ['red'] }
+              ],
+              categories: [{ uuid: 'cat-1', name: 'Red' }]
+            }
+          })
+        ],
+        {
+          _ui: {
+            nodes: { 'node-1': { type: 'wait_for_response', config: {} } },
+            languages: []
+          },
+          localization: { [SPANISH]: { 'case-1': { arguments: ['rojo'] } } }
+        }
+      );
+      const table = await createTable(def, {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      const entries = (table as any).getEntries();
+      expect(entries).to.have.length(1);
+      expect(entries[0].rules[0].arguments).to.deep.equal(['red']);
+    });
+
+    it('ignores rules with no arguments', async () => {
+      const def = definition(
+        [
+          node({
+            router: {
+              cases: [{ uuid: 'case-1', type: 'has_text', arguments: [] }],
+              categories: [{ uuid: 'cat-1', name: 'Has Text' }]
+            }
+          })
+        ],
+        {
+          _ui: {
+            nodes: {
+              'node-1': {
+                type: 'wait_for_response',
+                config: { localizeRules: true }
+              }
+            },
+            languages: []
+          }
+        }
+      );
+      const table = await createTable(def, {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      expect((table as any).getEntries()).to.have.length(0);
+    });
+  });
+
+  describe('getTranslatedText', () => {
+    it('returns null when not translating', async () => {
+      const table = await createTable(
+        definition([node({ actions: [sendMsg()] })], {
+          localization: { [SPANISH]: { 'action-1': { text: ['Hola'] } } }
+        })
+      );
+      expect((table as any).getTranslatedText('action-1')).to.equal(null);
+    });
+
+    it('returns the first localized string when translating', async () => {
+      const table = await createTable(
+        definition([node({ actions: [sendMsg()] })], {
+          localization: { [SPANISH]: { 'action-1': { text: ['Hola'] } } }
+        }),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      expect((table as any).getTranslatedText('action-1')).to.equal('Hola');
+    });
+
+    it('returns null when the action has no translation', async () => {
+      const table = await createTable(
+        definition([node({ actions: [sendMsg()] })]),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      expect((table as any).getTranslatedText('action-1')).to.equal(null);
+    });
+
+    it('treats an empty translation as absent', async () => {
+      const table = await createTable(
+        definition([node({ actions: [sendMsg()] })], {
+          localization: { [SPANISH]: { 'action-1': { text: [''] } } }
+        }),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      expect((table as any).getTranslatedText('action-1')).to.equal(null);
+    });
+  });
+
+  describe('getTranslatedQuickReplies', () => {
+    const withReplies = (replies: any) =>
+      definition([node({ actions: [sendMsg()] })], {
+        localization: { [SPANISH]: { 'action-1': { quick_replies: replies } } }
+      });
+
+    it('returns an empty list when not translating', async () => {
+      const table = await createTable(withReplies(['Si']));
+      expect((table as any).getTranslatedQuickReplies('action-1')).to.deep.equal(
+        []
+      );
+    });
+
+    it('returns the localized replies', async () => {
+      const table = await createTable(withReplies(['Si', 'No']), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      expect((table as any).getTranslatedQuickReplies('action-1')).to.deep.equal(
+        ['Si', 'No']
+      );
+    });
+
+    it('trims and drops blank replies', async () => {
+      const table = await createTable(withReplies(['  Si  ', '', '   ']), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      expect((table as any).getTranslatedQuickReplies('action-1')).to.deep.equal(
+        ['Si']
+      );
+    });
+
+    it('ignores non string entries', async () => {
+      const table = await createTable(withReplies(['Si', 3, null]), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      expect((table as any).getTranslatedQuickReplies('action-1')).to.deep.equal(
+        ['Si']
+      );
+    });
+
+    it('returns an empty list when the field is not an array', async () => {
+      const table = await createTable(withReplies('Si'), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      expect((table as any).getTranslatedQuickReplies('action-1')).to.deep.equal(
+        []
+      );
+    });
+  });
+
+  describe('getTranslatedCategoryName', () => {
+    const withCategory = (name: any) =>
+      definition([node()], {
+        localization: { [SPANISH]: { 'cat-1': { name } } }
+      });
+
+    it('returns null when not translating', async () => {
+      const table = await createTable(withCategory(['Rojo']));
+      expect((table as any).getTranslatedCategoryName('cat-1')).to.equal(null);
+    });
+
+    it('reads the first entry of an array name', async () => {
+      const table = await createTable(withCategory(['Rojo']), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      expect((table as any).getTranslatedCategoryName('cat-1')).to.equal(
+        'Rojo'
+      );
+    });
+
+    it('reads a plain string name', async () => {
+      const table = await createTable(withCategory('Rojo'), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      expect((table as any).getTranslatedCategoryName('cat-1')).to.equal(
+        'Rojo'
+      );
+    });
+
+    it('returns null for a missing or empty name', async () => {
+      const table = await createTable(withCategory(['']), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      expect((table as any).getTranslatedCategoryName('cat-1')).to.equal(null);
+
+      const missing = await createTable(definition([node()]), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      expect((missing as any).getTranslatedCategoryName('cat-1')).to.equal(null);
+    });
+  });
+
+  describe('getTranslatedField and getTranslatedArrayField', () => {
+    const withEmail = (localization: any = {}) =>
+      definition(
+        [
+          node({
+            actions: [
+              {
+                uuid: 'action-email',
+                type: 'send_email',
+                subject: 'Hi',
+                body: 'Body'
+              }
+            ]
+          })
+        ],
+        { localization }
+      );
+
+    it('returns the first entry of a localized field', async () => {
+      const table = await createTable(
+        withEmail({ [SPANISH]: { 'action-email': { subject: ['Hola'] } } }),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      expect((table as any).getTranslatedField('action-email', 'subject')).to.equal(
+        'Hola'
+      );
+    });
+
+    it('returns null when not translating', async () => {
+      const table = await createTable(
+        withEmail({ [SPANISH]: { 'action-email': { subject: ['Hola'] } } })
+      );
+      expect((table as any).getTranslatedField('action-email', 'subject')).to.equal(
+        null
+      );
+    });
+
+    it('returns the whole array for an array field', async () => {
+      const table = await createTable(
+        withEmail({
+          [SPANISH]: { 'action-email': { attachments: ['image/jpeg:a.jpg'] } }
+        }),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      expect(
+        (table as any).getTranslatedArrayField('action-email', 'attachments')
+      ).to.deep.equal(['image/jpeg:a.jpg']);
+    });
+
+    it('returns an empty array when the field is missing', async () => {
+      const table = await createTable(withEmail(), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      expect(
+        (table as any).getTranslatedArrayField('action-email', 'attachments')
+      ).to.deep.equal([]);
+    });
+  });
+
+  describe('hasAnyTranslation', () => {
+    const entryFor = (action: any) => ({
+      kind: 'message',
+      node: node(),
+      action,
+      nodeIndex: 1
+    });
+
+    it('is false when there is no localization for the action', async () => {
+      const table = await createTable(
+        definition([node({ actions: [sendMsg()] })]),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      expect((table as any).hasAnyTranslation(entryFor(sendMsg()))).to.equal(
+        false
+      );
+    });
+
+    it('is true when a localizable field holds text', async () => {
+      const table = await createTable(
+        definition([node({ actions: [sendMsg()] })], {
+          localization: { [SPANISH]: { 'action-1': { text: ['Hola'] } } }
+        }),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      expect((table as any).hasAnyTranslation(entryFor(sendMsg()))).to.equal(
+        true
+      );
+    });
+
+    it('is false when the localized values are all blank', async () => {
+      const table = await createTable(
+        definition([node({ actions: [sendMsg()] })], {
+          localization: { [SPANISH]: { 'action-1': { text: ['  '] } } }
+        }),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      expect((table as any).hasAnyTranslation(entryFor(sendMsg()))).to.equal(
+        false
+      );
+    });
+
+    it('is false for an action type with nothing localizable', async () => {
+      const table = await createTable(definition([node()]), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      expect(
+        (table as any).hasAnyTranslation(
+          entryFor({ uuid: 'a', type: 'set_contact_name' })
+        )
+      ).to.equal(false);
+    });
+  });
+
+  describe('usesPairedRows and getPairedFields', () => {
+    it('pairs rows for actions with more than one text field', async () => {
+      const table = await createTable(definition([node()]));
+      expect(
+        (table as any).usesPairedRows({ type: 'send_email' })
+      ).to.equal(true);
+    });
+
+    it('does not pair rows for a single text field action', async () => {
+      const table = await createTable(definition([node()]));
+      expect((table as any).usesPairedRows({ type: 'send_msg' })).to.equal(
+        false
+      );
+    });
+
+    it('does not pair rows for actions with nothing localizable', async () => {
+      const table = await createTable(definition([node()]));
+      expect(
+        (table as any).usesPairedRows({ type: 'set_contact_name' })
+      ).to.equal(false);
+    });
+
+    it('returns each paired field with its label and original text', async () => {
+      const table = await createTable(definition([node()]), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      const fields = (table as any).getPairedFields({
+        uuid: 'action-email',
+        type: 'send_email',
+        subject: 'Hi',
+        body: 'Body text'
+      });
+      expect(fields.map((f: any) => f.key)).to.deep.equal(['subject', 'body']);
+      expect(fields[0].original).to.equal('Hi');
+      expect(fields[1].original).to.equal('Body text');
+      expect(fields[0].translated).to.equal(null);
+    });
+
+    it('carries the translation through for paired fields', async () => {
+      const table = await createTable(
+        definition([node()], {
+          localization: { [SPANISH]: { 'action-email': { subject: ['Hola'] } } }
+        }),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      const fields = (table as any).getPairedFields({
+        uuid: 'action-email',
+        type: 'send_email',
+        subject: 'Hi',
+        body: 'Body text'
+      });
+      expect(fields[0].translated).to.equal('Hola');
+      expect(fields[1].translated).to.equal(null);
+    });
+
+    it('returns nothing for an action with no form config', async () => {
+      const table = await createTable(definition([node()]));
+      expect(
+        (table as any).getPairedFields({ uuid: 'a', type: 'set_contact_name' })
+      ).to.deep.equal([]);
+    });
+  });
+
+  describe('stripLeadingLineBreaks', () => {
+    it('removes leading newlines only', async () => {
+      const table = await createTable(definition([node()]));
+      const strip = (text: string) => (table as any).stripLeadingLineBreaks(text);
+      expect(strip('\n\nhello')).to.equal('hello');
+      expect(strip('\r\nhello')).to.equal('hello');
+      expect(strip('hello\n\n')).to.equal('hello\n\n');
+      expect(strip('hello')).to.equal('hello');
+      expect(strip('')).to.equal('');
+    });
+  });
+
+  describe('getGroupTranslations', () => {
+    it('pairs each rule with its localized arguments', async () => {
+      const table = await createTable(
+        definition([node()], {
+          localization: { [SPANISH]: { 'case-1': { arguments: ['rojo'] } } }
+        }),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      const items = (table as any).getGroupTranslations({
+        kind: 'localization-group',
+        node: node(),
+        rules: [{ uuid: 'case-1', type: 'has_any_word', arguments: ['red'] }],
+        categories: [],
+        nodeIndex: 1
+      });
+      expect(items).to.have.length(1);
+      expect(items[0].original).to.equal('red');
+      expect(items[0].translated).to.equal('rojo');
+      expect(items[0].isRule).to.equal(true);
+      expect(items[0].operatorName).to.equal('has any of the words');
+    });
+
+    it('joins multiple arguments with commas', async () => {
+      const table = await createTable(
+        definition([node()], {
+          localization: {
+            [SPANISH]: { 'case-1': { arguments: ['rojo', 'carmesi'] } }
+          }
+        }),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      const items = (table as any).getGroupTranslations({
+        kind: 'localization-group',
+        node: node(),
+        rules: [
+          { uuid: 'case-1', type: 'has_any_word', arguments: ['red', 'crimson'] }
+        ],
+        categories: [],
+        nodeIndex: 1
+      });
+      expect(items[0].original).to.equal('red, crimson');
+      expect(items[0].translated).to.equal('rojo, carmesi');
+    });
+
+    it('falls back to the raw type for an unknown operator', async () => {
+      const table = await createTable(definition([node()]), {
+        languageCode: SPANISH,
+        isTranslating: true
+      });
+      const items = (table as any).getGroupTranslations({
+        kind: 'localization-group',
+        node: node(),
+        rules: [{ uuid: 'case-1', type: 'has_nonsense', arguments: ['x'] }],
+        categories: [],
+        nodeIndex: 1
+      });
+      expect(items[0].operatorName).to.equal('has_nonsense');
+      expect(items[0].translated).to.equal(null);
+    });
+
+    it('appends categories after the rules', async () => {
+      const table = await createTable(
+        definition([node()], {
+          localization: { [SPANISH]: { 'cat-1': { name: ['Rojo'] } } }
+        }),
+        { languageCode: SPANISH, isTranslating: true }
+      );
+      const items = (table as any).getGroupTranslations({
+        kind: 'localization-group',
+        node: node(),
+        rules: [{ uuid: 'case-1', type: 'has_any_word', arguments: ['red'] }],
+        categories: [{ uuid: 'cat-1', name: 'Red' }],
+        nodeIndex: 1
+      });
+      expect(items).to.have.length(2);
+      expect(items[1].isRule).to.equal(false);
+      expect(items[1].original).to.equal('Red');
+      expect(items[1].translated).to.equal('Rojo');
+    });
+  });
+
+  describe('getEntryRailColor', () => {
+    it('uses the action group colour for a message entry', async () => {
+      const table = await createTable(definition([node()]));
+      const color = (table as any).getEntryRailColor({
+        kind: 'message',
+        node: node(),
+        action: sendMsg(),
+        nodeIndex: 1
+      });
+      expect(color).to.equal('#3498db');
+    });
+
+    it('falls back to a neutral colour for an unknown action type', async () => {
+      const table = await createTable(definition([node()]));
+      const color = (table as any).getEntryRailColor({
+        kind: 'message',
+        node: node(),
+        action: { uuid: 'a', type: 'has_nonsense' },
+        nodeIndex: 1
+      });
+      expect(color).to.equal('#cbd5e1');
+    });
+
+    it('falls back to a neutral colour when the node has no ui type', async () => {
+      const table = await createTable(definition([node()]));
+      const color = (table as any).getEntryRailColor({
+        kind: 'localization-group',
+        node: node(),
+        rules: [],
+        categories: [],
+        nodeIndex: 1
+      });
+      expect(color).to.equal('#cbd5e1');
+    });
+
+    it('uses the node group colour for a localization group', async () => {
+      const table = await createTable(
+        definition([node()], {
+          _ui: {
+            nodes: { 'node-1': { type: 'wait_for_response' } },
+            languages: []
+          }
+        })
+      );
+      const color = (table as any).getEntryRailColor({
+        kind: 'localization-group',
+        node: node(),
+        rules: [],
+        categories: [],
+        nodeIndex: 1
+      });
+      expect(color).to.be.a('string');
+      expect(color.startsWith('#')).to.equal(true);
+    });
+  });
+
+  describe('edit requests', () => {
+    it('fires an action edit request forcing the base language', async () => {
+      const table = await createTable(
+        definition([node({ actions: [sendMsg()] })])
+      );
+      const events: any[] = [];
+      table.addEventListener(CustomEventType.ActionEditRequested, (e: any) =>
+        events.push(e.detail)
+      );
+      (table as any).handleBaseTextClick({
+        kind: 'message',
+        node: node(),
+        action: sendMsg(),
+        nodeIndex: 1
+      });
+      expect(events).to.have.length(1);
+      expect(events[0].forceBase).to.equal(true);
+      expect(events[0].nodeUuid).to.equal('node-1');
+      expect(events[0].action.uuid).to.equal('action-1');
+    });
+
+    it('fires an action edit request for the translation', async () => {
+      const table = await createTable(
+        definition([node({ actions: [sendMsg()] })])
+      );
+      const events: any[] = [];
+      table.addEventListener(CustomEventType.ActionEditRequested, (e: any) =>
+        events.push(e.detail)
+      );
+      (table as any).handleTranslationClick({
+        kind: 'message',
+        node: node(),
+        action: sendMsg(),
+        nodeIndex: 1
+      });
+      expect(events).to.have.length(1);
+      expect(events[0].forceBase).to.equal(undefined);
+    });
+
+    it('fires a node edit request for a localization group', async () => {
+      const table = await createTable(
+        definition([node()], {
+          _ui: {
+            nodes: { 'node-1': { type: 'wait_for_response' } },
+            languages: []
+          }
+        })
+      );
+      const events: any[] = [];
+      table.addEventListener(CustomEventType.NodeEditRequested, (e: any) =>
+        events.push(e.detail)
+      );
+      const entry = {
+        kind: 'localization-group',
+        node: node(),
+        rules: [],
+        categories: [],
+        nodeIndex: 1
+      };
+      (table as any).handleBaseGroupClick(entry);
+      (table as any).handleGroupTranslationClick(entry);
+      expect(events).to.have.length(2);
+      expect(events[0].forceBase).to.equal(true);
+      expect(events[1].forceBase).to.equal(undefined);
+    });
+
+    it('does not fire a node edit request when the node has no ui', async () => {
+      const table = await createTable(definition([node()]));
+      const events: any[] = [];
+      table.addEventListener(CustomEventType.NodeEditRequested, (e: any) =>
+        events.push(e.detail)
+      );
+      (table as any).handleBaseGroupClick({
+        kind: 'localization-group',
+        node: node(),
+        rules: [],
+        categories: [],
+        nodeIndex: 1
+      });
+      expect(events).to.have.length(0);
+    });
+  });
+
+  describe('focusSearchResult', () => {
+    it('does nothing when there are no rows', async () => {
+      const table = await createTable(definition([]));
+      await table.updateComplete;
+      // no throw is the assertion here
+      table.focusSearchResult('node-1', 'action-1');
+    });
+
+    it('scrolls the matching action row into view', async () => {
+      const table = await createTable(
+        definition([node({ actions: [sendMsg()] })])
+      );
+      await table.updateComplete;
+      const row = table.renderRoot.querySelector(
+        'tr[data-node-uuid="node-1"]'
+      ) as HTMLElement;
+      expect(row).to.not.equal(null);
+
+      let scrolled = false;
+      row.scrollIntoView = () => {
+        scrolled = true;
+      };
+      table.focusSearchResult('node-1', 'action-1');
+      expect(scrolled).to.equal(true);
+    });
+  });
+});

--- a/test/temba-node-editor-fields.test.ts
+++ b/test/temba-node-editor-fields.test.ts
@@ -181,9 +181,7 @@ describe('temba-node-editor fields', () => {
       };
       (editor as any).updateComputedFields('method');
 
-      expect(JSON.stringify(formData(editor).headers)).to.not.equal(
-        undefined
-      );
+      expect(JSON.stringify(formData(editor).headers)).to.not.equal(undefined);
       // the default headers follow the selected method
       expect(before).to.be.a('string');
     });

--- a/test/temba-node-editor-fields.test.ts
+++ b/test/temba-node-editor-fields.test.ts
@@ -171,19 +171,64 @@ describe('temba-node-editor fields', () => {
       return editor;
     };
 
+    // headers come back as {key, value} or {name, value} depending on the widget
+    const headerPairs = (editor: NodeEditor) =>
+      (formData(editor).headers || []).map((h: any) => ({
+        key: h.key ?? h.name,
+        value: h.value
+      }));
+
+    const setFormData = (editor: NodeEditor, values: any) => {
+      (editor as any).formData = { ...formData(editor), ...values };
+    };
+
     it('recomputes dependent fields when the method changes', async () => {
       const editor = await createWebhookEditor();
-      const before = JSON.stringify(formData(editor).headers);
 
-      (editor as any).formData = {
-        ...formData(editor),
-        method: [{ value: 'POST', name: 'POST' }]
-      };
+      // start on the GET defaults, which are eligible to be replaced
+      setFormData(editor, {
+        method: [{ value: 'GET', name: 'GET' }],
+        headers: [{ key: 'Accept', value: 'application/json' }]
+      });
+
+      setFormData(editor, { method: [{ value: 'POST', name: 'POST' }] });
       (editor as any).updateComputedFields('method');
 
-      expect(JSON.stringify(formData(editor).headers)).to.not.equal(undefined);
-      // the default headers follow the selected method
-      expect(before).to.be.a('string');
+      // POST additionally sends a Content-Type
+      expect(headerPairs(editor)).to.deep.equal([
+        { key: 'Accept', value: 'application/json' },
+        { key: 'Content-Type', value: 'application/json' }
+      ]);
+    });
+
+    it('drops back to the GET defaults when the method changes back', async () => {
+      const editor = await createWebhookEditor();
+
+      setFormData(editor, {
+        method: [{ value: 'GET', name: 'GET' }],
+        headers: [
+          { key: 'Accept', value: 'application/json' },
+          { key: 'Content-Type', value: 'application/json' }
+        ]
+      });
+      (editor as any).updateComputedFields('method');
+
+      expect(headerPairs(editor)).to.deep.equal([
+        { key: 'Accept', value: 'application/json' }
+      ]);
+    });
+
+    it('leaves headers the user has customized alone', async () => {
+      const editor = await createWebhookEditor();
+      const custom = [{ key: 'X-Api-Key', value: 'secret' }];
+
+      setFormData(editor, {
+        method: [{ value: 'POST', name: 'POST' }],
+        headers: custom
+      });
+      (editor as any).updateComputedFields('method');
+
+      expect(headerPairs(editor)).to.deep.equal(custom);
     });
 
     it('leaves fields alone when nothing depends on the change', async () => {

--- a/test/temba-node-editor-fields.test.ts
+++ b/test/temba-node-editor-fields.test.ts
@@ -1,0 +1,254 @@
+import '../temba-modules';
+import { fixture, expect } from '@open-wc/testing';
+import { NodeEditor } from '../src/flow/NodeEditor';
+
+const createEditor = async (action?: any): Promise<NodeEditor> => {
+  const editor = (await fixture(
+    '<temba-node-editor></temba-node-editor>'
+  )) as NodeEditor;
+  if (action) {
+    editor.action = action;
+    await editor.updateComplete;
+  }
+  return editor;
+};
+
+// a fake widget event carrying whatever shape the field component exposes
+const fieldEvent = (target: any): Event => {
+  const event = new Event('change');
+  Object.defineProperty(event, 'target', { value: target });
+  return event;
+};
+
+const formData = (editor: NodeEditor) => (editor as any).formData;
+
+describe('temba-node-editor fields', () => {
+  describe('group collapse state', () => {
+    it('toggles a group open and closed', async () => {
+      const editor = await createEditor();
+      const toggle = (label: string) =>
+        (editor as any).handleGroupToggle(label);
+
+      toggle('Advanced');
+      expect((editor as any).groupCollapseState['Advanced']).to.equal(true);
+
+      toggle('Advanced');
+      expect((editor as any).groupCollapseState['Advanced']).to.equal(false);
+    });
+
+    it('tracks groups independently', async () => {
+      const editor = await createEditor();
+      (editor as any).handleGroupToggle('Advanced');
+      (editor as any).handleGroupToggle('Other');
+      (editor as any).handleGroupToggle('Other');
+
+      expect((editor as any).groupCollapseState['Advanced']).to.equal(true);
+      expect((editor as any).groupCollapseState['Other']).to.equal(false);
+    });
+  });
+
+  describe('group hover state', () => {
+    it('records entering and leaving a group', async () => {
+      const editor = await createEditor();
+      (editor as any).handleGroupMouseEnter('Advanced');
+      expect((editor as any).groupHoverState['Advanced']).to.equal(true);
+
+      (editor as any).handleGroupMouseLeave('Advanced');
+      expect((editor as any).groupHoverState['Advanced']).to.equal(false);
+    });
+
+    it('keeps hover state per group', async () => {
+      const editor = await createEditor();
+      (editor as any).handleGroupMouseEnter('One');
+      (editor as any).handleGroupMouseEnter('Two');
+      (editor as any).handleGroupMouseLeave('One');
+
+      expect((editor as any).groupHoverState['One']).to.equal(false);
+      expect((editor as any).groupHoverState['Two']).to.equal(true);
+    });
+  });
+
+  describe('revealOptionalField', () => {
+    it('reveals a field', async () => {
+      const editor = await createEditor();
+      (editor as any).revealOptionalField('all_urns');
+      expect((editor as any).revealedOptionalFields.has('all_urns')).to.equal(
+        true
+      );
+    });
+
+    it('accumulates revealed fields', async () => {
+      const editor = await createEditor();
+      (editor as any).revealOptionalField('one');
+      (editor as any).revealOptionalField('two');
+      const revealed = (editor as any).revealedOptionalFields;
+      expect(revealed.has('one')).to.equal(true);
+      expect(revealed.has('two')).to.equal(true);
+    });
+
+    it('is idempotent', async () => {
+      const editor = await createEditor();
+      (editor as any).revealOptionalField('one');
+      (editor as any).revealOptionalField('one');
+      expect((editor as any).revealedOptionalFields.size).to.equal(1);
+    });
+  });
+
+  describe('handleFormFieldChange', () => {
+    const sendMsg = () => ({
+      uuid: 'action-1',
+      type: 'send_msg',
+      text: 'Hello'
+    });
+
+    it('reads a plain input value', async () => {
+      const editor = await createEditor(sendMsg());
+      (editor as any).handleFormFieldChange(
+        'text',
+        fieldEvent({ tagName: 'TEMBA-TEXTINPUT', value: 'Updated' })
+      );
+      expect(formData(editor).text).to.equal('Updated');
+    });
+
+    it('reads a checkbox as a boolean', async () => {
+      const editor = await createEditor(sendMsg());
+      (editor as any).handleFormFieldChange(
+        'all_urns',
+        fieldEvent({ tagName: 'TEMBA-CHECKBOX', checked: true, value: 'on' })
+      );
+      expect(formData(editor).all_urns).to.equal(true);
+    });
+
+    it('prefers the values collection of a multi widget', async () => {
+      const editor = await createEditor(sendMsg());
+      const values = [{ value: 'a' }, { value: 'b' }];
+      (editor as any).handleFormFieldChange(
+        'quick_replies',
+        fieldEvent({ tagName: 'TEMBA-SELECT', values, value: 'ignored' })
+      );
+      expect(formData(editor).quick_replies).to.equal(values);
+    });
+
+    it('clears an existing error for the field', async () => {
+      const editor = await createEditor(sendMsg());
+      (editor as any).errors = { text: 'Required', other: 'Still broken' };
+      (editor as any).handleFormFieldChange(
+        'text',
+        fieldEvent({ tagName: 'TEMBA-TEXTINPUT', value: 'Updated' })
+      );
+      expect((editor as any).errors.text).to.equal(undefined);
+      // unrelated errors survive
+      expect((editor as any).errors.other).to.equal('Still broken');
+    });
+
+    it('leaves other form values untouched', async () => {
+      const editor = await createEditor(sendMsg());
+      (editor as any).formData = { text: 'Hello', result_name: 'Colour' };
+      (editor as any).handleFormFieldChange(
+        'text',
+        fieldEvent({ tagName: 'TEMBA-TEXTINPUT', value: 'Updated' })
+      );
+      expect(formData(editor).result_name).to.equal('Colour');
+    });
+  });
+
+  describe('updateComputedFields', () => {
+    // split_by_webhook recomputes headers and body when the method changes
+    const webhookNode = () => ({
+      uuid: 'node-1',
+      actions: [],
+      exits: [],
+      router: { type: 'switch', categories: [] }
+    });
+
+    const createWebhookEditor = async (): Promise<NodeEditor> => {
+      const editor = (await fixture(
+        '<temba-node-editor></temba-node-editor>'
+      )) as NodeEditor;
+      editor.node = webhookNode() as any;
+      editor.nodeUI = { type: 'split_by_webhook' } as any;
+      await editor.updateComplete;
+      return editor;
+    };
+
+    it('recomputes dependent fields when the method changes', async () => {
+      const editor = await createWebhookEditor();
+      const before = JSON.stringify(formData(editor).headers);
+
+      (editor as any).formData = {
+        ...formData(editor),
+        method: [{ value: 'POST', name: 'POST' }]
+      };
+      (editor as any).updateComputedFields('method');
+
+      expect(JSON.stringify(formData(editor).headers)).to.not.equal(
+        undefined
+      );
+      // the default headers follow the selected method
+      expect(before).to.be.a('string');
+    });
+
+    it('leaves fields alone when nothing depends on the change', async () => {
+      const editor = await createWebhookEditor();
+      const before = JSON.stringify(formData(editor));
+      (editor as any).updateComputedFields('result_name');
+      expect(JSON.stringify(formData(editor))).to.equal(before);
+    });
+
+    it('does nothing without a config', async () => {
+      const editor = await createEditor();
+      // no throw is the assertion here
+      (editor as any).updateComputedFields('anything');
+    });
+  });
+
+  describe('expandGroupsWithErrors', () => {
+    // send_broadcast puts its template field in a collapsed accordion section
+    const createBroadcastEditor = async (): Promise<NodeEditor> => {
+      const editor = (await fixture(
+        '<temba-node-editor></temba-node-editor>'
+      )) as NodeEditor;
+      editor.action = {
+        uuid: 'action-1',
+        type: 'send_broadcast',
+        text: 'Hello'
+      } as any;
+      await editor.updateComplete;
+      return editor;
+    };
+
+    it('expands the accordion section holding the failing field', async () => {
+      const editor = await createBroadcastEditor();
+      (editor as any).expandGroupsWithErrors({ template: 'Required' });
+      expect(
+        (editor as any).groupCollapseState['accordion:WhatsApp Template']
+      ).to.equal(false);
+    });
+
+    it('leaves sections collapsed when their fields are fine', async () => {
+      const editor = await createBroadcastEditor();
+      // the section starts collapsed and an unrelated error does not open it
+      expect(
+        (editor as any).groupCollapseState['accordion:WhatsApp Template']
+      ).to.equal(true);
+
+      (editor as any).expandGroupsWithErrors({ text: 'Required' });
+      expect(
+        (editor as any).groupCollapseState['accordion:WhatsApp Template']
+      ).to.equal(true);
+    });
+
+    it('does nothing when there are no errors', async () => {
+      const editor = await createBroadcastEditor();
+      const before = { ...(editor as any).groupCollapseState };
+      (editor as any).expandGroupsWithErrors({});
+      expect((editor as any).groupCollapseState).to.deep.equal(before);
+    });
+
+    it('does nothing for a config with no layout', async () => {
+      const editor = await createEditor();
+      // no throw is the assertion here
+      (editor as any).expandGroupsWithErrors({ anything: 'Required' });
+    });
+  });
+});

--- a/test/temba-shortcuts.test.ts
+++ b/test/temba-shortcuts.test.ts
@@ -26,9 +26,7 @@ describe('temba-shortcuts', () => {
     (store as any).shortcuts = SHORTCUTS;
   });
 
-  const createList = async (
-    attrs = ''
-  ): Promise<ShortcutList> => {
+  const createList = async (attrs = ''): Promise<ShortcutList> => {
     const list = (await fixture(
       `<temba-shortcuts ${attrs}></temba-shortcuts>`
     )) as ShortcutList;
@@ -95,9 +93,9 @@ describe('temba-shortcuts', () => {
       await list.updateComplete;
       const message = list.shadowRoot.querySelector('.no-match');
       expect(message.textContent).to.contain('No matches for');
-      expect(
-        list.shadowRoot.querySelector('.filter').textContent
-      ).to.contain('nonsense');
+      expect(list.shadowRoot.querySelector('.filter').textContent).to.contain(
+        'nonsense'
+      );
     });
 
     it('resets the cursor when the filter changes', async () => {

--- a/test/temba-shortcuts.test.ts
+++ b/test/temba-shortcuts.test.ts
@@ -1,0 +1,229 @@
+import '../temba-modules';
+import { fixture, expect } from '@open-wc/testing';
+import { ShortcutList } from '../src/list/ShortcutList';
+import { Store } from '../src/store/Store';
+import { CustomEventType, Shortcut } from '../src/interfaces';
+import { loadStore } from './utils.test';
+
+const shortcut = (name: string, text: string): Shortcut => ({
+  uuid: `uuid-${name.toLowerCase().replace(/\s/g, '-')}`,
+  name,
+  text,
+  modified_on: '2024-01-01T00:00:00Z'
+});
+
+const SHORTCUTS = [
+  shortcut('Greeting', 'Hello and welcome!'),
+  shortcut('Goodbye', 'Thanks for chatting'),
+  shortcut('Hours', 'We are open 9 to 5')
+];
+
+describe('temba-shortcuts', () => {
+  let store: Store;
+
+  beforeEach(async () => {
+    store = await loadStore();
+    (store as any).shortcuts = SHORTCUTS;
+  });
+
+  const createList = async (
+    attrs = ''
+  ): Promise<ShortcutList> => {
+    const list = (await fixture(
+      `<temba-shortcuts ${attrs}></temba-shortcuts>`
+    )) as ShortcutList;
+    list.storeUpdated();
+    await list.updateComplete;
+    return list;
+  };
+
+  describe('loading', () => {
+    it('takes its shortcuts from the store', async () => {
+      const list = await createList();
+      expect(list.filteredShortcuts).to.have.length(3);
+      expect(list.filteredShortcuts[0].name).to.equal('Greeting');
+    });
+
+    it('shows an empty state when there are no shortcuts', async () => {
+      (store as any).shortcuts = [];
+      const list = await createList();
+      const message = list.shadowRoot.querySelector('.no-match');
+      expect(message).to.not.equal(null);
+      expect(message.textContent).to.contain('No shortcuts yet');
+    });
+  });
+
+  describe('filtering', () => {
+    it('narrows the list to matching names', async () => {
+      const list = await createList();
+      list.filter = 'good';
+      await list.updateComplete;
+      expect(list.filteredShortcuts).to.have.length(1);
+      expect(list.filteredShortcuts[0].name).to.equal('Goodbye');
+    });
+
+    it('matches case insensitively', async () => {
+      const list = await createList();
+      list.filter = 'HOURS';
+      await list.updateComplete;
+      expect(list.filteredShortcuts).to.have.length(1);
+      expect(list.filteredShortcuts[0].name).to.equal('Hours');
+    });
+
+    it('matches on the name rather than the body text', async () => {
+      const list = await createList();
+      list.filter = 'welcome';
+      await list.updateComplete;
+      expect(list.filteredShortcuts).to.have.length(0);
+    });
+
+    it('restores the full list when the filter is cleared', async () => {
+      const list = await createList();
+      list.filter = 'good';
+      await list.updateComplete;
+      list.filter = '';
+      await list.updateComplete;
+      expect(list.filteredShortcuts).to.have.length(3);
+    });
+
+    it('reports no matches for an unmatched filter', async () => {
+      const list = await createList();
+      list.filter = 'nonsense';
+      // filteredShortcuts is recomputed in updated(), so the empty state
+      // only reaches the DOM on the following render
+      await list.updateComplete;
+      await list.updateComplete;
+      const message = list.shadowRoot.querySelector('.no-match');
+      expect(message.textContent).to.contain('No matches for');
+      expect(
+        list.shadowRoot.querySelector('.filter').textContent
+      ).to.contain('nonsense');
+    });
+
+    it('resets the cursor when the filter changes', async () => {
+      const list = await createList();
+      list.cursorIndex = 2;
+      list.filter = 'o';
+      await list.updateComplete;
+      expect(list.cursorIndex).to.equal(0);
+    });
+  });
+
+  describe('search box', () => {
+    it('is hidden by default', async () => {
+      const list = await createList();
+      expect(list.shadowRoot.querySelector('.search-box')).to.equal(null);
+    });
+
+    it('is shown when requested', async () => {
+      const list = await createList('showSearch');
+      expect(list.shadowRoot.querySelector('.search-box')).to.not.equal(null);
+    });
+
+    it('filters as the user types', async () => {
+      const list = await createList('showSearch');
+      const input = list.shadowRoot.querySelector(
+        '.search-box input'
+      ) as HTMLInputElement;
+      input.value = 'hours';
+      input.dispatchEvent(new Event('input'));
+      await list.updateComplete;
+      expect(list.filteredShortcuts).to.have.length(1);
+      expect(list.filteredShortcuts[0].name).to.equal('Hours');
+    });
+
+    it('focuses the input on request', async () => {
+      const list = await createList('showSearch');
+      const input = list.shadowRoot.querySelector(
+        '.search-box input'
+      ) as HTMLInputElement;
+      list.focusSearch();
+      expect(list.shadowRoot.activeElement).to.equal(input);
+    });
+
+    it('does nothing when focusing with no search box', async () => {
+      const list = await createList();
+      // no throw is the assertion here
+      list.focusSearch();
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    const press = async (list: ShortcutList, key: string) => {
+      const input = list.shadowRoot.querySelector(
+        '.search-box input'
+      ) as HTMLInputElement;
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+      );
+      await list.updateComplete;
+    };
+
+    it('moves the cursor down and stops at the end', async () => {
+      const list = await createList('showSearch');
+      await press(list, 'ArrowDown');
+      expect(list.cursorIndex).to.equal(1);
+      await press(list, 'ArrowDown');
+      expect(list.cursorIndex).to.equal(2);
+      await press(list, 'ArrowDown');
+      expect(list.cursorIndex).to.equal(2);
+    });
+
+    it('moves the cursor up and stops at the start', async () => {
+      const list = await createList('showSearch');
+      list.cursorIndex = 1;
+      await press(list, 'ArrowUp');
+      expect(list.cursorIndex).to.equal(0);
+      await press(list, 'ArrowUp');
+      expect(list.cursorIndex).to.equal(0);
+    });
+
+    it('fires a selection on enter', async () => {
+      const list = await createList('showSearch');
+      list.cursorIndex = 1;
+      const selections: any[] = [];
+      list.addEventListener(CustomEventType.Selection, (e: any) =>
+        selections.push(e.detail.selected)
+      );
+      await press(list, 'Enter');
+      expect(selections).to.have.length(1);
+      expect(selections[0].name).to.equal('Goodbye');
+    });
+
+    it('fires nothing on enter with an empty list', async () => {
+      (store as any).shortcuts = [];
+      const list = await createList('showSearch');
+      const selections: any[] = [];
+      list.addEventListener(CustomEventType.Selection, (e: any) =>
+        selections.push(e.detail.selected)
+      );
+      await press(list, 'Enter');
+      expect(selections).to.have.length(0);
+    });
+
+    it('ignores other keys', async () => {
+      const list = await createList('showSearch');
+      await press(list, 'Escape');
+      expect(list.cursorIndex).to.equal(0);
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders the name and body of a shortcut', async () => {
+      const list = await createList();
+      const rendered = list.renderShortcut(SHORTCUTS[0]);
+      const host = (await fixture('<div></div>')) as HTMLElement;
+      const { render } = await import('lit-html');
+      render(rendered, host);
+      expect(host.textContent).to.contain('Greeting');
+      expect(host.textContent).to.contain('Hello and welcome!');
+    });
+
+    it('returns the shortcut under the cursor', async () => {
+      const list = await createList();
+      list.cursorIndex = 2;
+      await list.updateComplete;
+      expect(list.getShortcut().name).to.equal('Hours');
+    });
+  });
+});

--- a/test/temba-start-progress.test.ts
+++ b/test/temba-start-progress.test.ts
@@ -75,9 +75,7 @@ describe('temba-start-progress', () => {
 
     for (const status of ['Completed', 'Failed', 'Interrupted']) {
       it(`treats ${status} as complete`, async () => {
-        mockStatus([
-          start({ status, progress: { current: 100, total: 100 } })
-        ]);
+        mockStatus([start({ status, progress: { current: 100, total: 100 } })]);
         const progress = await createProgress();
         expect(progress.complete).to.equal(true);
         expect(progress.running).to.equal(false);

--- a/test/temba-start-progress.test.ts
+++ b/test/temba-start-progress.test.ts
@@ -1,0 +1,231 @@
+import '../temba-modules';
+import { fixture, expect } from '@open-wc/testing';
+import { useFakeTimers } from 'sinon';
+import { StartProgress } from '../src/live/StartProgress';
+import { mockGET, clearMockGets } from './utils.test';
+
+const STATUS_URL = '/api/v2/flow_starts.json';
+
+// a flow start payload as returned by the status endpoint
+const start = (overrides: any = {}) => ({
+  status: 'Started',
+  modified_on: new Date().toISOString(),
+  progress: { current: 10, total: 100 },
+  ...overrides
+});
+
+const mockStatus = (results: any[]) => {
+  clearMockGets();
+  mockGET(/flow_starts\.json/, { results, next: null });
+};
+
+const createProgress = async (id = 'start-1'): Promise<StartProgress> => {
+  const progress = (await fixture(
+    `<temba-start-progress statusEndpoint="${STATUS_URL}"></temba-start-progress>`
+  )) as StartProgress;
+  // assigning id is what kicks off the first refresh
+  progress.id = id;
+  await progress.updateComplete;
+  // let the fetch promise chain settle
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return progress;
+};
+
+describe('temba-start-progress', () => {
+  afterEach(() => {
+    clearMockGets();
+  });
+
+  describe('refresh', () => {
+    it('pulls progress counts from the status endpoint', async () => {
+      mockStatus([start({ progress: { current: 25, total: 200 } })]);
+      const progress = await createProgress();
+      expect(progress.current).to.equal(25);
+      expect(progress.total).to.equal(200);
+      expect(progress.refreshes).to.equal(1);
+    });
+
+    it('does nothing when the endpoint returns no starts', async () => {
+      mockStatus([]);
+      const progress = await createProgress();
+      expect(progress.refreshes).to.equal(0);
+      expect(progress.current).to.equal(undefined);
+    });
+
+    it('marks a started run as running', async () => {
+      mockStatus([start({ status: 'Started' })]);
+      const progress = await createProgress();
+      expect(progress.running).to.equal(true);
+      expect(progress.complete).to.equal(false);
+      expect(progress.message).to.equal(null);
+    });
+
+    it('shows a preparing message while pending', async () => {
+      mockStatus([start({ status: 'Pending' })]);
+      const progress = await createProgress();
+      expect(progress.message).to.equal('Preparing to start..');
+      expect(progress.running).to.equal(false);
+    });
+
+    it('shows a waiting message while queued', async () => {
+      mockStatus([start({ status: 'Queued' })]);
+      const progress = await createProgress();
+      expect(progress.message).to.equal('Waiting..');
+    });
+
+    for (const status of ['Completed', 'Failed', 'Interrupted']) {
+      it(`treats ${status} as complete`, async () => {
+        mockStatus([
+          start({ status, progress: { current: 100, total: 100 } })
+        ]);
+        const progress = await createProgress();
+        expect(progress.complete).to.equal(true);
+        expect(progress.running).to.equal(false);
+      });
+    }
+
+    it('estimates an eta once progress is underway', async () => {
+      mockStatus([
+        start({
+          status: 'Started',
+          modified_on: new Date(Date.now() - 1000).toISOString(),
+          progress: { current: 1000, total: 2000 }
+        })
+      ]);
+      const progress = await createProgress();
+      expect(progress.eta).to.be.a('string');
+      // the eta is in the near future, not the past
+      expect(new Date(progress.eta).getTime()).to.be.greaterThan(
+        Date.now() - 1000
+      );
+    });
+
+    it('skips an eta that is months away', async () => {
+      mockStatus([
+        start({
+          status: 'Started',
+          modified_on: new Date(Date.now() - 1000).toISOString(),
+          progress: { current: 1000, total: 10000000000 }
+        })
+      ]);
+      const progress = await createProgress();
+      expect(progress.eta).to.equal(null);
+    });
+
+    it('skips the eta when the rate is too low to be meaningful', async () => {
+      mockStatus([
+        start({
+          status: 'Started',
+          modified_on: new Date(Date.now() - 1000000).toISOString(),
+          progress: { current: 1, total: 100 }
+        })
+      ]);
+      const progress = await createProgress();
+      expect(progress.eta).to.equal(undefined);
+    });
+  });
+
+  describe('polling', () => {
+    it('schedules another refresh while work remains', async () => {
+      mockStatus([
+        start({ status: 'Started', progress: { current: 10, total: 100 } })
+      ]);
+      const progress = await createProgress();
+      expect(progress.refreshes).to.equal(1);
+
+      // the follow-up completes, so polling stops after one more round
+      mockStatus([
+        start({ status: 'Completed', progress: { current: 100, total: 100 } })
+      ]);
+
+      // the backoff after the first refresh is 1s
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      expect(progress.refreshes).to.equal(2);
+      expect(progress.complete).to.equal(true);
+    });
+
+    it('stops polling once the work is complete', async () => {
+      mockStatus([
+        start({ status: 'Completed', progress: { current: 100, total: 100 } })
+      ]);
+      const progress = await createProgress();
+      const after = progress.refreshes;
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(progress.refreshes).to.equal(after);
+    });
+  });
+
+  describe('scheduleRemoval', () => {
+    it('removes itself from the DOM after a delay', async () => {
+      mockStatus([]);
+      const progress = await createProgress();
+      const parent = progress.parentElement;
+      expect(parent.contains(progress)).to.equal(true);
+
+      const clock = useFakeTimers();
+      try {
+        progress.scheduleRemoval();
+        expect(parent.contains(progress)).to.equal(true);
+        clock.tick(5000);
+      } finally {
+        clock.restore();
+      }
+      expect(parent.contains(progress)).to.equal(false);
+    });
+  });
+
+  describe('interrupting', () => {
+    it('opens the interrupt dialog', async () => {
+      mockStatus([]);
+      const progress = await createProgress();
+      progress.interruptTitle = 'Stop this start';
+      progress.interruptEndpoint = '/flow_start/interrupt/1/';
+
+      const opened: any[] = [];
+      const original = (window as any).showModax;
+      (window as any).showModax = (title: string, endpoint: string) =>
+        opened.push({ title, endpoint });
+      try {
+        progress.interruptStart();
+      } finally {
+        (window as any).showModax = original;
+      }
+
+      expect(opened).to.deep.equal([
+        { title: 'Stop this start', endpoint: '/flow_start/interrupt/1/' }
+      ]);
+    });
+
+    it('offers an interrupt control only while running', async () => {
+      mockStatus([start({ status: 'Started' })]);
+      const progress = await createProgress();
+      progress.interruptTitle = 'Stop';
+      progress.interruptEndpoint = '/interrupt/';
+      await progress.updateComplete;
+      expect(
+        progress.shadowRoot.querySelector('temba-icon[name="close"]')
+      ).to.not.equal(null);
+    });
+
+    it('hides the interrupt control when not running', async () => {
+      mockStatus([start({ status: 'Completed' })]);
+      const progress = await createProgress();
+      progress.interruptTitle = 'Stop';
+      progress.interruptEndpoint = '/interrupt/';
+      await progress.updateComplete;
+      expect(
+        progress.shadowRoot.querySelector('temba-icon[name="close"]')
+      ).to.equal(null);
+    });
+
+    it('hides the interrupt control with no endpoint configured', async () => {
+      mockStatus([start({ status: 'Started' })]);
+      const progress = await createProgress();
+      await progress.updateComplete;
+      expect(
+        progress.shadowRoot.querySelector('temba-icon[name="close"]')
+      ).to.equal(null);
+    });
+  });
+});

--- a/test/temba-start-progress.test.ts
+++ b/test/temba-start-progress.test.ts
@@ -2,7 +2,7 @@ import '../temba-modules';
 import { fixture, expect } from '@open-wc/testing';
 import { useFakeTimers } from 'sinon';
 import { StartProgress } from '../src/live/StartProgress';
-import { mockGET, clearMockGets } from './utils.test';
+import { mockGET, clearMockGets, waitForCondition } from './utils.test';
 
 const STATUS_URL = '/api/v2/flow_starts.json';
 
@@ -136,8 +136,9 @@ describe('temba-start-progress', () => {
         start({ status: 'Completed', progress: { current: 100, total: 100 } })
       ]);
 
-      // the backoff after the first refresh is 1s
-      await new Promise((resolve) => setTimeout(resolve, 1200));
+      // the backoff after the first refresh is 1s; poll for the follow-up
+      // rather than sleeping a fixed margin, which goes flaky under load
+      await waitForCondition(() => progress.refreshes > 1, 60, 50);
       expect(progress.refreshes).to.equal(2);
       expect(progress.complete).to.equal(true);
     });

--- a/test/temba-store-api.test.ts
+++ b/test/temba-store-api.test.ts
@@ -1,0 +1,343 @@
+import '../temba-modules';
+import { expect } from '@open-wc/testing';
+import { DateTime, Duration } from 'luxon';
+import { Store } from '../src/store/Store';
+import { loadStore, mockGET, clearMockGets } from './utils.test';
+
+// a dirty-trackable stand-in for a component registered with the store
+const trackable = (dirtyMessage?: string) => {
+  const element: any = {
+    dirty: true,
+    dirtyMessage,
+    cleaned: 0,
+    markClean() {
+      element.cleaned++;
+      element.dirty = false;
+    }
+  };
+  return element;
+};
+
+describe('temba-store api', () => {
+  let store: Store;
+
+  beforeEach(async () => {
+    store = await loadStore();
+  });
+
+  afterEach(() => {
+    clearMockGets();
+  });
+
+  describe('dirty tracking', () => {
+    it('reports no message when nothing is dirty', () => {
+      expect(store.getDirtyMessage()).to.equal(undefined);
+    });
+
+    it('reports a default message for a dirty element', () => {
+      store.markDirty(trackable());
+      expect(store.getDirtyMessage()).to.contain('unsaved changes');
+    });
+
+    it('prefers the element supplied message', () => {
+      store.markDirty(trackable('Your draft will be lost'));
+      expect(store.getDirtyMessage()).to.equal('Your draft will be lost');
+    });
+
+    it('reports the message of the first dirty element', () => {
+      store.markDirty(trackable('First'));
+      store.markDirty(trackable('Second'));
+      expect(store.getDirtyMessage()).to.equal('First');
+    });
+
+    it('registers an element only once', () => {
+      const element = trackable();
+      store.markDirty(element);
+      store.markDirty(element);
+      store.cleanAll();
+      expect(element.cleaned).to.equal(1);
+    });
+
+    it('cleans every registered element', () => {
+      const first = trackable();
+      const second = trackable();
+      store.markDirty(first);
+      store.markDirty(second);
+
+      store.cleanAll();
+
+      expect(first.cleaned).to.equal(1);
+      expect(second.cleaned).to.equal(1);
+      expect(store.getDirtyMessage()).to.equal(undefined);
+    });
+
+    it('forgets an element that marks itself clean', () => {
+      const element = trackable();
+      store.markDirty(element);
+      store.markClean(element);
+      expect(store.getDirtyMessage()).to.equal(undefined);
+    });
+  });
+
+  describe('shiftAndRound', () => {
+    const duration = (opts: any) => Duration.fromObject(opts);
+
+    it('uses the singular form for exactly one unit', () => {
+      expect(store.shiftAndRound(duration({ days: 1 }), 'days', 'day')).to.equal(
+        '1 day'
+      );
+      expect(
+        store.shiftAndRound(duration({ hours: 1 }), 'hours', 'hour')
+      ).to.equal('1 hour');
+    });
+
+    it('uses the plural form otherwise', () => {
+      expect(store.shiftAndRound(duration({ days: 3 }), 'days', 'day')).to.equal(
+        '3 days'
+      );
+    });
+
+    it('rounds to the nearest whole unit', () => {
+      expect(
+        store.shiftAndRound(duration({ hours: 2, minutes: 40 }), 'hours', 'hour')
+      ).to.equal('3 hours');
+      expect(
+        store.shiftAndRound(duration({ hours: 1, minutes: 10 }), 'hours', 'hour')
+      ).to.equal('1 hour');
+    });
+  });
+
+  describe('getCountdown', () => {
+    const inFuture = (opts: any) => DateTime.now().plus(opts);
+
+    it('collapses anything past a month', () => {
+      expect(store.getCountdown(inFuture({ months: 3 }))).to.equal('> 1 month');
+    });
+
+    it('counts down in days', () => {
+      expect(store.getCountdown(inFuture({ days: 5, hours: 1 }))).to.equal(
+        '~ 5 days'
+      );
+    });
+
+    it('counts down in hours', () => {
+      expect(store.getCountdown(inFuture({ hours: 5 }))).to.equal('~ 5 hours');
+    });
+
+    it('counts down in minutes', () => {
+      expect(store.getCountdown(inFuture({ minutes: 30 }))).to.equal(
+        '~ 30 minutes'
+      );
+    });
+
+    it('uses the singular form for a single hour', () => {
+      expect(
+        store.getCountdown(inFuture({ hours: 1, minutes: 2 }))
+      ).to.equal('~ 1 hour');
+    });
+  });
+
+  describe('keyed assets', () => {
+    it('stores values under a name', () => {
+      store.setKeyedAssets('custom', ['one', 'two']);
+      expect(store.getKeyedAssets()['custom']).to.deep.equal(['one', 'two']);
+    });
+
+    it('replaces any previous values', () => {
+      store.setKeyedAssets('custom', ['one']);
+      store.setKeyedAssets('custom', ['two']);
+      expect(store.getKeyedAssets()['custom']).to.deep.equal(['two']);
+    });
+  });
+
+  describe('shortcuts', () => {
+    it('returns an empty list before anything is loaded', () => {
+      (store as any).shortcuts = null;
+      expect(store.getShortcuts()).to.deep.equal([]);
+    });
+
+    it('returns the loaded shortcuts', () => {
+      const shortcuts = [
+        { uuid: 'a', name: 'Greeting', text: 'Hi', modified_on: '' }
+      ];
+      (store as any).shortcuts = shortcuts;
+      expect(store.getShortcuts()).to.equal(shortcuts);
+    });
+
+    it('refreshes shortcuts from the endpoint', async () => {
+      mockGET(/shortcuts\.json/, {
+        results: [
+          { uuid: 'a', name: 'Greeting', text: 'Hi', modified_on: '' },
+          { uuid: 'b', name: 'Bye', text: 'Later', modified_on: '' }
+        ],
+        next: null
+      });
+      (store as any).shortcutsEndpoint = '/api/v2/shortcuts.json';
+
+      await store.refreshShortcuts();
+
+      expect(store.getShortcuts()).to.have.length(2);
+      expect(store.getShortcuts()[0].name).to.equal('Greeting');
+    });
+  });
+
+  describe('refreshGlobals', () => {
+    it('records the keys of every global', async () => {
+      mockGET(/globals\.json/, {
+        results: [{ key: 'org_name' }, { key: 'support_email' }],
+        next: null
+      });
+      (store as any).globalsEndpoint = '/api/v2/globals.json';
+
+      await store.refreshGlobals();
+
+      expect(store.getKeyedAssets()['globals']).to.deep.equal([
+        'org_name',
+        'support_email'
+      ]);
+    });
+  });
+
+  describe('getResults', () => {
+    const RESULTS_URL = '/api/v2/things.json';
+
+    it('fetches and caches results', async () => {
+      mockGET(/things\.json/, { results: [{ id: 1 }], next: null });
+      const first = await store.getResults(RESULTS_URL);
+      expect(first).to.deep.equal([{ id: 1 }]);
+
+      // a second call is served from cache, so changing the mock has no effect
+      clearMockGets();
+      mockGET(/things\.json/, { results: [{ id: 2 }], next: null });
+      const second = await store.getResults(RESULTS_URL);
+      expect(second).to.deep.equal([{ id: 1 }]);
+    });
+
+    it('refetches when forced', async () => {
+      mockGET(/things\.json/, { results: [{ id: 1 }], next: null });
+      await store.getResults(RESULTS_URL);
+
+      clearMockGets();
+      mockGET(/things\.json/, { results: [{ id: 2 }], next: null });
+      const forced = await store.getResults(RESULTS_URL, { force: true });
+      expect(forced).to.deep.equal([{ id: 2 }]);
+    });
+
+    it('shares one fetch between concurrent callers', async () => {
+      mockGET(/things\.json/, { results: [{ id: 1 }], next: null });
+      const [a, b, c] = await Promise.all([
+        store.getResults(RESULTS_URL),
+        store.getResults(RESULTS_URL),
+        store.getResults(RESULTS_URL)
+      ]);
+      expect(a).to.deep.equal([{ id: 1 }]);
+      expect(b).to.deep.equal(a);
+      expect(c).to.deep.equal(a);
+    });
+  });
+
+  describe('cache', () => {
+    const cached = (url: string) => (store as any).cache.get(url);
+
+    it('removes an entry', () => {
+      store.updateCache('/some/url', { hello: 'world' });
+      expect(cached('/some/url')).to.deep.equal({ hello: 'world' });
+      store.removeFromCache('/some/url');
+      expect(cached('/some/url')).to.equal(undefined);
+    });
+
+    it('ignores removal of an unknown entry', () => {
+      // no throw is the assertion here
+      store.removeFromCache('/never/cached');
+    });
+
+    it('fires an update event when the cache is written', () => {
+      const seen: any[] = [];
+      store.addEventListener('temba-store-updated', (e: any) =>
+        seen.push(e.detail)
+      );
+      store.updateCache('/some/url', { hello: 'world' });
+      expect(seen).to.have.length(1);
+      expect(seen[0].url).to.equal('/some/url');
+    });
+  });
+
+  describe('user avatars', () => {
+    it('stores and reads an avatar', () => {
+      store.setUserAvatar('user-1', 'http://example.com/a.png');
+      expect(store.getUserAvatar('user-1')).to.equal(
+        'http://example.com/a.png'
+      );
+    });
+
+    it('ignores incomplete entries', () => {
+      store.setUserAvatar('', 'http://example.com/a.png');
+      store.setUserAvatar('user-2', '');
+      expect(store.getUserAvatar('user-2')).to.equal(undefined);
+    });
+  });
+
+  describe('resolveUsers', () => {
+    it('fills in avatars for referenced users', async () => {
+      mockGET(/users\.json\?uuid=user-1/, {
+        results: [
+          {
+            uuid: 'user-1',
+            email: 'ann@example.com',
+            first_name: 'Ann',
+            last_name: 'Smith',
+            avatar: 'http://example.com/ann.png'
+          }
+        ],
+        next: null
+      });
+
+      const items = [
+        { created_by: { email: 'ann@example.com', uuid: 'user-1' } }
+      ];
+      await store.resolveUsers(items, ['created_by']);
+
+      expect(items[0].created_by).to.include({
+        avatar: 'http://example.com/ann.png',
+        uuid: 'user-1'
+      });
+      expect(store.getUserAvatar('user-1')).to.equal(
+        'http://example.com/ann.png'
+      );
+    });
+
+    it('resolves users at a nested path', async () => {
+      mockGET(/users\.json\?uuid=user-2/, {
+        results: [
+          {
+            uuid: 'user-2',
+            email: 'bo@example.com',
+            first_name: 'Bo',
+            avatar: 'http://example.com/bo.png'
+          }
+        ],
+        next: null
+      });
+
+      const items = [
+        { ticket: { assignee: { email: 'bo@example.com', uuid: 'user-2' } } }
+      ];
+      await store.resolveUsers(items, ['ticket.assignee']);
+
+      expect((items[0].ticket.assignee as any).avatar).to.equal(
+        'http://example.com/bo.png'
+      );
+    });
+
+    it('ignores items missing the referenced key', async () => {
+      const items = [{ other: 'value' }];
+      // resolves without attempting any fetch
+      await store.resolveUsers(items, ['created_by']);
+      expect(items[0]).to.deep.equal({ other: 'value' });
+    });
+
+    it('handles an empty item list', async () => {
+      await store.resolveUsers([], ['created_by']);
+    });
+  });
+});

--- a/test/temba-store-api.test.ts
+++ b/test/temba-store-api.test.ts
@@ -83,26 +83,34 @@ describe('temba-store api', () => {
     const duration = (opts: any) => Duration.fromObject(opts);
 
     it('uses the singular form for exactly one unit', () => {
-      expect(store.shiftAndRound(duration({ days: 1 }), 'days', 'day')).to.equal(
-        '1 day'
-      );
+      expect(
+        store.shiftAndRound(duration({ days: 1 }), 'days', 'day')
+      ).to.equal('1 day');
       expect(
         store.shiftAndRound(duration({ hours: 1 }), 'hours', 'hour')
       ).to.equal('1 hour');
     });
 
     it('uses the plural form otherwise', () => {
-      expect(store.shiftAndRound(duration({ days: 3 }), 'days', 'day')).to.equal(
-        '3 days'
-      );
+      expect(
+        store.shiftAndRound(duration({ days: 3 }), 'days', 'day')
+      ).to.equal('3 days');
     });
 
     it('rounds to the nearest whole unit', () => {
       expect(
-        store.shiftAndRound(duration({ hours: 2, minutes: 40 }), 'hours', 'hour')
+        store.shiftAndRound(
+          duration({ hours: 2, minutes: 40 }),
+          'hours',
+          'hour'
+        )
       ).to.equal('3 hours');
       expect(
-        store.shiftAndRound(duration({ hours: 1, minutes: 10 }), 'hours', 'hour')
+        store.shiftAndRound(
+          duration({ hours: 1, minutes: 10 }),
+          'hours',
+          'hour'
+        )
       ).to.equal('1 hour');
     });
   });
@@ -131,9 +139,9 @@ describe('temba-store api', () => {
     });
 
     it('uses the singular form for a single hour', () => {
-      expect(
-        store.getCountdown(inFuture({ hours: 1, minutes: 2 }))
-      ).to.equal('~ 1 hour');
+      expect(store.getCountdown(inFuture({ hours: 1, minutes: 2 }))).to.equal(
+        '~ 1 hour'
+      );
     });
   });
 


### PR DESCRIPTION
Adds tests for the largest coverage gaps in the codebase. No source changes — tests only.

Overall statement coverage goes from **84.4% to 87.3%** (line coverage, which the `check-coverage` gate uses, from 87.5% to 90.3%), adding **474 test cases** across 17 new files. Full suite is green: 2658 passing, 0 failing.

### Per-file coverage

| File | Before | After |
|---|---|---|
| `live/StartProgress.ts` | 19.3% | 100% |
| `flow/actions/audio-player.ts` | 39.4% | 100% |
| `flow/MessageTable.ts` | 44.4% | 94.4% |
| `list/ShortcutList.ts` | 55.1% | 100% |
| `form/MediaPicker.ts` | 61.6% | 100% |
| `flow/Plumber.ts` | 62.9% | 73.2% |
| `flow/FlowSearch.ts` | 66.3% | 77.8% |
| `form/BaseListEditor.ts` | 67.9% | 99.5% |
| `excellent/ExcellentParser.ts` | 69.7% | 99.4% |
| `flow/NodeEditor.ts` | 70.1% | 74.1% |
| `store/Store.ts` | 71.5% | 93.9% |
| `form/ImagePicker.ts` | 72.5% | 100% |
| `flow/CanvasNode.ts` | 77.2% | 86.7% |
| `store/AppState.ts` | 80.6% | 94.6% |
| `display/sms/*` | 70–77% | 99–100% |
| `flow/nodes/shared-rules.ts` | no tests | 98.9% |
| `excellent/caret-utils.ts` | no tests | 91.6% |

### What's covered

**MessageTable** — 21 of its 23 functions were never called by any test despite the message/translation table being reachable from the editor. Covers entry building, the translation getters, paired-row rendering for multi-field actions, rail colours, and the edit-request events.

**Flow editor** — `CanvasNode` exit disconnection, action/node removal and its two-click arming, edit-request routing, drag ghost handling; `NodeEditor` field-change value extraction, computed fields, group/accordion expansion on validation errors; `FlowSearch` table-scope search including translations and the flow-scope sticky note path; `Plumber` activity overlays and the recent-contacts popup.

**Store layer** — `Store` dirty tracking, countdown formatting, keyed assets, result caching and `resolveUsers`; the 12 `AppState` actions that had no coverage (`fetchRevision`, `updateConnection`, `updateNodeUIConfig`, `removeStickyNotes`, `setTranslationFilters`, and others).

**Quick wins** — `StartProgress` polling/backoff/eta, the audio player's playback and single-active-player behaviour, `ShortcutList` filtering and keyboard nav, `MediaPicker` drag-drop and upload validation (`verifyAccept` and `getAcceptableFiles` were both entirely untested on a file-upload path), `ImagePicker` cropping, `BaseListEditor` list semantics.

**Pure logic** — SMS GSM/unicode splitters (segment counts drive billing, so the boundary cases are worth pinning), `ExcellentParser`'s three untested public methods, `shared-rules.ts`, and `caret-utils.ts`.

### Notes

A few tests pin behaviour that reads as surprising, with a comment explaining why rather than asserting what I first assumed:

- `isWordChar(0)` returns `true` — the end-of-input sentinel is coerced numerically by the `'0' <= ch <= '9'` comparison. Callers guard on `nextCh === 0` separately, so it's harmless, but the test documents it.
- The GSM/unicode splitters bank two parts internally and then rejoin them when the total still fits one segment, so e.g. 77 euro signs (154 septets) reports as a single part.
- `Plumber.fetchRecentContacts` calls `fetch` with only an `AbortSignal` and no `method`, so the shared test fetch mock routes it to its non-GET list; the test uses `mockPOST` with a comment.

The 5 pre-existing `xit`-disabled tests are untouched.
