### PR TITLE
Ignore pnpm artifacts so a stray pnpm install can't be committed or published

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ run.sh
 /node_modules
 /npm-debug.log
 
+## pnpm — we use bun (see bun.lock); these are leftovers from a stray `pnpm install`
+/.pnpm-store/
+/pnpm-lock.yaml
+/pnpm-workspace.yaml
+
 ## testing
 /coverage/
 /screenshots/test

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,9 @@
 node_modules
 bun.lock
 bunfig.toml
+.pnpm-store
+pnpm-lock.yaml
+pnpm-workspace.yaml
 .vscode/
 .DS_Store
 .devcontainer


### PR DESCRIPTION
We switched from pnpm to bun in #1050, and everything tracked already reflects that — CI runs `bun install --frozen-lockfile`, `bunfig.toml` configures the install linker, and `bun.lock` is the committed lockfile. But nothing prevents `pnpm install` from being run in a checkout, and its artifacts were never ignored.

Running it leaves three files sitting untracked in `git status` indefinitely: `pnpm-lock.yaml`, `pnpm-workspace.yaml`, and a `.pnpm-store/` cache (~500MB). This adds them to `.gitignore`, plus `.npmignore` so a publish from a dirty working tree can't ship them.

Worth noting the failure mode, since it's non-obvious: pnpm generates `pnpm-workspace.yaml` with placeholder `allowBuilds` entries that read literally `esbuild: set this to true or false`. Until those are filled in, pnpm skips esbuild's postinstall, so esbuild has no working native binary and can't transform destructuring — which takes out ~100 of the 163 test files with `Failed to fetch dynamically imported module` and drags reported coverage from 90% to 72%. The failure looks like a broken test suite rather than a wrong package manager, so it's worth not leaving the trap lying around.

No source or behavior changes. Full suite still green: 163 files, 2672 passing, 0 failing, 5 skipped, 90.23% line coverage.