### PR TITLE
Raise content menu dropdown above floating windows

### DIFF
--- a/src/display/Dropdown.ts
+++ b/src/display/Dropdown.ts
@@ -31,7 +31,8 @@ export class Dropdown extends RapidElement {
         position: fixed;
         /* open popups sit above floating windows (simulator, 5000) and
            other page chrome, but below dialogs and toasts (10000);
-           temba-content-menu's :host mirrors this value (see ContentMenu.ts) */
+           temba-content-menu mirrors this value on its temba-dropdown
+           flex item (see ContentMenu.ts) */
         z-index: 9000;
         /* the dormant (height: 0) rule is applied 250ms after close, so
            until then this stays a laid-out, invisible fixed box at

--- a/src/display/Dropdown.ts
+++ b/src/display/Dropdown.ts
@@ -35,7 +35,9 @@ export class Dropdown extends RapidElement {
 
       .dropdown {
         position: fixed;
-        z-index: 2;
+        /* open popups sit above floating windows (simulator, 5000) and
+           other page chrome, but below dialogs and toasts (10000) */
+        z-index: 9000;
         padding: 0;
         opacity: 0;
         border-radius: calc(var(--curvature) * 1.5);

--- a/src/display/Dropdown.ts
+++ b/src/display/Dropdown.ts
@@ -9,9 +9,6 @@ import { styleMap } from 'lit-html/directives/style-map.js';
 export class Dropdown extends RapidElement {
   static get styles() {
     return css`
-      :host {
-      }
-
       .wrapper {
         position: relative;
       }
@@ -25,9 +22,6 @@ export class Dropdown extends RapidElement {
         overflow: auto;
       }
 
-      .dropdown:focus {
-      }
-
       .dropdown.dormant {
         height: 0;
         overflow: hidden;
@@ -36,8 +30,14 @@ export class Dropdown extends RapidElement {
       .dropdown {
         position: fixed;
         /* open popups sit above floating windows (simulator, 5000) and
-           other page chrome, but below dialogs and toasts (10000) */
+           other page chrome, but below dialogs and toasts (10000);
+           temba-content-menu's :host mirrors this value (see ContentMenu.ts) */
         z-index: 9000;
+        /* the dormant (height: 0) rule is applied 250ms after close, so
+           until then this stays a laid-out, invisible fixed box at
+           z-index 9000 over whatever it was covering — ignore pointer
+           events unless we're actually open */
+        pointer-events: none;
         padding: 0;
         opacity: 0;
         border-radius: calc(var(--curvature) * 1.5);
@@ -69,6 +69,7 @@ export class Dropdown extends RapidElement {
 
       .open .dropdown {
         opacity: 1;
+        pointer-events: auto;
         transform: translateY(0.5em) scale(1);
       }
 

--- a/src/list/ContentList.ts
+++ b/src/list/ContentList.ts
@@ -533,9 +533,8 @@ export class ContentList<T = any> extends RapidElement {
            width. */
         margin-right: -20px;
         /* Contain the sticky header's z-index inside this frame so it
-           can't compete with the page header's content-menu dropdown
-           (also z-index 2), which otherwise paints under the table
-           header by DOM-order tie-break. */
+           can't compete with the page header's content-menu dropdown,
+           which otherwise paints under the table header. */
         isolation: isolate;
       }
       .table-scroll {

--- a/src/list/ContentList.ts
+++ b/src/list/ContentList.ts
@@ -537,10 +537,11 @@ export class ContentList<T = any> extends RapidElement {
            its own stacking context so those values can only order
            against each other and never interleave with page-level
            layers like floating windows or open dropdowns. Without it
-           any ancestor that raises this frame would let the table's
-           z-index 6 compete directly with page chrome. Note this also
-           caps this list's own label dropdown, which renders inside
-           the frame and so cannot escape it. */
+           the frame is z-index auto, so the table's 1-6 would join the
+           nearest ancestor stacking context — normally the root — and
+           tie against page chrome using comparably small values. Note
+           this also caps this list's own label dropdown, which renders
+           inside the frame and so cannot escape it. */
         isolation: isolate;
       }
       .table-scroll {

--- a/src/list/ContentList.ts
+++ b/src/list/ContentList.ts
@@ -532,9 +532,15 @@ export class ContentList<T = any> extends RapidElement {
            within the panel padding so row dividers don't bleed full-
            width. */
         margin-right: -20px;
-        /* Contain the sticky header's z-index inside this frame so it
-           can't compete with the page header's content-menu dropdown,
-           which otherwise paints under the table header. */
+        /* Keep the table's internal layering (sticky header, pinned
+           columns and their hover/shadow layers, z-index 1-6) inside
+           its own stacking context so those values can only order
+           against each other and never interleave with page-level
+           layers like floating windows or open dropdowns. Without it
+           any ancestor that raises this frame would let the table's
+           z-index 6 compete directly with page chrome. Note this also
+           caps this list's own label dropdown, which renders inside
+           the frame and so cannot escape it. */
         isolation: isolate;
       }
       .table-scroll {

--- a/src/list/ContentMenu.ts
+++ b/src/list/ContentMenu.ts
@@ -34,21 +34,21 @@ export enum ContentMenuItemType {
 export class ContentMenu extends RapidElement {
   static get styles() {
     return css`
-      :host {
-        /* the host is typically a flex item in the page header, so this
-           z-index takes effect and creates a stacking context that caps
-           the dropdown inside it — keep it in sync with the dropdown's
-           z-index (9000) so the open menu clears floating windows like
-           the simulator (5000). This also keeps the closed toggle above
-           those windows — a behavior change from the old 5000, which
-           tied with floating windows and lost on DOM order — and an
-           intended one: the menu has to stay clickable when a floating
-           window overlaps the header. */
-        z-index: 9000;
-      }
       .container {
         display: flex;
         align-items: center;
+      }
+
+      temba-dropdown {
+        /* as a flex item of .container this z-index takes effect and
+           creates a stacking context — keep it in sync with the popup's
+           z-index inside temba-dropdown (9000) so the open menu clears
+           floating windows like the simulator (5000). This also keeps
+           the closed toggle above those windows, intentionally: the
+           menu has to stay clickable when a floating window overlaps
+           the header. Scoped here rather than on :host so the action
+           buttons rendered alongside keep their normal stacking. */
+        z-index: 9000;
       }
 
       .button_item,

--- a/src/list/ContentMenu.ts
+++ b/src/list/ContentMenu.ts
@@ -36,7 +36,12 @@ export class ContentMenu extends RapidElement {
     return css`
       :host {
         tabindex: 0;
-        z-index: 5000;
+        /* the host is typically a flex item in the page header, so this
+           z-index takes effect and creates a stacking context that caps
+           the dropdown inside it — keep it in sync with the dropdown's
+           z-index (9000) so the open menu clears floating windows like
+           the simulator (5000) */
+        z-index: 9000;
       }
       .container {
         display: flex;

--- a/src/list/ContentMenu.ts
+++ b/src/list/ContentMenu.ts
@@ -35,12 +35,13 @@ export class ContentMenu extends RapidElement {
   static get styles() {
     return css`
       :host {
-        tabindex: 0;
         /* the host is typically a flex item in the page header, so this
            z-index takes effect and creates a stacking context that caps
            the dropdown inside it — keep it in sync with the dropdown's
            z-index (9000) so the open menu clears floating windows like
-           the simulator (5000) */
+           the simulator (5000). This also keeps the closed toggle above
+           those windows, which is intended: the menu has to stay
+           clickable when a floating window overlaps the header. */
         z-index: 9000;
       }
       .container {
@@ -73,7 +74,6 @@ export class ContentMenu extends RapidElement {
         color: rgb(45, 45, 45);
         z-index: 50;
         min-width: 200px;
-        tabindex: 0;
       }
 
       .divider {
@@ -87,7 +87,6 @@ export class ContentMenu extends RapidElement {
         font-size: 1.1rem;
         cursor: pointer;
         font-weight: 400;
-        tabindex: 0;
       }
 
       .item:hover {

--- a/src/list/ContentMenu.ts
+++ b/src/list/ContentMenu.ts
@@ -40,8 +40,10 @@ export class ContentMenu extends RapidElement {
            the dropdown inside it — keep it in sync with the dropdown's
            z-index (9000) so the open menu clears floating windows like
            the simulator (5000). This also keeps the closed toggle above
-           those windows, which is intended: the menu has to stay
-           clickable when a floating window overlaps the header. */
+           those windows — a behavior change from the old 5000, which
+           tied with floating windows and lost on DOM order — and an
+           intended one: the menu has to stay clickable when a floating
+           window overlaps the header. */
         z-index: 9000;
       }
       .container {

--- a/test/temba-content-menu.test.ts
+++ b/test/temba-content-menu.test.ts
@@ -101,4 +101,42 @@ describe('temba-content-menu', () => {
     });
     expect(contentMenu.legacy).equals(1);
   });
+
+  it('fires selection when an open menu item is clicked', async () => {
+    const contentMenu: ContentMenu = await getContentMenu({
+      endpoint: '/test-assets/list/content-menu-contact-read.json'
+    });
+
+    const toggle = contentMenu.shadowRoot.querySelector(
+      '.toggle'
+    ) as HTMLElement;
+    toggle.click();
+
+    // wait out the deferred position calculation
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await contentMenu.updateComplete;
+
+    // the item must actually be hit-testable — the popup only accepts
+    // pointer events while open
+    const item = contentMenu.shadowRoot.querySelector('.item') as HTMLElement;
+    const bounds = item.getBoundingClientRect();
+    expect(
+      contentMenu.shadowRoot.elementFromPoint(
+        bounds.left + bounds.width / 2,
+        bounds.top + bounds.height / 2
+      )
+    ).to.equal(item);
+
+    const selection = new Promise<CustomEvent>((resolve) => {
+      contentMenu.addEventListener(
+        CustomEventType.Selection,
+        (event: Event) => resolve(event as CustomEvent),
+        { once: true }
+      );
+    });
+    item.click();
+
+    const event = await selection;
+    expect(event.detail.item.label).to.equal(contentMenu.items[0].label);
+  });
 });

--- a/test/temba-dropdown.test.ts
+++ b/test/temba-dropdown.test.ts
@@ -416,6 +416,29 @@ describe(TAG, () => {
     expect(dropdown.open).to.equal(true);
   });
 
+  it('only hit-tests the popup while open', async () => {
+    const dropdown = await getDropdown();
+    const toggle = dropdown.querySelector('[slot="toggle"]') as HTMLElement;
+
+    toggle.click();
+    await waitForStableRender(dropdown);
+
+    // the open popup is the topmost thing at its own center
+    const content = dropdown.querySelector('[slot="dropdown"]') as HTMLElement;
+    const bounds = content.getBoundingClientRect();
+    const x = bounds.left + bounds.width / 2;
+    const y = bounds.top + bounds.height / 2;
+    expect(document.elementFromPoint(x, y)).to.equal(content);
+
+    // after close the popup stays laid out until it goes dormant 250ms
+    // later, but it must not swallow clicks aimed at what it was covering
+    dropdown.close();
+    await dropdown.updateComplete;
+    expect(dropdown.open).to.equal(false);
+    expect(dropdown.dormant).to.equal(false);
+    expect(document.elementFromPoint(x, y)).to.not.equal(content);
+  });
+
   it('renders without mask by default', async () => {
     const dropdown = await getDropdown(); // No mask explicitly set
 


### PR DESCRIPTION
Fixes #1070

## Summary

The content menu dropdown painted underneath the simulator when it was open, making the editor menu inaccessible. The same collision hid the menu behind the contact history search button. The dropdown popup now stacks above floating windows and page chrome while staying below dialogs and toasts.

## Changes

- **src/display/Dropdown.ts** — the popup was `position: fixed` at `z-index: 2`, losing to the simulator's `temba-floating-window` (5000) and the contact history search toggle (5). Raised to 9000 (below dialogs/modax/toasts at 10000). Also added a `pointer-events` guard: after closing, the popup stays laid out for 250ms before going dormant, and at 9000 that invisible box would otherwise swallow clicks aimed at whatever it was covering.
- **src/list/ContentMenu.ts** — the old `:host { z-index: 5000 }` silently created a stacking context (the host is a flex item in the page header, so z-index takes effect) that capped the inner popup at 5000 — tying the simulator's window and losing by DOM order. The raise to 9000 now lives on the `temba-dropdown` flex item inside the menu rather than on `:host`, so the menu toggle and popup clear floating windows (and the toggle stays clickable when a window overlaps the header) while the action buttons rendered alongside keep their normal stacking. Removed dead `tabindex: 0` CSS declarations (tabindex is an attribute, not a CSS property).
- **src/list/ContentList.ts** — comment-only: the `isolation: isolate` justification referenced the dropdown's old z-index and a failure mode this change makes impossible; rewritten around its remaining purpose (containing the table's internal z 1–6 layers).
- **Tests** — two regression tests covering the hit-testing behavior this PR changes: the dropdown popup is the topmost element at its own center while open but not during the 250ms close window, and clicking an open content menu item fires the selection event.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Open content menu with simulator visible | menu paints under the phone/option pane | menu paints above |
| Open content menu on contact history | search button paints over menu items | menu paints above |
| Click where a just-closed menu was (within 250ms) | click swallowed by invisible popup box | click reaches the element underneath |
| Simulator dragged over header action buttons | buttons hidden under window | unchanged (buttons keep normal stacking) |
| Dialogs / modax / toasts over an open menu | on top | unchanged (still on top) |

## Review notes

Pre-PR review ran two cycles and verified the fix empirically (hit-testing the open menu against a synthetic overlay matching FloatingWindow's exact styling). Substantive catches, all addressed:

- Closing dropdown could swallow clicks for 250ms at its new z-index → `pointer-events` gating added.
- Stale/incorrect comments in ContentList and Dropdown → corrected; z-index coupling now documented on both sides.
- No test guarded the pointer-events behavior (programmatic `.click()` bypasses hit-testing) → `elementFromPoint`-based regression tests added.
- PR review: raising `:host` also lifted the header action buttons above floating windows → raise scoped to the `temba-dropdown` element only.

Noted but out of scope: menu items are keyboard-inaccessible (pre-existing; needs role/tabindex/key handling as a follow-up).

## Test plan

- [x] Full suite in the components container: 2686 passed, 0 failed (includes screenshot comparisons)
- [x] New regression tests for popup hit-testing and menu item selection
- [x] Manually verified in the dev stack: menu opens above the simulator on the flow editor and above the search button on contact history
- [x] Checked other temba-dropdown consumers (PopupSelect, PageHeader, TembaMenu, ContentList) for stacking regressions — none