### PR TITLE
Fix quick reply entry and display for broadcasts

### DIFF
--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -2,7 +2,7 @@ import { TemplateResult, html, nothing, PropertyValueMap, css } from 'lit';
 import { property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { RapidElement } from '../RapidElement';
-import { CustomEventType } from '../interfaces';
+import { CustomEventType, QuickReply } from '../interfaces';
 import { TicketEvent } from '../events';
 import { renderEventSummary } from '../events/eventRenderers';
 import { DEFAULT_AVATAR } from '../webchat/assets';
@@ -81,7 +81,7 @@ interface User extends ObjectReference {
 export interface Msg {
   text: string;
   channel: ObjectReference;
-  quick_replies: string[];
+  quick_replies: (string | QuickReply)[];
   urn: string;
   direction: string;
   type: string;

--- a/src/form/Compose.ts
+++ b/src/form/Compose.ts
@@ -410,25 +410,14 @@ export class Compose extends FieldElement {
     // own keydown inserts a newline (which would flash before the send
     // clears it); bubble keeps Enter-to-send working from anywhere else
     // in the compose after inner widgets have had their shot at it
-    this.addEventListener(
-      'keydown',
-      this.handleHostKeyDown as EventListener,
-      true
-    );
-    this.addEventListener('keydown', this.handleHostKeyDown as EventListener);
+    this.addEventListener('keydown', this.handleHostKeyDownCapture, true);
+    this.addEventListener('keydown', this.handleHostKeyDownBubble);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.removeEventListener(
-      'keydown',
-      this.handleHostKeyDown as EventListener,
-      true
-    );
-    this.removeEventListener(
-      'keydown',
-      this.handleHostKeyDown as EventListener
-    );
+    this.removeEventListener('keydown', this.handleHostKeyDownCapture, true);
+    this.removeEventListener('keydown', this.handleHostKeyDownBubble);
   }
 
   private handleShortcutIconClick() {
@@ -454,7 +443,18 @@ export class Compose extends FieldElement {
     });
   }
 
-  private handleHostKeyDown = (evt: KeyboardEvent) => {
+  // events from inside our shadow tree are retargeted to the host, so
+  // both registrations see eventPhase as AT_TARGET — the phase can't
+  // tell us which registration is firing, so each binds it explicitly
+  private handleHostKeyDownCapture = (evt: KeyboardEvent) => {
+    this.handleHostKeyDown(evt, true);
+  };
+
+  private handleHostKeyDownBubble = (evt: KeyboardEvent) => {
+    this.handleHostKeyDown(evt, false);
+  };
+
+  private handleHostKeyDown = (evt: KeyboardEvent, capture: boolean) => {
     if (evt.key === 'Escape' && this.showShortcuts) {
       evt.preventDefault();
       evt.stopPropagation();
@@ -474,10 +474,12 @@ export class Compose extends FieldElement {
       // during capture only editor presses are claimed — anything else
       // (quick replies, attachments) waits for the bubble so the widget
       // it targets keeps first claim on the event
-      if (
-        evt.eventPhase === Event.CAPTURING_PHASE &&
-        !(editor && evt.composedPath().includes(editor))
-      ) {
+      if (capture && !(editor && evt.composedPath().includes(editor))) {
+        return;
+      }
+      // by the bubble an inner widget may have claimed the Enter for
+      // itself (e.g. the quick reply select adding a tag) — not a send
+      if (!capture && evt.defaultPrevented) {
         return;
       }
       if (editor) {

--- a/src/form/Compose.ts
+++ b/src/form/Compose.ts
@@ -1,7 +1,13 @@
 import { TemplateResult, html, css, PropertyValues, nothing } from 'lit';
 import { FieldElement } from './FieldElement';
 import { property } from 'lit/decorators.js';
-import { Attachment, CustomEventType, Language, Shortcut } from '../interfaces';
+import {
+  Attachment,
+  CustomEventType,
+  Language,
+  QuickReply,
+  Shortcut
+} from '../interfaces';
 import { Icon } from '../Icons';
 import { DEFAULT_MEDIA_ENDPOINT } from '../utils';
 import { Select } from './select/Select';
@@ -12,7 +18,7 @@ import { setCaretOffset } from '../excellent/caret-utils';
 export interface ComposeValue {
   text: string;
   attachments: { uuid: string }[];
-  quick_replies: string[];
+  quick_replies: (string | QuickReply)[];
   optin: string;
   template: string;
   variables: string[];
@@ -236,7 +242,7 @@ export class Compose extends FieldElement {
     [lang: string]: {
       text: string;
       attachments: Attachment[];
-      quick_replies: string[];
+      quick_replies: (string | QuickReply)[];
       optin?: { name: string; uuid: string };
       template?: string;
       variables?: string[];
@@ -357,11 +363,12 @@ export class Compose extends FieldElement {
       this.currentText = langValue.text || '';
       this.initialText = langValue.text || '';
       this.currentAttachments = langValue.attachments || [];
-      this.currentQuickReplies = (langValue.quick_replies || []).map(
-        (value) => {
-          return { name: value, value };
-        }
-      );
+      this.currentQuickReplies = (langValue.quick_replies || [])
+        .map((reply) =>
+          typeof reply === 'string' ? reply : (reply.text ?? null)
+        )
+        .filter((reply): reply is string => reply !== null)
+        .map((value) => ({ name: value, value }));
       this.currentOptin = langValue['optin'] ? [langValue['optin']] : [];
     }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -47,6 +47,14 @@ export interface Attachment {
   error: string;
 }
 
+/** A quick reply as stored/served by the server (engine shape) —
+ * `text` buttons carry text, `location` requests may omit it. */
+export interface QuickReply {
+  type?: string;
+  text?: string;
+  extra?: string;
+}
+
 export enum DateStyle {
   DayFirst = 'day_first',
   MonthFirst = 'month_first',
@@ -231,8 +239,9 @@ export interface Broadcast {
   /** Base-language attachments (`{content_type, url}` objects or
    * `contentType:url` strings). */
   attachments?: (string | Attachment)[];
-  /** Base-language quick replies. */
-  quick_replies?: string[];
+  /** Base-language quick replies — engine `{text}` objects, with
+   * plain strings tolerated for older data. */
+  quick_replies?: (string | QuickReply)[];
   /** The opt-in the broadcast requests, when it is one. */
   optin?: ObjectReference | null;
   /** The WhatsApp template the broadcast sends, when it uses one. */
@@ -271,7 +280,7 @@ export interface Msg {
   text: string;
   status: string;
   channel: ObjectReference;
-  quick_replies: string[];
+  quick_replies: (string | QuickReply)[];
   urn: string;
   /** The message's contact — populated by the messages CRUDL
    * endpoint. Carries whichever of name/urn the endpoint exposes. */

--- a/src/list/BroadcastList.ts
+++ b/src/list/BroadcastList.ts
@@ -874,7 +874,7 @@ export class BroadcastList extends ContentList<Broadcast> {
                               html`<temba-label type="neutral"
                                 >${typeof reply === 'string'
                                   ? reply
-                                  : reply.text}</temba-label
+                                  : (reply.text ?? reply.type)}</temba-label
                               >`
                           )}
                         </div>`

--- a/src/list/BroadcastList.ts
+++ b/src/list/BroadcastList.ts
@@ -872,7 +872,9 @@ export class BroadcastList extends ContentList<Broadcast> {
                           ${broadcast.quick_replies.map(
                             (reply) =>
                               html`<temba-label type="neutral"
-                                >${reply}</temba-label
+                                >${typeof reply === 'string'
+                                  ? reply
+                                  : reply.text}</temba-label
                               >`
                           )}
                         </div>`

--- a/src/list/TicketList.ts
+++ b/src/list/TicketList.ts
@@ -42,7 +42,6 @@ export class TicketList extends TembaList {
     // keeps mostRecentItem meaning the newest fetched item (compareItems
     // re-sorts the merged list immediately anyway)
 
-
     this.compareItems = (a: Contact, b: Contact): number => {
       const aClosed = !!a.ticket.closed_on;
       const bClosed = !!b.ticket.closed_on;

--- a/test/temba-broadcast-list.test.ts
+++ b/test/temba-broadcast-list.test.ts
@@ -432,7 +432,8 @@ describe('temba-broadcast-list', () => {
         attachments: [
           { content_type: 'image/jpeg', url: '/test-assets/img/meow.jpg' }
         ],
-        quick_replies: ['Confirm', 'Change'],
+        // server sends engine {text} objects; plain strings are legacy
+        quick_replies: [{ text: 'Confirm' }, 'Change'],
         exclusions: ['Skip contacts in a flow'],
         contacts: [{ uuid: 'c-1', name: 'Ben Haggerty' }]
       })
@@ -447,6 +448,7 @@ describe('temba-broadcast-list', () => {
     const replies = message.querySelectorAll('.detail-pills temba-label');
     expect(replies).to.have.length(2);
     expect(replies[0].textContent.trim()).to.equal('Confirm');
+    expect(replies[1].textContent.trim()).to.equal('Change');
 
     // recipients render un-capped in the detail, with exclusions below
     const recipients = detail.querySelectorAll(

--- a/test/temba-broadcast-list.test.ts
+++ b/test/temba-broadcast-list.test.ts
@@ -433,7 +433,7 @@ describe('temba-broadcast-list', () => {
           { content_type: 'image/jpeg', url: '/test-assets/img/meow.jpg' }
         ],
         // server sends engine {text} objects; plain strings are legacy
-        quick_replies: [{ text: 'Confirm' }, 'Change'],
+        quick_replies: [{ text: 'Confirm' }, 'Change', { type: 'location' }],
         exclusions: ['Skip contacts in a flow'],
         contacts: [{ uuid: 'c-1', name: 'Ben Haggerty' }]
       })
@@ -446,9 +446,10 @@ describe('temba-broadcast-list', () => {
       message.querySelectorAll('.detail-attachments temba-thumbnail')
     ).to.have.length(1);
     const replies = message.querySelectorAll('.detail-pills temba-label');
-    expect(replies).to.have.length(2);
+    expect(replies).to.have.length(3);
     expect(replies[0].textContent.trim()).to.equal('Confirm');
     expect(replies[1].textContent.trim()).to.equal('Change');
+    expect(replies[2].textContent.trim()).to.equal('location');
 
     // recipients render un-capped in the detail, with exclusions below
     const recipients = detail.querySelectorAll(

--- a/test/temba-compose.test.ts
+++ b/test/temba-compose.test.ts
@@ -195,7 +195,7 @@ describe('temba-compose broadcast edit', () => {
       eng: {
         text: 'Hello from broadcast',
         attachments: [],
-        quick_replies: ['Yes', 'No'],
+        quick_replies: [{ text: 'Yes' }, 'No'],
         optin: null,
         template: null,
         variables: []
@@ -218,7 +218,14 @@ describe('temba-compose broadcast edit', () => {
     // Verify the compose initialized correctly
     expect(compose.currentLanguage).to.equal('eng');
     expect(compose.currentText).to.equal('Hello from broadcast');
-    expect(compose.currentQuickReplies).to.have.length(2);
+    expect(compose.currentQuickReplies).to.deep.equal([
+      { name: 'Yes', value: 'Yes' },
+      { name: 'No', value: 'No' }
+    ]);
+    expect(JSON.parse(compose.value).eng.quick_replies).to.deep.equal([
+      'Yes',
+      'No'
+    ]);
 
     // Verify the message editor exists in shadow DOM and has content
     const editor = compose.shadowRoot.querySelector('temba-message-editor');

--- a/test/temba-compose.test.ts
+++ b/test/temba-compose.test.ts
@@ -267,6 +267,68 @@ describe('temba-compose broadcast edit', () => {
   });
 });
 
+describe('temba-compose enter key', () => {
+  const getComposeWithText = async () => {
+    const compose: Compose = await getCompose({
+      quickreplies: true,
+      chatbox: true,
+      counter: true,
+      value: getComposeValue(getInitialValue('hello there'))
+    });
+    return compose;
+  };
+
+  it('sends on Enter in the message editor', async () => {
+    const compose = await getComposeWithText();
+    let submitted = 0;
+    compose.addEventListener('temba-submitted', () => {
+      submitted++;
+    });
+
+    // click into the editor and press Enter
+    await typeInto('temba-compose:temba-message-editor', '', false, false);
+    await waitFor(100);
+    await pressKey('Enter', 1);
+    await waitFor(100);
+    expect(submitted).to.equal(1);
+  });
+
+  it('adds a quick reply on Enter without sending', async () => {
+    const compose = await getComposeWithText();
+    let submitted = 0;
+    compose.addEventListener('temba-submitted', () => {
+      submitted++;
+    });
+
+    // expand the quick replies section
+    const section = compose.shadowRoot.querySelector(
+      'temba-accordion-section'
+    ) as any;
+    section.collapsed = false;
+    await section.updateComplete;
+    await compose.updateComplete;
+
+    const select = compose.shadowRoot.querySelector(
+      'temba-select.quick-replies'
+    ) as any;
+
+    await typeInto(
+      'temba-compose:temba-select.quick-replies',
+      'Maybe',
+      false,
+      false
+    );
+    await pressKey('Enter', 1);
+    await waitFor(100);
+    await compose.updateComplete;
+
+    expect(select.values.length).to.equal(1);
+    expect(select.values[0].value).to.equal('Maybe');
+    expect(compose.currentQuickReplies).to.have.length(1);
+    expect(submitted).to.equal(0);
+  });
+});
+
 describe('temba-compose language visualization', () => {
   const getLangSelect = async (compose: Compose) => {
     const select = compose.shadowRoot.querySelector(


### PR DESCRIPTION
## Summary

Fix broadcast quick replies end to end: Enter now adds a quick reply without submitting the broadcast, and server-shaped quick reply objects render and load correctly while legacy strings remain supported.

## Changes

- Split Compose's host keydown handling into explicit capture and bubble callbacks. Editor Enter still submits, while Enter claimed by the quick-reply select only adds the reply.
- Added a shared `QuickReply` engine shape and widened broadcast/message quick-reply types to accept engine objects or legacy strings.
- Normalize `{text}` objects when loading an existing broadcast into Compose, then serialize the edited quick replies as strings.
- Render object replies by text in broadcast details, falling back to the reply type for non-text requests such as location.
- Added regression coverage for editor submission, quick-reply entry, mixed server/legacy display values, non-text display fallback, and engine-shaped broadcast editing.

## Behavior examples

| Scenario | Result |
| --- | --- |
| Enter in the message editor | Submits once |
| Enter in the quick-reply field | Adds the reply without submitting |
| Detail receives `{ "text": "Confirm" }` | Renders `Confirm` |
| Detail receives `{ "type": "location" }` | Renders `location` |
| Edit receives `[{ "text": "Yes" }, "No"]` | Loads `Yes` and `No`, then serializes them as strings |

## Test plan

- [x] Format and TypeScript/build checks in `app-broadcast-qr-components-1`
- [x] Locale extraction and build
- [x] `test/temba-compose.test.ts` (21 tests)
- [x] `test/temba-broadcast-list.test.ts` (23 tests)
- [x] Both GitHub `Test` workflows and CLA check
- [x] All review threads resolved
