### PR TITLE
Align editor input limits with flow engine validation limits

### DIFF
--- a/src/flow/actions/send_msg.ts
+++ b/src/flow/actions/send_msg.ts
@@ -117,7 +117,8 @@ export const send_msg: ActionConfig = {
           type: 'text',
           placeholder: 'Expression (e.g. @contact.photo)',
           required: true,
-          evaluated: true
+          evaluated: true,
+          maxLength: 8192
         }
       }
     }

--- a/src/flow/actions/set_contact_field.ts
+++ b/src/flow/actions/set_contact_field.ts
@@ -45,6 +45,7 @@ export const set_contact_field: ActionConfig = {
       label: 'Value',
       placeholder: 'Enter field value...',
       evaluated: true,
+      maxLength: 1000,
       helpText:
         'The new value for the contact field. You can use expressions like @contact.name'
     }

--- a/src/flow/actions/set_contact_field.ts
+++ b/src/flow/actions/set_contact_field.ts
@@ -45,7 +45,7 @@ export const set_contact_field: ActionConfig = {
       label: 'Value',
       placeholder: 'Enter field value...',
       evaluated: true,
-      maxLength: 1000,
+      maxLength: 10000,
       helpText:
         'The new value for the contact field. You can use expressions like @contact.name'
     }

--- a/src/flow/actions/set_contact_name.ts
+++ b/src/flow/actions/set_contact_name.ts
@@ -20,6 +20,7 @@ export const set_contact_name: ActionConfig = {
       placeholder: 'Enter contact name...',
       required: true,
       evaluated: true,
+      maxLength: 1000,
       helpText:
         'The new name for the contact. You can use expressions like @contact.name'
     }

--- a/src/flow/nodes/split_by_ticket.ts
+++ b/src/flow/nodes/split_by_ticket.ts
@@ -43,6 +43,7 @@ export const split_by_ticket: NodeConfig = {
       required: false,
       evaluated: true,
       placeholder: 'Enter a note for the ticket (optional)',
+      maxLength: 10000,
       minHeight: 100
     }
   },

--- a/src/flow/nodes/wait_for_dial.ts
+++ b/src/flow/nodes/wait_for_dial.ts
@@ -34,6 +34,7 @@ export const wait_for_dial: NodeConfig = {
       label: 'Phone Number',
       required: true,
       evaluated: true,
+      maxLength: 1000,
       placeholder: 'Phone number or expression'
     },
     dial_limit_seconds: {

--- a/test/flow-config-limits.test.ts
+++ b/test/flow-config-limits.test.ts
@@ -13,7 +13,7 @@ describe('flow form config limits', () => {
   });
 
   it('caps contact field value length', () => {
-    expect((set_contact_field.form.value as any).maxLength).to.equal(1000);
+    expect((set_contact_field.form.value as any).maxLength).to.equal(10000);
   });
 
   it('caps contact name length', () => {

--- a/test/flow-config-limits.test.ts
+++ b/test/flow-config-limits.test.ts
@@ -1,0 +1,37 @@
+import { expect } from '@open-wc/testing';
+import { split_by_ticket } from '../src/flow/nodes/split_by_ticket';
+import { set_contact_field } from '../src/flow/actions/set_contact_field';
+import { set_contact_name } from '../src/flow/actions/set_contact_name';
+import { send_msg } from '../src/flow/actions/send_msg';
+import { wait_for_dial } from '../src/flow/nodes/wait_for_dial';
+
+// these limits must match the validation caps enforced by the flow engine -
+// without them the editor emits definitions the engine rejects at save time
+describe('flow form config limits', () => {
+  it('caps ticket note length', () => {
+    expect((split_by_ticket.form.note as any).maxLength).to.equal(10000);
+  });
+
+  it('caps contact field value length', () => {
+    expect((set_contact_field.form.value as any).maxLength).to.equal(1000);
+  });
+
+  it('caps contact name length', () => {
+    expect((set_contact_name.form.name as any).maxLength).to.equal(1000);
+  });
+
+  it('caps attachment expression length', () => {
+    const attachments = send_msg.form.runtime_attachments as any;
+    expect(attachments.itemConfig.expression.maxLength).to.equal(8192);
+  });
+
+  it('caps dial phone length', () => {
+    expect((wait_for_dial.form.phone as any).maxLength).to.equal(1000);
+  });
+
+  it('caps quick reply count and length', () => {
+    const quickReplies = send_msg.form.quick_replies as any;
+    expect(quickReplies.maxItems).to.equal(10);
+    expect(quickReplies.maxLength).to.equal(1000);
+  });
+});


### PR DESCRIPTION
## What

Declares `maxLength` on flow editor form fields that were missing one, matching the maximum lengths the flow engine now validates on flow definitions.

| Field | Cap |
| --- | --- |
| Open Ticket → note | 10000 |
| Update Field → value | 10000 |
| Update Name → name | 1000 |
| Send Message → runtime attachment expression | 8192 |
| Wait for Dial → phone number | 1000 |

## Why

The engine recently added maximum length validation to definition fields that were previously unbounded. The editor already enforced matching limits on most inputs (via `maxLength` in the node/action form configs, checked in `NodeEditor`), but these free-text inputs never declared one — so they could accept a value that the engine then rejects when the flow is saved. Declaring the cap surfaces the limit as an inline validation error while editing instead.

## Notes for reviewers

- The contact field value cap is 10000, not 1000 — the engine raised it after the initial round of limits, since the value is an evaluated template whose source can be much longer than what it evaluates to.
- Attachments added by upload go through the message editor, which already caps count (10) and is bounded by the upload flow; the only free-text attachment input is the runtime attachment *expression*, which is what gets the 8192 cap here.
- Quick replies were already capped correctly (10 entries × 1000 chars), as were `set_contact_language` / `set_contact_timezone` (selects with fixed option values, well under the 1000 cap) — no changes needed.
- `wait_for_dial`'s phone field turned up during the sweep of remaining free-text inputs; it has the same problem, so it is included.
- New test `test/flow-config-limits.test.ts` asserts each cap, following the existing pattern in `test/flow-shared-rules.test.ts`.
- Full suite passes: 2678 passed, 0 failed, 5 skipped.