### PR TITLE
Add fallbacks for browsers without color-mix() support

### DIFF
--- a/src/display/Button.ts
+++ b/src/display/Button.ts
@@ -101,9 +101,11 @@ export class Button extends LitElement {
         background: var(--success, #16a34a);
         color: #fff;
       }
+      /* Hover darkening: static pre-mixed values first for browsers
+         without color-mix(), re-derived from the token below. */
       .attention-button:hover,
       .affirmative:hover {
-        background: color-mix(in srgb, var(--success, #16a34a) 88%, black);
+        background: #138f41;
       }
 
       /* DS .btn-danger — flat danger fill (no lift). */
@@ -112,7 +114,17 @@ export class Button extends LitElement {
         color: #fff;
       }
       .destructive-button:hover {
-        background: color-mix(in srgb, var(--danger, #d03f3f) 88%, black);
+        background: #b73737;
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .attention-button:hover,
+        .affirmative:hover {
+          background: color-mix(in srgb, var(--success, #16a34a) 88%, black);
+        }
+        .destructive-button:hover {
+          background: color-mix(in srgb, var(--danger, #d03f3f) 88%, black);
+        }
       }
 
       /* DS .btn-ghost — text-only, hover fills with sunken */

--- a/src/display/Chat.ts
+++ b/src/display/Chat.ts
@@ -518,19 +518,15 @@ export class Chat extends RapidElement {
          same theme vars the flat fills used — color-mix keeps host
          re-theming working — with a whisper of shadow for depth and
          a hairline border mixed just darker than the fill so bubbles
-         hold their edge against the background. */
+         hold their edge against the background. Base rules carry flat
+         fills and pre-mixed borders for browsers without color-mix()
+         (pre-Chrome 111); the @supports block below layers the
+         gradients on top. */
       .bubble {
         padding: 10px 14px;
-        background: linear-gradient(
-          180deg,
-          color-mix(in srgb, var(--color-chat-in, #e5e5ea) 62%, white) 0%,
-          var(--color-chat-in, #e5e5ea) 100%
-        );
+        background: var(--color-chat-in, #e5e5ea);
         border-radius: 18px;
-        border: var(
-          --chat-border-in,
-          1px solid color-mix(in srgb, var(--color-chat-in, #e5e5ea) 93%, black)
-        );
+        border: var(--chat-border-in, 1px solid #d5d5da);
         box-shadow: 0 1px 2px rgba(16, 24, 40, 0.06);
       }
 
@@ -550,18 +546,38 @@ export class Chat extends RapidElement {
       }
 
       .incoming .bubble {
-        background: linear-gradient(
-          180deg,
-          color-mix(in srgb, var(--color-chat-out, #007aff) 90%, white) 0%,
-          var(--color-chat-out, #007aff) 58%,
-          color-mix(in srgb, var(--color-chat-out, #007aff) 95%, black) 100%
-        );
-        border: var(
-          --chat-border-out,
-          1px solid
-            color-mix(in srgb, var(--color-chat-out, #007aff) 90%, black)
-        );
+        background: var(--color-chat-out, #007aff);
+        border: var(--chat-border-out, 1px solid #006ee6);
         color: white;
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .bubble {
+          background: linear-gradient(
+            180deg,
+            color-mix(in srgb, var(--color-chat-in, #e5e5ea) 62%, white) 0%,
+            var(--color-chat-in, #e5e5ea) 100%
+          );
+          border: var(
+            --chat-border-in,
+            1px solid
+              color-mix(in srgb, var(--color-chat-in, #e5e5ea) 93%, black)
+          );
+        }
+
+        .incoming .bubble {
+          background: linear-gradient(
+            180deg,
+            color-mix(in srgb, var(--color-chat-out, #007aff) 90%, white) 0%,
+            var(--color-chat-out, #007aff) 58%,
+            color-mix(in srgb, var(--color-chat-out, #007aff) 95%, black) 100%
+          );
+          border: var(
+            --chat-border-out,
+            1px solid
+              color-mix(in srgb, var(--color-chat-out, #007aff) 90%, black)
+          );
+        }
       }
 
       .incoming .latest .bubble {
@@ -573,8 +589,11 @@ export class Chat extends RapidElement {
       }
 
       /* Notes get the same top-lit gradient treatment as message
-         bubbles, derived from their sticky-note yellow. */
+         bubbles, derived from their sticky-note yellow. The flat fill
+         first is the fallback for browsers without color-mix() — all
+         literals here, so the invalid gradient drops at parse time. */
       .note .bubble {
+        background: #fffac3;
         background: linear-gradient(
           180deg,
           color-mix(in srgb, #fffac3 62%, white) 0%,

--- a/src/display/Label.ts
+++ b/src/display/Label.ts
@@ -100,7 +100,10 @@ export default class Label extends LitElement {
          dark variant shade), so flow stays bluish, group stays purplish,
          etc. — no grey wash. */
       .label[class*='pill-'].clickable .mask:hover {
-        background: color-mix(in oklab, currentColor 10%, transparent);
+        /* Neutral wash first for browsers without color-mix() — the
+           currentColor mix can't fall back per-declaration because
+           currentColor keeps it valid until computed-value time. */
+        background: rgba(0, 0, 0, 0.06);
       }
       .label[class*='pill-'] temba-icon {
         margin-right: 0;
@@ -121,14 +124,26 @@ export default class Label extends LitElement {
         margin: 0;
         border: 0;
         border-radius: 999px;
-        background: color-mix(in oklab, currentColor 25%, transparent);
+        background: rgba(0, 0, 0, 0.12);
         color: inherit;
         opacity: 0.8;
         --icon-color: currentColor;
       }
       .label[class*='pill-'] .remove:hover {
         opacity: 1;
-        background: color-mix(in oklab, currentColor 45%, transparent);
+        background: rgba(0, 0, 0, 0.22);
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .label[class*='pill-'].clickable .mask:hover {
+          background: color-mix(in oklab, currentColor 10%, transparent);
+        }
+        .label[class*='pill-'] .remove {
+          background: color-mix(in oklab, currentColor 25%, transparent);
+        }
+        .label[class*='pill-'] .remove:hover {
+          background: color-mix(in oklab, currentColor 45%, transparent);
+        }
       }
 
       /* When a removable X is present, tighten the mask's left padding

--- a/src/form/RangePicker.ts
+++ b/src/form/RangePicker.ts
@@ -123,10 +123,18 @@ export class RangePicker extends RapidElement {
     /* The hover wash sits on the sunken track, so --sunken itself
        would be invisible here. Derived from --text-1 rather than a raw
        rgba literal so it follows the palette (the tokens file mixes
-       against transparent the same way for --focus-halo). */
+       against transparent the same way for --focus-halo). The rgba
+       fallback pre-mixes the default --text-1 for browsers without
+       color-mix(). */
     .range-btn:hover:not(.selected) {
-      background: color-mix(in srgb, var(--text-1) 6%, transparent);
+      background: rgba(26, 31, 38, 0.06);
       color: var(--text-1);
+    }
+
+    @supports (color: color-mix(in srgb, red, red)) {
+      .range-btn:hover:not(.selected) {
+        background: color-mix(in srgb, var(--text-1) 6%, transparent);
+      }
     }
 
     .range-btn.selected {

--- a/src/form/select/Select.ts
+++ b/src/form/select/Select.ts
@@ -371,14 +371,27 @@ export class Select<T extends SelectOption> extends FieldElement {
         margin: 0;
         border: 0;
         border-radius: 999px;
-        background: color-mix(in oklab, currentColor 25%, transparent);
+        /* Neutral wash first for browsers without color-mix(); the
+           currentColor-tinted version below needs the @supports gate
+           because currentColor keeps the declaration valid until
+           computed-value time. */
+        background: rgba(0, 0, 0, 0.12);
         color: inherit;
         opacity: 0.8;
         --icon-color: currentColor;
       }
       .multi .remove-item:hover {
         opacity: 1;
-        background: color-mix(in oklab, currentColor 45%, transparent);
+        background: rgba(0, 0, 0, 0.22);
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .multi .remove-item {
+          background: color-mix(in oklab, currentColor 25%, transparent);
+        }
+        .multi .remove-item:hover {
+          background: color-mix(in oklab, currentColor 45%, transparent);
+        }
       }
 
       input {

--- a/src/list/BroadcastList.ts
+++ b/src/list/BroadcastList.ts
@@ -198,7 +198,8 @@ export class BroadcastList extends ContentList<Broadcast> {
       }
       .menu-button.destructive:hover {
         border-color: #dc2626;
-        background: color-mix(in srgb, #dc2626 6%, var(--surface, #fff));
+        /* pre-mixed fallback for browsers without color-mix() */
+        background: #fdf2f2;
       }
       .detail-body {
         display: flex;
@@ -243,14 +244,24 @@ export class BroadcastList extends ContentList<Broadcast> {
         align-items: flex-start;
         gap: 0.6em;
         padding: 0.9em 1em 1em;
-        background: color-mix(
-          in srgb,
-          var(--sunken, #f1f3f5) 45%,
-          var(--surface, #fff)
-        );
+        /* pre-mixed fallback for browsers without color-mix() */
+        background: #f9fafa;
         border: 1px solid var(--border, #e4e7ec);
         border-radius: var(--r);
         line-height: 1.5;
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .menu-button.destructive:hover {
+          background: color-mix(in srgb, #dc2626 6%, var(--surface, #fff));
+        }
+        .detail-message {
+          background: color-mix(
+            in srgb,
+            var(--sunken, #f1f3f5) 45%,
+            var(--surface, #fff)
+          );
+        }
       }
       .detail-message temba-expression-highlight {
         align-self: stretch;

--- a/src/list/ContentList.ts
+++ b/src/list/ContentList.ts
@@ -154,24 +154,33 @@ export class ContentList<T = any> extends RapidElement {
         --sort-gutter: 16px;
         /* Selected-row wash — accent-50 on its own reads grey, so a
            touch of the accent-400 rail colour is mixed in to give
-           the selection a faint accent tint. */
-        --cl-selected: color-mix(
-          in oklab,
-          var(--accent-400) 9%,
-          var(--accent-50)
-        );
+           the selection a faint accent tint. Statics pre-mixed from
+           the default accent for browsers without color-mix(); the
+           @supports block below re-derives them from the tokens. */
+        --cl-selected: #e5ecf8;
         /* The dividers bracketing a selected row — the plain grey
            --border reads as a seam against the wash, so this is the
            same accent pushed a little further. */
-        --cl-selected-border: color-mix(
-          in oklab,
-          var(--accent-400) 24%,
-          var(--accent-50)
-        );
+        --cl-selected-border: #cbdaf1;
         /* Tint shared by the frozen (pinned) columns and the header
            row, so the header reads as the same quiet sub-panel as the
            pinned section. */
-        --cl-pin-bg: color-mix(in oklab, var(--sunken) 35%, var(--surface));
+        --cl-pin-bg: #fafbfc;
+      }
+      @supports (color: color-mix(in srgb, red, red)) {
+        :host {
+          --cl-selected: color-mix(
+            in oklab,
+            var(--accent-400) 9%,
+            var(--accent-50)
+          );
+          --cl-selected-border: color-mix(
+            in oklab,
+            var(--accent-400) 24%,
+            var(--accent-50)
+          );
+          --cl-pin-bg: color-mix(in oklab, var(--sunken) 35%, var(--surface));
+        }
       }
       /* fillWindow — take the slack of a height-bounded flex-column
          parent so the table scrolls internally; min-height: 0 (set
@@ -296,7 +305,14 @@ export class ContentList<T = any> extends RapidElement {
         color: var(--danger);
       }
       .bulk-action.destructive:hover {
-        background: color-mix(in oklab, var(--danger) 20%, white);
+        /* pre-mixed fallback for browsers without color-mix() */
+        background: #f6d9d9;
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .bulk-action.destructive:hover {
+          background: color-mix(in oklab, var(--danger) 20%, white);
+        }
       }
       .bulk-action temba-icon {
         --icon-color: currentColor;

--- a/src/list/FieldList.ts
+++ b/src/list/FieldList.ts
@@ -377,7 +377,14 @@ export class FieldList extends EndpointMonitorElement {
 
       .menu-button.destructive:hover {
         border-color: #dc2626;
-        background: color-mix(in srgb, #dc2626 6%, var(--surface, #fff));
+        /* pre-mixed fallback for browsers without color-mix() */
+        background: #fdf2f2;
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .menu-button.destructive:hover {
+          background: color-mix(in srgb, #dc2626 6%, var(--surface, #fff));
+        }
       }
 
       .detail-body {

--- a/src/live/CampaignEvents.ts
+++ b/src/live/CampaignEvents.ts
@@ -273,11 +273,20 @@ export class CampaignEvents extends EndpointMonitorElement {
         justify-content: center;
         /* icons inside the dot take the dot's hue */
         --icon-color: var(--dot-color);
-        background: color-mix(
-          in srgb,
-          var(--dot-color) 12%,
-          var(--color-widget-bg, #fff)
-        );
+        /* plain widget bg for browsers without color-mix(); the tinted
+           fill below needs the @supports gate since var() keeps an
+           invalid declaration alive until computed-value time */
+        background: var(--color-widget-bg, #fff);
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .dot {
+          background: color-mix(
+            in srgb,
+            var(--dot-color) 12%,
+            var(--color-widget-bg, #fff)
+          );
+        }
       }
 
       /* the anchor marks the field's date itself - painted with the widget
@@ -470,7 +479,8 @@ export class CampaignEvents extends EndpointMonitorElement {
 
       .menu-button.destructive:hover {
         border-color: #dc2626;
-        background: color-mix(in srgb, #dc2626 6%, var(--surface, #fff));
+        /* pre-mixed fallback for browsers without color-mix() */
+        background: #fdf2f2;
       }
 
       /* the event's action, contained with a leading type label. Children
@@ -481,14 +491,24 @@ export class CampaignEvents extends EndpointMonitorElement {
         align-items: flex-start;
         gap: 0.6em;
         padding: 0.9em 1em 1em;
-        background: color-mix(
-          in srgb,
-          var(--sunken, #f1f3f5) 45%,
-          var(--surface, #fff)
-        );
+        /* pre-mixed fallback for browsers without color-mix() */
+        background: #f9fafa;
         border: 1px solid var(--border, #e4e7ec);
         border-radius: var(--r);
         line-height: 1.5;
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .menu-button.destructive:hover {
+          background: color-mix(in srgb, #dc2626 6%, var(--surface, #fff));
+        }
+        .detail-action {
+          background: color-mix(
+            in srgb,
+            var(--sunken, #f1f3f5) 45%,
+            var(--surface, #fff)
+          );
+        }
       }
 
       /* the close (✕) in the header's upper right - the square

--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -140,10 +140,18 @@ export class ContactChat extends ContactStoreElement {
 
       /* While the contact is in a flow the compose outline carries the
          flow hue: resting border matches the flow pill border, focus
-         goes solid flow green */
+         goes solid flow green. The pre-mixed static comes first — a
+         custom property can't fall back per-declaration, so the
+         derived version needs the @supports gate. */
       .in-flow .compose {
-        --compose-border: 1px solid
-          color-mix(in srgb, var(--flow, #16a34a) 25%, white);
+        --compose-border: 1px solid #c5e8d2;
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .in-flow .compose {
+          --compose-border: 1px solid
+            color-mix(in srgb, var(--flow, #16a34a) 25%, white);
+        }
       }
 
       .in-flow .compose temba-compose {
@@ -459,10 +467,18 @@ export class ContactChat extends ContactStoreElement {
          status-area grey. Fallbacks match the --flow design token for
          pages without tokens. */
       .in-flow .contact-status {
-        background: color-mix(in srgb, var(--flow, #16a34a) 12%, white);
+        /* pre-mixed statics first for browsers without color-mix() */
+        background: #e3f4e9;
         color: var(--flow, #16a34a);
         --icon-color: var(--flow, #16a34a);
-        border-top-color: color-mix(in srgb, var(--flow, #16a34a) 25%, white);
+        border-top-color: #c5e8d2;
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .in-flow .contact-status {
+          background: color-mix(in srgb, var(--flow, #16a34a) 12%, white);
+          border-top-color: color-mix(in srgb, var(--flow, #16a34a) 25%, white);
+        }
       }
 
       /* compact the interrupt button to the row's caption scale */
@@ -530,7 +546,14 @@ export class ContactChat extends ContactStoreElement {
       }
 
       .in-flow .chat-box {
-        background: color-mix(in srgb, var(--flow, #16a34a) 12%, white);
+        /* pre-mixed static first for browsers without color-mix() */
+        background: #e3f4e9;
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .in-flow .chat-box {
+          background: color-mix(in srgb, var(--flow, #16a34a) 12%, white);
+        }
       }
 
       .ticket-controls {

--- a/src/live/ContactTimeline.ts
+++ b/src/live/ContactTimeline.ts
@@ -189,24 +189,36 @@ export class ContactTimeline extends EndpointMonitorElement {
         padding: 0.05em 0.65em;
         border-radius: 999px;
         white-space: nowrap;
-        background: color-mix(
-          in srgb,
-          var(--pill-hue) 12%,
-          var(--color-widget-bg, #fff)
-        );
-        border: 1px solid
-          color-mix(in srgb, var(--pill-hue) 25%, var(--color-widget-bg, #fff));
+        /* plain bg / neutral border for browsers without color-mix();
+           the hue-tinted versions live in the @supports block below */
+        background: var(--color-widget-bg, #fff);
+        border: 1px solid var(--pill-hue);
         color: var(--pill-hue);
         cursor: pointer;
         transition: background 100ms ease-in-out;
       }
 
-      .campaign-pill:hover {
-        background: color-mix(
-          in srgb,
-          var(--pill-hue) 22%,
-          var(--color-widget-bg, #fff)
-        );
+      @supports (color: color-mix(in srgb, red, red)) {
+        .campaign-pill {
+          background: color-mix(
+            in srgb,
+            var(--pill-hue) 12%,
+            var(--color-widget-bg, #fff)
+          );
+          border: 1px solid
+            color-mix(
+              in srgb,
+              var(--pill-hue) 25%,
+              var(--color-widget-bg, #fff)
+            );
+        }
+        .campaign-pill:hover {
+          background: color-mix(
+            in srgb,
+            var(--pill-hue) 22%,
+            var(--color-widget-bg, #fff)
+          );
+        }
       }
 
       .campaign-pill:focus-visible {
@@ -289,24 +301,34 @@ export class ContactTimeline extends EndpointMonitorElement {
       }
 
       /* past events are filled with a lighter tint of the same hue and keep
-         the solid border - they're settled, whether real or projected */
+         the solid border - they're settled, whether real or projected.
+         Plain widget bg first for browsers without color-mix(). */
       .dot.past {
-        background: color-mix(
-          in srgb,
-          var(--dot-color) 25%,
-          var(--color-widget-bg, #fff)
-        );
+        background: var(--color-widget-bg, #fff);
       }
 
       /* future events haven't occurred yet - signal that with a dotted
          border and the faintest tint of the hue inside */
       .dot.future {
         border-style: dotted;
-        background: color-mix(
-          in srgb,
-          var(--dot-color) 8%,
-          var(--color-widget-bg, #fff)
-        );
+        background: var(--color-widget-bg, #fff);
+      }
+
+      @supports (color: color-mix(in srgb, red, red)) {
+        .dot.past {
+          background: color-mix(
+            in srgb,
+            var(--dot-color) 25%,
+            var(--color-widget-bg, #fff)
+          );
+        }
+        .dot.future {
+          background: color-mix(
+            in srgb,
+            var(--dot-color) 8%,
+            var(--color-widget-bg, #fff)
+          );
+        }
       }
 
       /* the now dot and label both paint with the SPA content background

--- a/src/styles/designTokens.ts
+++ b/src/styles/designTokens.ts
@@ -20,16 +20,21 @@ export const designTokens = css`
        Fallback matches the design-system.css default so component-
        only test harnesses pick up the same brand colour. */
     --accent: rgb(var(--primary-rgb, 73, 127, 206));
-    --accent-50: color-mix(in srgb, var(--accent) 6%, white);
-    --accent-100: color-mix(in srgb, var(--accent) 16%, white);
-    --accent-200: color-mix(in srgb, var(--accent) 32%, white);
-    --accent-300: color-mix(in srgb, var(--accent) 60%, white);
+    /* Static ramp values are pre-mixed from the default anchor for
+       browsers without color-mix() (pre-Chrome 111, e.g. the last
+       Chrome available on Windows 7/8.1). The @supports block below
+       re-derives them from --accent so host re-theming still works
+       where color-mix() is available. */
+    --accent-50: #f4f7fc;
+    --accent-100: #e2ebf7;
+    --accent-200: #c5d6ef;
+    --accent-300: #92b2e2;
     --accent-400: var(--accent);
-    --accent-500: color-mix(in srgb, var(--accent) 90%, black);
-    --accent-600: color-mix(in srgb, var(--accent) 80%, black);
-    --accent-700: color-mix(in srgb, var(--accent) 65%, black);
-    --accent-800: color-mix(in srgb, var(--accent) 50%, black);
-    --accent-900: color-mix(in srgb, var(--accent) 35%, black);
+    --accent-500: #4272b9;
+    --accent-600: #3a66a5;
+    --accent-700: #2f5386;
+    --accent-800: #244067;
+    --accent-900: #1a2c48;
 
     /* neutrals */
     --bg: #f6f7f9;
@@ -124,14 +129,16 @@ export const designTokens = css`
        error state (e.g. the dropdown popup) reference --focus-muted
        / --focus-halo directly to skip that override. */
     --focus: rgb(var(--focus-rgb, 91, 156, 229));
-    --focus-50: color-mix(in srgb, var(--focus) 12%, white);
-    --focus-100: color-mix(in srgb, var(--focus) 24%, white);
-    --focus-200: color-mix(in srgb, var(--focus) 40%, white);
-    --focus-300: color-mix(in srgb, var(--focus) 60%, white);
-    --focus-600: color-mix(in srgb, var(--focus) 60%, black);
-    --focus-700: color-mix(in srgb, var(--focus) 45%, black);
-    --focus-muted: color-mix(in srgb, var(--focus) 60%, white);
-    --focus-halo: 0 0 0 3px color-mix(in srgb, var(--focus) 30%, transparent);
+    /* Static values pre-mixed from the default focus hue for browsers
+       without color-mix(); re-derived in the @supports block below. */
+    --focus-50: #ebf3fc;
+    --focus-100: #d8e7f9;
+    --focus-200: #bdd7f5;
+    --focus-300: #9dc4ef;
+    --focus-600: #375e89;
+    --focus-700: #294667;
+    --focus-muted: #9dc4ef;
+    --focus-halo: 0 0 0 3px rgba(91, 156, 229, 0.3);
     --color-focus: var(--focus-muted);
     --widget-box-shadow-focused: var(--focus-halo);
 
@@ -159,5 +166,35 @@ export const designTokens = css`
     --temba-select-selected-line-height: 1.4;
     --temba-select-selected-font-size: 13.5px;
     --temba-select-min-height: var(--input-h);
+  }
+
+  /* Where color-mix() is supported, derive the accent / focus ramps
+     from their anchors so host pages can re-theme by overriding just
+     --primary-rgb / --focus-rgb. Browsers without color-mix() keep the
+     static pre-mixed values above. Note the static values can't act as
+     per-declaration fallbacks — a custom property is never invalid at
+     parse time, so the last declaration always wins — hence the
+     @supports gate. */
+  @supports (color: color-mix(in srgb, red, red)) {
+    :host {
+      --accent-50: color-mix(in srgb, var(--accent) 6%, white);
+      --accent-100: color-mix(in srgb, var(--accent) 16%, white);
+      --accent-200: color-mix(in srgb, var(--accent) 32%, white);
+      --accent-300: color-mix(in srgb, var(--accent) 60%, white);
+      --accent-500: color-mix(in srgb, var(--accent) 90%, black);
+      --accent-600: color-mix(in srgb, var(--accent) 80%, black);
+      --accent-700: color-mix(in srgb, var(--accent) 65%, black);
+      --accent-800: color-mix(in srgb, var(--accent) 50%, black);
+      --accent-900: color-mix(in srgb, var(--accent) 35%, black);
+
+      --focus-50: color-mix(in srgb, var(--focus) 12%, white);
+      --focus-100: color-mix(in srgb, var(--focus) 24%, white);
+      --focus-200: color-mix(in srgb, var(--focus) 40%, white);
+      --focus-300: color-mix(in srgb, var(--focus) 60%, white);
+      --focus-600: color-mix(in srgb, var(--focus) 60%, black);
+      --focus-700: color-mix(in srgb, var(--focus) 45%, black);
+      --focus-muted: color-mix(in srgb, var(--focus) 60%, white);
+      --focus-halo: 0 0 0 3px color-mix(in srgb, var(--focus) 30%, transparent);
+    }
   }
 `;

--- a/src/styles/designTokens.ts
+++ b/src/styles/designTokens.ts
@@ -138,7 +138,10 @@ export const designTokens = css`
     --focus-600: #375e89;
     --focus-700: #294667;
     --focus-muted: #9dc4ef;
-    --focus-halo: 0 0 0 3px rgba(91, 156, 229, 0.3);
+    /* The halo is a translucent wash, so unlike the opaque ramp steps
+       it can keep tracking the theme without color-mix() — rgba(var())
+       substitution works wherever custom properties do. */
+    --focus-halo: 0 0 0 3px rgba(var(--focus-rgb, 91, 156, 229), 0.3);
     --color-focus: var(--focus-muted);
     --widget-box-shadow-focused: var(--focus-halo);
 

--- a/src/styles/pillVariants.ts
+++ b/src/styles/pillVariants.ts
@@ -100,10 +100,14 @@ export const pillVariants = css`
     border-color: var(--pill-border, var(--border));
     --icon-color: var(--text-2);
   }
+  /* Anchor-derived variants carry static pre-mixed bg/border values
+     for browsers without color-mix() (pre-Chrome 111); the @supports
+     block at the bottom re-derives them from the anchors so host
+     re-theming still works where color-mix() is available. */
   .pill-flow {
-    background: color-mix(in srgb, var(--flow) 12%, white);
+    background: #e3f4e9;
     color: var(--flow);
-    border-color: color-mix(in srgb, var(--flow) 25%, white);
+    border-color: #c5e8d2;
     --icon-color: var(--flow);
   }
   /* Recipient color — shared by contacts and groups. Anchored to
@@ -111,27 +115,27 @@ export const pillVariants = css`
      identity even when the host page re-themes via --primary-rgb. */
   .pill-contact,
   .pill-group {
-    background: color-mix(in srgb, var(--recipient) 12%, white);
+    background: #e5eef6;
     color: var(--recipient);
-    border-color: color-mix(in srgb, var(--recipient) 25%, white);
+    border-color: #cadbec;
     --icon-color: var(--recipient);
   }
   .pill-channel {
-    background: color-mix(in srgb, var(--channel) 12%, white);
+    background: #ede4f5;
     color: var(--channel);
-    border-color: color-mix(in srgb, var(--channel) 25%, white);
+    border-color: #dac8e9;
     --icon-color: var(--channel);
   }
   .pill-topic {
-    background: color-mix(in srgb, var(--topic) 12%, white);
+    background: #faefe1;
     color: var(--topic);
-    border-color: color-mix(in srgb, var(--topic) 25%, white);
+    border-color: #f6ddc1;
     --icon-color: var(--topic);
   }
   .pill-campaign {
-    background: color-mix(in srgb, var(--campaign) 12%, white);
+    background: #e1f2f6;
     color: var(--campaign);
-    border-color: color-mix(in srgb, var(--campaign) 25%, white);
+    border-color: #c1e4ec;
     --icon-color: var(--campaign);
   }
   .pill-field {
@@ -170,5 +174,33 @@ export const pillVariants = css`
     color: var(--text-2);
     border-color: var(--pill-border, var(--border));
     --icon-color: var(--text-2);
+  }
+
+  /* Anchor-derived bg/border for browsers with color-mix(). These
+     can't be simple same-rule fallbacks: a declaration containing
+     var() isn't dropped at parse time, it goes invalid at
+     computed-value time and takes the earlier declaration with it. */
+  @supports (color: color-mix(in srgb, red, red)) {
+    .pill-flow {
+      background: color-mix(in srgb, var(--flow) 12%, white);
+      border-color: color-mix(in srgb, var(--flow) 25%, white);
+    }
+    .pill-contact,
+    .pill-group {
+      background: color-mix(in srgb, var(--recipient) 12%, white);
+      border-color: color-mix(in srgb, var(--recipient) 25%, white);
+    }
+    .pill-channel {
+      background: color-mix(in srgb, var(--channel) 12%, white);
+      border-color: color-mix(in srgb, var(--channel) 25%, white);
+    }
+    .pill-topic {
+      background: color-mix(in srgb, var(--topic) 12%, white);
+      border-color: color-mix(in srgb, var(--topic) 25%, white);
+    }
+    .pill-campaign {
+      background: color-mix(in srgb, var(--campaign) 12%, white);
+      border-color: color-mix(in srgb, var(--campaign) 25%, white);
+    }
   }
 `;

--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -20,18 +20,22 @@
   --primary-rgb: 73, 127, 206;
 
   /* accent ramp — derived from --primary-rgb via sRGB mixing.
-     400 == primary; the ramp computes outward in both directions. */
+     400 == primary; the ramp computes outward in both directions.
+     Static values pre-mixed from the default anchor come first for
+     browsers without color-mix() (pre-Chrome 111); the @supports
+     block below re-derives them from --accent so re-theming via
+     --primary-rgb still works where color-mix() is available. */
   --accent:      rgb(var(--primary-rgb));
-  --accent-50:   color-mix(in srgb, var(--accent) 6%,  white);
-  --accent-100:  color-mix(in srgb, var(--accent) 16%, white);
-  --accent-200:  color-mix(in srgb, var(--accent) 32%, white);
-  --accent-300:  color-mix(in srgb, var(--accent) 60%, white);
+  --accent-50:   #f4f7fc;
+  --accent-100:  #e2ebf7;
+  --accent-200:  #c5d6ef;
+  --accent-300:  #92b2e2;
   --accent-400:  var(--accent);
-  --accent-500:  color-mix(in srgb, var(--accent) 90%, black);
-  --accent-600:  color-mix(in srgb, var(--accent) 80%, black);
-  --accent-700:  color-mix(in srgb, var(--accent) 65%, black);
-  --accent-800:  color-mix(in srgb, var(--accent) 50%, black);
-  --accent-900:  color-mix(in srgb, var(--accent) 35%, black);
+  --accent-500:  #4272b9;
+  --accent-600:  #3a66a5;
+  --accent-700:  #2f5386;
+  --accent-800:  #244067;
+  --accent-900:  #1a2c48;
 
   /* neutrals */
   --bg:            #F6F7F9;
@@ -92,6 +96,24 @@
   --rail-w:               56px;
   --section-w:            248px;
   --section-w-collapsed:  56px;
+}
+
+/* Where color-mix() is supported, derive the accent ramp from --accent
+   so re-theming via --primary-rgb works without design-system.js.
+   Custom properties can't fall back per-declaration (they're never
+   invalid at parse time), hence the @supports gate. */
+@supports (color: color-mix(in srgb, red, red)) {
+  :root {
+    --accent-50:  color-mix(in srgb, var(--accent) 6%,  white);
+    --accent-100: color-mix(in srgb, var(--accent) 16%, white);
+    --accent-200: color-mix(in srgb, var(--accent) 32%, white);
+    --accent-300: color-mix(in srgb, var(--accent) 60%, white);
+    --accent-500: color-mix(in srgb, var(--accent) 90%, black);
+    --accent-600: color-mix(in srgb, var(--accent) 80%, black);
+    --accent-700: color-mix(in srgb, var(--accent) 65%, black);
+    --accent-800: color-mix(in srgb, var(--accent) 50%, black);
+    --accent-900: color-mix(in srgb, var(--accent) 35%, black);
+  }
 }
 
 /* ─── base ───────────────────────────────────────────────────────────── */
@@ -364,7 +386,13 @@
   color: white;
 }
 .ds .btn-danger:hover {
-  background: color-mix(in srgb, var(--danger) 88%, black);
+  /* pre-mixed fallback for browsers without color-mix() */
+  background: #b73737;
+}
+@supports (color: color-mix(in srgb, red, red)) {
+  .ds .btn-danger:hover {
+    background: color-mix(in srgb, var(--danger) 88%, black);
+  }
 }
 .ds .btn.is-disabled,
 .ds .btn:disabled { opacity: 0.45; cursor: not-allowed; }
@@ -533,7 +561,14 @@
 .ds .input:focus-within {
   outline: 0;
   border-color: var(--accent-300);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+  /* translucent-ring fallback for browsers without color-mix() */
+  box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.25);
+}
+@supports (color: color-mix(in srgb, red, red)) {
+  .ds .input:focus,
+  .ds .input:focus-within {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+  }
 }
 
 .ds .input-tokens {

--- a/static/css/temba-components.css
+++ b/static/css/temba-components.css
@@ -50,7 +50,10 @@
     --focus-600: #375e89;
     --focus-700: #294667;
     --focus-muted: #9dc4ef;
-    --focus-halo: 0 0 0 3px rgba(91, 156, 229, 0.3);
+    /* The halo is a translucent wash, so unlike the opaque ramp steps
+       it can keep tracking the theme without color-mix() — rgba(var())
+       substitution works wherever custom properties do. */
+    --focus-halo: 0 0 0 3px rgba(var(--focus-rgb, 91, 156, 229), 0.3);
     --color-focus: #a4cafe;
     --color-widget-bg: #fff;
     --color-widget-bg-focused: #fff;

--- a/static/css/temba-components.css
+++ b/static/css/temba-components.css
@@ -41,15 +41,16 @@
     --curvature: 6px;
     --curvature-widget: 6px;
     --focus: rgb(var(--focus-rgb, 91, 156, 229));
-    --focus-50: color-mix(in srgb, var(--focus) 12%, white);
-    --focus-100: color-mix(in srgb, var(--focus) 24%, white);
-    --focus-200: color-mix(in srgb, var(--focus) 40%, white);
-    --focus-300: color-mix(in srgb, var(--focus) 60%, white);
-    --focus-600: color-mix(in srgb, var(--focus) 60%, black);
-    --focus-700: color-mix(in srgb, var(--focus) 45%, black);
-    --focus-muted: color-mix(in srgb, var(--focus) 60%, white);
-    --focus-halo: 0 0 0 3px
-      color-mix(in srgb, var(--focus) 30%, transparent);
+    /* Static values pre-mixed from the default focus hue for browsers
+       without color-mix(); re-derived in the @supports block below. */
+    --focus-50: #ebf3fc;
+    --focus-100: #d8e7f9;
+    --focus-200: #bdd7f5;
+    --focus-300: #9dc4ef;
+    --focus-600: #375e89;
+    --focus-700: #294667;
+    --focus-muted: #9dc4ef;
+    --focus-halo: 0 0 0 3px rgba(91, 156, 229, 0.3);
     --color-focus: #a4cafe;
     --color-widget-bg: #fff;
     --color-widget-bg-focused: #fff;
@@ -199,6 +200,24 @@
 
     --color-automated: rgb(78, 205, 106);
 
+  }
+
+  /* Where color-mix() is supported, derive the focus ramp from --focus
+     so re-theming via --focus-rgb works. Custom properties can't fall
+     back per-declaration (they're never invalid at parse time), hence
+     the @supports gate. */
+  @supports (color: color-mix(in srgb, red, red)) {
+    html {
+      --focus-50: color-mix(in srgb, var(--focus) 12%, white);
+      --focus-100: color-mix(in srgb, var(--focus) 24%, white);
+      --focus-200: color-mix(in srgb, var(--focus) 40%, white);
+      --focus-300: color-mix(in srgb, var(--focus) 60%, white);
+      --focus-600: color-mix(in srgb, var(--focus) 60%, black);
+      --focus-700: color-mix(in srgb, var(--focus) 45%, black);
+      --focus-muted: color-mix(in srgb, var(--focus) 60%, white);
+      --focus-halo: 0 0 0 3px
+        color-mix(in srgb, var(--focus) 30%, transparent);
+    }
   }
 
   temba-button {


### PR DESCRIPTION
Chat message bubbles rendered with no background — and outgoing bubbles with invisible white-on-white text — on browsers without `color-mix()` support (pre-Chrome 111, e.g. the last Chrome available on Windows 7/8.1). The bubble fills introduced in #1074 build their gradients and borders from `color-mix()`, and an unsupported declaration is dropped entirely, with no fallback left behind.

## What changed

Every `color-mix()` usage now degrades gracefully:

- **Chat bubbles** get flat fills from the same theme vars (`--color-chat-in` / `--color-chat-out`) and pre-mixed hairline borders as base declarations, with the gradient versions gated behind `@supports (color: color-mix(in srgb, red, red))`.
- **Design token ramps** (`--accent-*`, `--focus-*` in `designTokens.ts` and the static CSS mirrors) carry static values pre-mixed from the default anchors, re-derived from `--primary-rgb` / `--focus-rgb` inside the `@supports` block so host re-theming keeps working where supported.
- **Pill variants, tinted dots, hover washes and focus halos** (pillVariants, ContactChat, ContactTimeline, CampaignEvents, ContentList, BroadcastList, FieldList, Button, Label, Select, RangePicker) follow the same pattern, falling back to pre-mixed statics, plain surface fills, or `rgba()` washes.

## Why `@supports` rather than double declarations

Two CSS parsing rules make the classic fallback-line approach insufficient here (now noted in comments where relevant):

- A declaration containing `var()` is not dropped at parse time — it goes invalid at *computed-value* time, which discards the property entirely, including any earlier fallback declaration in the same rule.
- Custom property definitions are never invalid at parse time, so a later `--token: color-mix(...)` always wins over an earlier static definition.

Only literal-only mixes (e.g. the note bubble's yellow gradient) use the plain preceding-declaration fallback.

## Notes for reviewers

- On browsers with `color-mix()` support, rendering is unchanged — the full test suite including screenshot comparisons passes.
- Static fallback values were computed from the default token anchors, so themed deployments fall back to default-hue tints on old browsers rather than their brand hue — a deliberate trade-off to keep the fallbacks static.