### PR TITLE
Ignore stray .pnpm-store directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ run.sh
 /node_modules
 /npm-debug.log
 
+## stray local store left behind by pnpm runs (pre-bun tooling)
+/.pnpm-store/
+
 ## testing
 /coverage/
 /screenshots/test


### PR DESCRIPTION
The pre-bun pnpm tooling could leave a local `.pnpm-store/` behind when run against a mounted checkout. #1050's companion cleanup added it to `.npmignore` but never to `.gitignore`, so the directory lingers as untracked noise in working copies. Ignore it — the repo's dependency management is bun-only since #1050, so nothing legitimate writes it anymore.