### PR TITLE
1/4 Own listener teardown in RapidElement and stop compiling on every dispatch

### DIFF
--- a/src/RapidElement.ts
+++ b/src/RapidElement.ts
@@ -40,6 +40,34 @@ export interface EventHandler {
   isWindow?: boolean;
 }
 
+/**
+ * Inline handlers compiled from an element's -<event-type> attribute, keyed
+ * by their source. Page authors write a finite set of these, so compiling
+ * each one once keeps dispatch off the Function constructor entirely.
+ */
+const inlineHandlers = new Map<string, (event: Event) => any>();
+
+const compileInlineHandler = (source: string): ((event: Event) => any) => {
+  let compiled = inlineHandlers.get(source);
+  if (!compiled) {
+    compiled = new Function(
+      'event',
+      `
+        with(document) {
+          with(this) {
+            let handler = ${source};
+            if(typeof handler === 'function') {
+              handler(event);
+            }
+          }
+        }
+      `
+    ) as (event: Event) => any;
+    inlineHandlers.set(source, compiled);
+  }
+  return compiled;
+};
+
 export class RapidElement extends LitElement {
   DEBUG = false;
   DEBUG_UPDATES = false;
@@ -49,34 +77,50 @@ export class RapidElement extends LitElement {
   service: string;
 
   private eles: { [selector: string]: HTMLDivElement } = {};
+
+  // teardowns for the listeners we installed, so disconnecting removes the
+  // exact functions we added
+  private listenerTeardowns: (() => void)[] = [];
+
   public getEventHandlers(): EventHandler[] {
     return [];
+  }
+
+  /**
+   * Adds a listener this element owns the teardown for - it is bound to this
+   * element and removed automatically when we disconnect. Use this instead of
+   * addEventListener for anything on document or window, where a listener
+   * that outlives its element keeps the whole element alive.
+   */
+  public listenTo(
+    target: EventTarget,
+    event: string,
+    method: EventListener,
+    options?: AddEventListenerOptions
+  ): void {
+    const bound = method.bind(this);
+    target.addEventListener(event, bound, options);
+    this.listenerTeardowns.push(() =>
+      target.removeEventListener(event, bound, options)
+    );
   }
 
   connectedCallback() {
     super.connectedCallback();
 
     for (const handler of this.getEventHandlers()) {
-      if (handler.isDocument) {
-        document.addEventListener(handler.event, handler.method.bind(this));
-      } else if (handler.isWindow) {
-        window.addEventListener(handler.event, handler.method.bind(this));
-      } else {
-        this.addEventListener(handler.event, handler.method.bind(this));
-      }
+      const target = handler.isDocument
+        ? document
+        : handler.isWindow
+          ? window
+          : this;
+      this.listenTo(target, handler.event, handler.method);
     }
   }
 
   disconnectedCallback() {
-    for (const handler of this.getEventHandlers()) {
-      if (handler.isDocument) {
-        document.removeEventListener(handler.event, handler.method);
-      } else if (handler.isWindow) {
-        window.removeEventListener(handler.event, handler.method);
-      } else {
-        this.removeEventListener(handler.event, handler.method);
-      }
-    }
+    this.listenerTeardowns.forEach((teardown) => teardown());
+    this.listenerTeardowns = [];
     super.disconnectedCallback();
   }
 
@@ -121,9 +165,7 @@ export class RapidElement extends LitElement {
   }
 
   public fireCustomEvent(type: CustomEventType, detail: any = {}): any {
-    if (this['DEBUG_EVENTS']) {
-      showEvent(this, type, detail);
-    }
+    showEvent(this, type, detail);
 
     const event = new CustomEvent(type, {
       detail,
@@ -135,30 +177,26 @@ export class RapidElement extends LitElement {
   }
 
   public dispatchEvent(event: any): any {
-    super.dispatchEvent(event);
+    const dispatched = super.dispatchEvent(event);
+
+    // the page can hang a handler off the target for any of our events, as a
+    // -<event-type> property or an attribute of the same name
     const ele = event.target;
-    if (ele) {
-      // lookup events with - prefix and try to invoke them
-      const eventFire = (ele as any)['-' + event.type];
-      if (eventFire) {
-        return eventFire(event);
-      } else {
-        const func = new Function(
-          'event',
-          `
-          with(document) {
-            with(this) {
-              let handler = ${ele.getAttribute('-' + event.type)};
-              if(typeof handler === 'function') { 
-                handler(event);
-              }
-            }
-          }
-        `
-        );
-        return func.call(ele, event);
-      }
+    if (!ele) {
+      return dispatched;
     }
+
+    const eventFire = (ele as any)['-' + event.type];
+    if (eventFire) {
+      return eventFire(event);
+    }
+
+    const inline = ele.getAttribute ? ele.getAttribute('-' + event.type) : null;
+    if (!inline) {
+      return dispatched;
+    }
+
+    return compileInlineHandler(inline).call(ele, event);
   }
 
   public closestElement(selector: string, base: Element = this) {

--- a/src/RapidElement.ts
+++ b/src/RapidElement.ts
@@ -196,7 +196,11 @@ export class RapidElement extends LitElement {
       return dispatched;
     }
 
-    return compileInlineHandler(inline).call(ele, event);
+    // the compiled handler has no return value of its own, so handing its
+    // undefined back would read as a cancelled event - what the caller wants
+    // to know is whether anything called preventDefault
+    compileInlineHandler(inline).call(ele, event);
+    return dispatched;
   }
 
   public closestElement(selector: string, base: Element = this) {

--- a/test/temba-rapid-element.test.ts
+++ b/test/temba-rapid-element.test.ts
@@ -508,6 +508,28 @@ describe('RapidElement', () => {
       delete (window as any).inlineAttrHandler;
     });
 
+    it('reports the dispatch as uncancelled once the handler has run', () => {
+      let ran = false;
+      (window as any).inlineAttrHandler = () => {
+        ran = true;
+      };
+
+      const host = document.createElement('div');
+      host.innerHTML = `<div -inline-attr-event="inlineAttrHandler"></div>`;
+      const target = host.firstElementChild;
+
+      const event = new CustomEvent('inline-attr-event');
+      Object.defineProperty(event, 'target', { value: target });
+
+      // the compiled handler returns nothing of its own, so handing that back
+      // would read as a cancelled event
+      const result = element.dispatchEvent(event);
+
+      expect(ran).to.equal(true);
+      expect(result).to.equal(true);
+      delete (window as any).inlineAttrHandler;
+    });
+
     it('does not compile anything when the target has no attribute', () => {
       const target = document.createElement('div');
       const compile = stub(window, 'Function' as any);

--- a/test/temba-rapid-element.test.ts
+++ b/test/temba-rapid-element.test.ts
@@ -337,5 +337,187 @@ describe('RapidElement', () => {
 
       document.body.removeChild(elementWithHandlers);
     });
+
+    it('stops listening on document and window once disconnected', async () => {
+      const counts = { doc: 0, win: 0, self: 0 };
+
+      class TeardownElement extends RapidElement {
+        getEventHandlers() {
+          return [
+            { event: 'teardown-self', method: () => counts.self++ },
+            {
+              event: 'teardown-doc',
+              method: () => counts.doc++,
+              isDocument: true
+            },
+            {
+              event: 'teardown-win',
+              method: () => counts.win++,
+              isWindow: true
+            }
+          ];
+        }
+      }
+      customElements.define('test-teardown-element', TeardownElement);
+
+      const ele: TeardownElement = await fixture(
+        html`<test-teardown-element></test-teardown-element>`
+      );
+
+      document.dispatchEvent(new Event('teardown-doc'));
+      window.dispatchEvent(new Event('teardown-win'));
+      ele.dispatchEvent(new Event('teardown-self'));
+      expect(counts).to.deep.equal({ doc: 1, win: 1, self: 1 });
+
+      ele.remove();
+
+      document.dispatchEvent(new Event('teardown-doc'));
+      window.dispatchEvent(new Event('teardown-win'));
+      ele.dispatchEvent(new Event('teardown-self'));
+      expect(counts).to.deep.equal({ doc: 1, win: 1, self: 1 });
+    });
+
+    it('reinstalls handlers when reconnected', async () => {
+      let calls = 0;
+
+      class ReconnectElement extends RapidElement {
+        getEventHandlers() {
+          return [
+            {
+              event: 'reconnect-doc',
+              method: () => calls++,
+              isDocument: true
+            }
+          ];
+        }
+      }
+      customElements.define('test-reconnect-element', ReconnectElement);
+
+      const ele: ReconnectElement = await fixture(
+        html`<test-reconnect-element></test-reconnect-element>`
+      );
+      const parent = ele.parentElement;
+
+      ele.remove();
+      parent.appendChild(ele);
+
+      // exactly one live listener - the first registration was torn down
+      document.dispatchEvent(new Event('reconnect-doc'));
+      expect(calls).to.equal(1);
+
+      ele.remove();
+      document.dispatchEvent(new Event('reconnect-doc'));
+      expect(calls).to.equal(1);
+    });
+
+    it('binds handlers to the element', async () => {
+      class BindingElement extends RapidElement {
+        public seen: any = null;
+
+        public handleBound() {
+          this.seen = this;
+        }
+
+        getEventHandlers() {
+          return [
+            {
+              event: 'binding-doc',
+              method: this.handleBound,
+              isDocument: true
+            }
+          ];
+        }
+      }
+      customElements.define('test-binding-element', BindingElement);
+
+      const ele: BindingElement = await fixture(
+        html`<test-binding-element></test-binding-element>`
+      );
+
+      document.dispatchEvent(new Event('binding-doc'));
+      expect(ele.seen).to.equal(ele);
+    });
+  });
+
+  describe('listenTo', () => {
+    it('removes what it added on disconnect', async () => {
+      let calls = 0;
+      const ele: TestRapidElement = await fixture(
+        html`<test-rapid-element></test-rapid-element>`
+      );
+
+      ele.listenTo(document, 'listen-to-doc', () => calls++);
+      document.dispatchEvent(new Event('listen-to-doc'));
+      expect(calls).to.equal(1);
+
+      ele.remove();
+      document.dispatchEvent(new Event('listen-to-doc'));
+      expect(calls).to.equal(1);
+    });
+
+    it('honors listener options', async () => {
+      let calls = 0;
+      const ele: TestRapidElement = await fixture(
+        html`<test-rapid-element></test-rapid-element>`
+      );
+
+      ele.listenTo(document, 'listen-to-once', () => calls++, { once: true });
+      document.dispatchEvent(new Event('listen-to-once'));
+      document.dispatchEvent(new Event('listen-to-once'));
+      expect(calls).to.equal(1);
+    });
+  });
+
+  describe('dispatchEvent return value', () => {
+    it('returns true for an uncancelled event', () => {
+      const result = element.dispatchEvent(
+        new CustomEvent('uncancelled-event', { cancelable: true })
+      );
+      expect(result).to.be.true;
+    });
+
+    it('returns false when a listener cancels the event', () => {
+      element.addEventListener('cancelled-event', (event: Event) =>
+        event.preventDefault()
+      );
+      const result = element.dispatchEvent(
+        new CustomEvent('cancelled-event', { cancelable: true })
+      );
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('inline -event attribute handlers', () => {
+    it('invokes the handler named by the attribute', () => {
+      let seen: Event = null;
+      (window as any).inlineAttrHandler = (event: Event) => {
+        seen = event;
+      };
+
+      // the - prefix is only legal through the html parser, which is how
+      // pages actually declare these
+      const host = document.createElement('div');
+      host.innerHTML = `<div -inline-attr-event="inlineAttrHandler"></div>`;
+      const target = host.firstElementChild;
+
+      const event = new CustomEvent('inline-attr-event');
+      Object.defineProperty(event, 'target', { value: target });
+      element.dispatchEvent(event);
+
+      expect(seen).to.equal(event);
+      delete (window as any).inlineAttrHandler;
+    });
+
+    it('does not compile anything when the target has no attribute', () => {
+      const target = document.createElement('div');
+      const compile = stub(window, 'Function' as any);
+
+      const event = new CustomEvent('no-inline-handler');
+      Object.defineProperty(event, 'target', { value: target });
+      element.dispatchEvent(event);
+
+      expect(compile.called).to.be.false;
+      compile.restore();
+    });
   });
 });


### PR DESCRIPTION
First of four stacked PRs from a pass over the socket/event/listener architecture. Merge in order.

### Listeners were never removed

`getEventHandlers()` added its listeners with `handler.method.bind(this)` and removed them with the unbound `handler.method`. `bind()` returns a new function, so `removeEventListener` never matched anything and no listener was ever torn down.

What that leaks today:

- every `temba-options` that connects leaves two permanent `document` listeners (`keydown`, `scroll`) holding a detached element and its shadow root alive — and selects are created and destroyed constantly in lists and dialogs
- every `ResizeElement` leaves a `window` resize listener; it's doubly broken there because `getEventHandlers()` returns `throttle(this.handleResize, 50)`, a fresh function on each call, so even the unbound identities differed

Behaviour survives only because `Options.handleKeyDown` bails on `offsetParent === null`. The comment at `Options.ts:636` about options "swallowing arrow keys document-wide" reads like this has already been felt once.

Listeners now go through `listenTo()`, which binds once, records the exact function it installed, and removes it on disconnect. `getEventHandlers()` stays as the declarative front end (it's public API, and downstream subclasses may override it) and `listenTo` is public for the ~15 files that currently hand-roll `boundX = this.x.bind(this)` pairs on document/window — migrating those is follow-up work, not this PR.

### A JS compile on every dispatched event

`dispatchEvent` built a `new Function` for every event, whether or not the target had a `-<event-type>` attribute — with no attribute, `getAttribute` returns `null` and the source still compiled as `let handler = null`. That put a full compile in the path of `CursorChanged` on mousemove and `Resized` during drags, and forced `unsafe-eval` on any page that wants a CSP.

It now checks for the attribute first and only compiles when one exists, memoized by source. The property form (`ele['-temba-x']`) is unchanged.

### dispatchEvent return value

The override returned the inline handler's return value instead of the boolean from `super.dispatchEvent`, so `if (!el.dispatchEvent(evt))` silently didn't work. Nothing in tree reads the return today (all 163 `fireCustomEvent` call sites checked), so fixing it is free now and wouldn't be later.

Also dropped a redundant `DEBUG_EVENTS` check in `fireCustomEvent` that made `DEBUG = true` log plain events but not custom ones.

### Testing

Full suite green (2737 passing). New coverage for: document/window teardown on disconnect, reinstall on reconnect, handler binding, `listenTo` teardown and listener options, the `dispatchEvent` boolean in both directions, inline attribute handlers still firing, and no compile happening when the target has no attribute.