### PR TITLE
2/4 Give the central watcher the contact chat's history channel

### DIFF
--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -49,6 +49,7 @@ import {
 } from '../events/eventRenderers';
 import { publishToSocket } from './SocketService';
 import { subscribeToContactHistory, RealtimeSubscription } from './Realtime';
+import { applyContactEvent, watchContact } from './ContactWatch';
 import { Icon } from '../Icons';
 import { designTokens } from '../styles/designTokens';
 import { DateTime } from 'luxon';
@@ -835,13 +836,24 @@ export class ContactChat extends ContactStoreElement {
       if (!this.subscriptions.has(key)) {
         this.subscriptions.set(
           key,
-          subscribeToContactHistory(
-            topic.contact,
-            topic.ticket,
-            (data: any) => this.handleSocketEvent(data),
-            // on every (re)subscribe fetch anything we might have missed
-            () => this.fetchMissedEvents()
-          )
+          // the contact's own channel is owned by the central watcher, which
+          // every other contact component on the page shares - we take it as
+          // a stream and keep rendering history ourselves. Ticket detail
+          // events aren't contact state and stay a direct subscription
+          topic.ticket
+            ? subscribeToContactHistory(
+                topic.contact,
+                topic.ticket,
+                (data: any) => this.handleSocketEvent(data),
+                // on every (re)subscribe fetch anything we might have missed
+                () => this.fetchMissedEvents()
+              )
+            : watchContact(
+                topic.contact,
+                '*',
+                (event: any) => this.handleSocketEvent(event),
+                () => this.fetchMissedEvents()
+              )
         );
       }
     });
@@ -882,26 +894,15 @@ export class ContactChat extends ContactStoreElement {
 
   /**
    * Ephemeral events that update contact state rather than record history.
-   * They are never persisted, so this is the only place they can be applied.
-   * The current contact is the store's cached copy of the contact, so
-   * updating it in place also keeps the cache fresh for later readers.
+   * They are never persisted, so applying them is the only way they show up.
+   * How each one applies is the central watcher's to define - we just run it
+   * against our copy, which is the store's cached contact, so applying it in
+   * place also keeps the cache fresh for later readers.
    */
   private handleContactStateEvent(
     event: ContactFlowChangedEvent | ContactLastSeenChangedEvent
   ) {
-    const contact = this.currentContact;
-    if (event.type === Events.CONTACT_LAST_SEEN_CHANGED) {
-      const lastSeenOn = (event as ContactLastSeenChangedEvent).last_seen_on;
-      // last seen only ever moves forward - ignore out of order deliveries
-      if (
-        !contact.last_seen_on ||
-        new Date(lastSeenOn) > new Date(contact.last_seen_on)
-      ) {
-        contact.last_seen_on = lastSeenOn;
-      }
-    } else {
-      contact.flow = (event as ContactFlowChangedEvent).flow || null;
-    }
+    applyContactEvent(this.currentContact, event);
     this.requestUpdate();
   }
 

--- a/src/live/ContactWatch.ts
+++ b/src/live/ContactWatch.ts
@@ -28,7 +28,12 @@ import { RealtimeSubscription, subscribeToContactHistory } from './Realtime';
  * unsubscribes the socket subscription and cached contact are dropped.
  *
  * Wildcard watchers are event-stream consumers (e.g. chat renders history) -
- * they get every live event but no eventless deliveries.
+ * they get every live event but no eventless deliveries, and an entry with
+ * only those holds no contact and fetches nothing. They keep their own copy
+ * instead, applying events to it with applyContactEvent so how an event
+ * changes a contact is still defined in one place. Any watcher can pass
+ * onSubscribed to be told when the channel goes live, which is where a
+ * stream consumer catches up on what it missed while offline.
  */
 
 // same shape components previously fetched themselves - urns are expanded and
@@ -65,6 +70,7 @@ export type ContactEventHandler = (event: any, contact: Contact) => void;
 interface Watcher {
   types: string[] | '*';
   onEvent: ContactEventHandler;
+  onSubscribed?: () => void;
 }
 
 interface WatchedContact {
@@ -76,6 +82,9 @@ interface WatchedContact {
   // events landing while one is outstanding need a refetch to survive
   fetching: number;
   refetchTimer: number;
+  // whether the channel is live, so watchers joining an already-subscribed
+  // channel still get their initial catch-up call
+  subscribed: boolean;
 }
 
 const watched = new Map<string, WatchedContact>();
@@ -170,6 +179,33 @@ const refetchTypes = new Set<string>([Events.CONTACT_URNS_CHANGED]);
 
 const matches = (watcher: Watcher, type: string): boolean => {
   return watcher.types === '*' || watcher.types.includes(type);
+};
+
+/**
+ * Whether anyone is watching this contact's *state*. Wildcard watchers are
+ * stream consumers - they take the events and keep their own view of the
+ * contact - so an entry with only those has no contact to hold current and
+ * nothing to fetch.
+ */
+const needsContact = (entry: WatchedContact): boolean => {
+  return entry.watchers.some((watcher) => watcher.types !== '*');
+};
+
+/**
+ * Applies a live contact event to a contact, the same way the registry
+ * applies it to the one it holds. Exposed for stream consumers that keep
+ * their own copy, so how an event changes a contact is defined once.
+ * Returns false when the event couldn't be applied.
+ */
+export const applyContactEvent = (
+  contact: Contact,
+  event: any
+): boolean | void => {
+  const apply = appliers[event.type];
+  if (!contact || !apply) {
+    return;
+  }
+  return apply(contact, event);
 };
 
 // watchers are page components we don't control - one of them throwing can't
@@ -294,11 +330,14 @@ const handleEvent = (uuid: string, entry: WatchedContact, event: any) => {
   // was no snapshot to patch, a fetch that predates the event is still in
   // flight, or the applier couldn't resolve what it needed. Scheduling ahead
   // of the fan-out keeps a throwing watcher from costing us the refetch, and
-  // the debounce collapses a burst into a single fetch
-  const stale =
-    !!apply && (!entry.contact || entry.fetching > 0 || applied === false);
-  if (stale || refetchTypes.has(event.type)) {
-    scheduleRefetch(uuid, entry);
+  // the debounce collapses a burst into a single fetch. Entries nobody needs
+  // a contact from have nothing to keep current
+  if (needsContact(entry)) {
+    const stale =
+      !!apply && (!entry.contact || entry.fetching > 0 || applied === false);
+    if (stale || refetchTypes.has(event.type)) {
+      scheduleRefetch(uuid, entry);
+    }
   }
 
   for (const watcher of [...entry.watchers]) {
@@ -308,20 +347,52 @@ const handleEvent = (uuid: string, entry: WatchedContact, event: any) => {
   }
 };
 
+/**
+ * A (re)subscribe on the contact's channel. Watchers that render contact
+ * state get a fresh fetch; every watcher that asked for it gets told, so
+ * stream consumers can fetch whatever they missed while we were away.
+ */
+const handleSubscribed = (uuid: string, entry: WatchedContact) => {
+  entry.subscribed = true;
+  if (needsContact(entry)) {
+    fetchContact(uuid, entry);
+  }
+  for (const watcher of [...entry.watchers]) {
+    notifySubscribed(watcher);
+  }
+};
+
+const notifySubscribed = (watcher: Watcher) => {
+  if (!watcher.onSubscribed) {
+    return;
+  }
+  try {
+    watcher.onSubscribed();
+  } catch (error) {
+    console.error('contact watcher failed', error);
+  }
+};
+
 export const watchContact = (
   uuid: string,
   types: string[] | '*',
-  onEvent: ContactEventHandler
+  onEvent: ContactEventHandler,
+  onSubscribed?: () => void
 ): RealtimeSubscription => {
-  let entry = watched.get(uuid);
+  const entry = watched.get(uuid);
+  const watcher: Watcher = { types, onEvent, onSubscribed };
+
   if (!entry) {
     const newEntry: WatchedContact = {
-      watchers: [],
+      // registered before we subscribe so the first (re)subscribe already
+      // knows whether anyone needs a contact held for them
+      watchers: [watcher],
       sub: null,
       contact: null,
       fetchSeq: 0,
       fetching: 0,
-      refetchTimer: null
+      refetchTimer: null,
+      subscribed: false
     };
     watched.set(uuid, newEntry);
     newEntry.sub = subscribeToContactHistory(
@@ -330,13 +401,19 @@ export const watchContact = (
       (event) => handleEvent(uuid, newEntry, event),
       // fires on every (re)subscribe incl. after reconnects - (re)fetch so
       // watchers see anything that changed while we weren't listening
-      () => fetchContact(uuid, newEntry)
+      () => handleSubscribed(uuid, newEntry)
     );
-    entry = newEntry;
+    return unwatch(uuid, newEntry, watcher);
   }
 
-  const watcher: Watcher = { types, onEvent };
   entry.watchers.push(watcher);
+
+  // a watcher that renders contact state joining an entry that was holding
+  // none (only stream consumers so far) needs one fetched for it. On a
+  // channel that isn't live yet the pending (re)subscribe covers it
+  if (types !== '*' && entry.subscribed && !entry.contact && !entry.fetching) {
+    fetchContact(uuid, entry);
+  }
 
   // late joiners on an already-fetched contact get their initial delivery
   // without waiting for another fetch - async so it mirrors the fetch path
@@ -349,19 +426,35 @@ export const watchContact = (
     });
   }
 
-  return {
-    unsubscribe: () => {
-      const index = entry.watchers.indexOf(watcher);
-      if (index < 0) {
-        return;
+  // and joiners on an already-live channel get their initial catch-up call,
+  // which they'd otherwise wait for a reconnect to see
+  if (entry.subscribed && onSubscribed) {
+    Promise.resolve().then(() => {
+      if (entry.watchers.includes(watcher)) {
+        notifySubscribed(watcher);
       }
-      entry.watchers.splice(index, 1);
-      if (entry.watchers.length === 0) {
-        dropEntry(uuid, entry);
-      }
-    }
-  };
+    });
+  }
+
+  return unwatch(uuid, entry, watcher);
 };
+
+const unwatch = (
+  uuid: string,
+  entry: WatchedContact,
+  watcher: Watcher
+): RealtimeSubscription => ({
+  unsubscribe: () => {
+    const index = entry.watchers.indexOf(watcher);
+    if (index < 0) {
+      return;
+    }
+    entry.watchers.splice(index, 1);
+    if (entry.watchers.length === 0) {
+      dropEntry(uuid, entry);
+    }
+  }
+});
 
 /**
  * Pushes a fresh copy of a contact into the registry, priming its watchers.

--- a/src/live/ContactWatch.ts
+++ b/src/live/ContactWatch.ts
@@ -452,6 +452,12 @@ const unwatch = (
     entry.watchers.splice(index, 1);
     if (entry.watchers.length === 0) {
       dropEntry(uuid, entry);
+    } else if (!needsContact(entry)) {
+      // only stream consumers left, and nothing keeps their contact current -
+      // holding onto this one would leave it drifting until a state watcher
+      // joined later and got primed with the drift
+      entry.contact = null;
+      clearRefetch(entry);
     }
   }
 });

--- a/test/temba-contact-watch.test.ts
+++ b/test/temba-contact-watch.test.ts
@@ -165,6 +165,42 @@ describe('ContactWatch', () => {
       assert.equal(delivered.name, 'Dave Matthews');
       assert.equal(contactFetches(getUrl).length, 1);
     });
+
+    it('fetches again for a state watcher joining after the last one left', async () => {
+      let subscribed = 0;
+      watchContact(
+        CONTACT,
+        '*',
+        () => undefined,
+        () => subscribed++
+      );
+      await waitForCondition(() => subscribed === 1);
+
+      let delivered: Contact = null;
+      const state = watchContact(
+        CONTACT,
+        CONTACT_STATE_TYPES,
+        (_event, contact) => {
+          delivered = contact;
+        }
+      );
+      await waitForCondition(() => !!delivered);
+      assert.equal(contactFetches(getUrl).length, 1);
+
+      // the details pane closes, but the chat's stream keeps the entry alive
+      state.unsubscribe();
+
+      // nothing holds that contact current any more, so a state watcher
+      // joining later has to fetch rather than be primed with what we last
+      // saw and stopped maintaining
+      let rejoined: Contact = null;
+      watchContact(CONTACT, CONTACT_STATE_TYPES, (_event, contact) => {
+        rejoined = contact;
+      });
+
+      await waitForCondition(() => !!rejoined);
+      assert.equal(contactFetches(getUrl).length, 2);
+    });
   });
 
   describe('applyContactEvent', () => {

--- a/test/temba-contact-watch.test.ts
+++ b/test/temba-contact-watch.test.ts
@@ -1,0 +1,219 @@
+import { assert } from '@open-wc/testing';
+import { spy } from 'sinon';
+import { Contact } from '../src/interfaces';
+import { Events } from '../src/events/eventRenderers';
+import {
+  applyContactEvent,
+  CONTACT_STATE_TYPES,
+  resetContactWatches,
+  watchContact
+} from '../src/live/ContactWatch';
+import { setSocketProvider, SocketProvider } from '../src/live/SocketService';
+import { getStore } from '../src/store/Store';
+import {
+  clearMockGets,
+  loadStore,
+  mockGET,
+  MockSocketProvider,
+  waitForCondition
+} from './utils.test';
+
+const CONTACT = 'contact-dave-active';
+const CHANNEL = `history:${CONTACT}`;
+
+// fetches the watcher made for the contact, ignoring everything else the
+// store pulls down
+const contactFetches = (getUrl: any) =>
+  getUrl.getCalls().filter((call: any) => call.args[0].includes(CONTACT));
+
+describe('ContactWatch', () => {
+  let mockSocket: MockSocketProvider;
+  let previousProvider: SocketProvider;
+  let getUrl: any;
+
+  beforeEach(async () => {
+    mockSocket = new MockSocketProvider();
+    previousProvider = setSocketProvider(mockSocket);
+    clearMockGets();
+    mockGET(
+      /\/api\/v2\/contacts\.json\?expand_urns=true&urn_order=priority&uuid=contact-dave-active/,
+      '/test-assets/contacts/contact-dave-active'
+    );
+    await loadStore();
+    getUrl = spy(getStore(), 'getUrl');
+  });
+
+  afterEach(() => {
+    getUrl.restore();
+    resetContactWatches();
+    setSocketProvider(previousProvider);
+  });
+
+  describe('onSubscribed', () => {
+    it('tells a watcher when the channel goes live', async () => {
+      let subscribed = 0;
+      watchContact(
+        CONTACT,
+        '*',
+        () => undefined,
+        () => subscribed++
+      );
+
+      await waitForCondition(() => subscribed === 1);
+      assert.deepEqual(mockSocket.activeChannels(), [CHANNEL]);
+    });
+
+    it('gives a late joiner its own catch-up call', async () => {
+      let first = 0;
+      watchContact(
+        CONTACT,
+        '*',
+        () => undefined,
+        () => first++
+      );
+      await waitForCondition(() => first === 1);
+
+      // joining an already-live channel would otherwise mean waiting for a
+      // reconnect to hear anything
+      let second = 0;
+      watchContact(
+        CONTACT,
+        '*',
+        () => undefined,
+        () => second++
+      );
+
+      await waitForCondition(() => second === 1);
+      assert.equal(first, 1, 'existing watcher should not be told again');
+    });
+
+    it('does not call it once unsubscribed', async () => {
+      let subscribed = 0;
+      const watch = watchContact(
+        CONTACT,
+        '*',
+        () => undefined,
+        () => subscribed++
+      );
+      watch.unsubscribe();
+
+      await waitForCondition(() => mockSocket.activeChannels().length === 0);
+      assert.equal(subscribed, 0);
+    });
+  });
+
+  describe('stream consumers', () => {
+    it('holds no contact and fetches nothing for wildcard watchers alone', async () => {
+      const events: any[] = [];
+      let subscribed = 0;
+      watchContact(
+        CONTACT,
+        '*',
+        (event) => events.push(event),
+        () => subscribed++
+      );
+      await waitForCondition(() => subscribed === 1);
+
+      // a state event that would normally keep a held contact current
+      mockSocket.serverPublish(CHANNEL, {
+        type: Events.CONTACT_NAME_CHANGED,
+        name: 'David J. Matthews'
+      });
+
+      // events still stream through, but nothing was fetched to apply them to
+      assert.equal(events.length, 1);
+      assert.deepEqual(contactFetches(getUrl), []);
+    });
+
+    it('does not refetch for a stream-only entry on a urn change', async () => {
+      let subscribed = 0;
+      watchContact(
+        CONTACT,
+        '*',
+        () => undefined,
+        () => subscribed++
+      );
+      await waitForCondition(() => subscribed === 1);
+
+      mockSocket.serverPublish(CHANNEL, {
+        type: Events.CONTACT_URNS_CHANGED,
+        urns: ['tel:+12065551212']
+      });
+
+      // the debounced refetch would have landed by now
+      await waitForCondition(() => true, 1, 200);
+      assert.deepEqual(contactFetches(getUrl), []);
+    });
+
+    it('fetches once a state watcher joins a stream-only entry', async () => {
+      let subscribed = 0;
+      watchContact(
+        CONTACT,
+        '*',
+        () => undefined,
+        () => subscribed++
+      );
+      await waitForCondition(() => subscribed === 1);
+      assert.deepEqual(contactFetches(getUrl), []);
+
+      let delivered: Contact = null;
+      watchContact(CONTACT, CONTACT_STATE_TYPES, (_event, contact) => {
+        delivered = contact;
+      });
+
+      await waitForCondition(() => !!delivered);
+      assert.equal(delivered.name, 'Dave Matthews');
+      assert.equal(contactFetches(getUrl).length, 1);
+    });
+  });
+
+  describe('applyContactEvent', () => {
+    it('applies a flow change', () => {
+      const contact = { flow: null } as Contact;
+      applyContactEvent(contact, {
+        type: Events.CONTACT_FLOW_CHANGED,
+        flow: { uuid: 'flow-1', name: 'Registration' }
+      });
+      assert.equal(contact.flow.name, 'Registration');
+
+      applyContactEvent(contact, {
+        type: Events.CONTACT_FLOW_CHANGED,
+        flow: null
+      });
+      assert.isNull(contact.flow);
+    });
+
+    it('only moves last seen forward', () => {
+      const contact = { last_seen_on: '2026-01-02T00:00:00Z' } as Contact;
+
+      applyContactEvent(contact, {
+        type: Events.CONTACT_LAST_SEEN_CHANGED,
+        last_seen_on: '2026-01-01T00:00:00Z'
+      });
+      assert.equal(contact.last_seen_on, '2026-01-02T00:00:00Z');
+
+      applyContactEvent(contact, {
+        type: Events.CONTACT_LAST_SEEN_CHANGED,
+        last_seen_on: '2026-01-03T00:00:00Z'
+      });
+      assert.equal(contact.last_seen_on, '2026-01-03T00:00:00Z');
+    });
+
+    it('ignores events it has no applier for', () => {
+      const contact = { name: 'Dave' } as Contact;
+      assert.isUndefined(
+        applyContactEvent(contact, { type: 'msg_created', msg: {} })
+      );
+      assert.equal(contact.name, 'Dave');
+    });
+
+    it('tolerates a missing contact', () => {
+      assert.isUndefined(
+        applyContactEvent(null, {
+          type: Events.CONTACT_NAME_CHANGED,
+          name: 'Dave'
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
Second of four stacked PRs. **Targets #1099** — merge that first.

### The duplication

`ContactChat` opted out of the central watcher (`watchTypes = null`, added in #1087) and ran its own subscription on `history:<contact-uuid>`, applying `contact_last_seen_changed` and `contact_flow_changed` with its own copy of the appliers. The "last seen only ever moves forward" guard and the flow-or-null rule existed in two places, and any new contact-state event would have had to be taught to both.

Both subscriptions were on the same channel, so `SocketManager` deduped the actual centrifugo subscription — but the fetch/apply machinery on top of it was doubled.

The chat now takes that channel as a stream from the registry, which becomes the only thing that opens it and the only thing that defines how an event changes a contact. Ticket detail events (`history:<contact>:<ticket>`) aren't contact state and stay a direct subscription.

### What had to change in ContactWatch

Two gaps made the opt-out necessary in the first place:

**Watchers can now pass `onSubscribed`.** Fires on every (re)subscribe, and once for a watcher joining an already-live channel. The chat drives `fetchMissedEvents()` off it — without it there was no way to be a watcher and still catch up after a reconnect.

**An entry watched only by stream consumers holds no contact.** It doesn't fetch on subscribe and doesn't schedule refetches, because nobody is reading the contact it would be keeping current. Without this, a chat-only page (no details pane) would have picked up an extra contact fetch per contact switch purely for joining the registry — on the ticket console, the page where agents switch contacts constantly. A state watcher joining such an entry later fetches for itself.

Stream consumers keep their own contact and apply events to it via the exported `applyContactEvent`, which runs the registry's own applier table.

### What this deliberately does not do

The chat still loads its contact through the store rather than reading the registry's, so there are still two copies on a ticket page. Collapsing that means reworking the reset/catch-up choreography that hangs off `currentContact` identity: with contact deliveries feeding `data`, every `contact_last_seen_changed` (i.e. every inbound message) would change the object identity and trigger both `fetchMissedEvents()` and `fetchPreviousMessages()` from `updated()` — two HTTP fetches per event. Worth doing, but it's a rework of the chat's load choreography rather than a plumbing change, so it's left for a follow-up.

### Testing

Full suite green (2747 passing). The existing chat tests covering flow and last-seen updates from socket events pass unchanged, which is what exercises the `applyContactEvent` path.

New `test/temba-contact-watch.test.ts` covers: `onSubscribed` on channel-live, the late-joiner catch-up call, no call after unsubscribe, stream-only entries fetching nothing (including on a urn change, which normally forces a refetch), a state watcher joining a stream-only entry triggering its own fetch, and `applyContactEvent` for flow, forward-only last seen, unknown event types, and a missing contact.