### PR TITLE
3/4 Type what each realtime topic publishes

### DIFF
--- a/src/events/eventRenderers.ts
+++ b/src/events/eventRenderers.ts
@@ -59,6 +59,10 @@ export enum Events {
   TICKET_OPENED = 'ticket_opened',
   TICKET_REOPENED = 'ticket_reopened',
   TICKET_TOPIC_CHANGED = 'ticket_topic_changed',
+  // ephemeral, drives the chat's typing indicator instead of recording
+  // history - published by agents as they compose and never persisted
+  TYPING_STARTED = 'typing_started',
+  TYPING_STOPPED = 'typing_stopped',
   WARNING = 'warning',
   WEBHOOK_CALLED = 'webhook_called'
 }

--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -26,17 +26,13 @@ import {
 } from '../utils';
 import { ContactStoreElement } from './ContactStoreElement';
 import { Compose, ComposeValue } from '../form/Compose';
-import {
-  ContactFlowChangedEvent,
-  ContactHistoryPage,
-  ContactLastSeenChangedEvent
-} from '../events';
+import { ContactHistoryPage } from '../events';
 import {
   Chat,
   MessageType,
   ContactEvent,
   MsgEvent,
-  TypingEvent
+  TypingEvent as RenderedTypingEvent
 } from '../display/Chat';
 import { DEFAULT_AVATAR } from '../webchat/assets';
 import { UserSelect } from '../form/select/UserSelect';
@@ -48,7 +44,12 @@ import {
   renderTicketAssigneeChanged
 } from '../events/eventRenderers';
 import { publishToSocket } from './SocketService';
-import { subscribeToContactHistory, RealtimeSubscription } from './Realtime';
+import {
+  ContactHistoryEvent,
+  RealtimeSubscription,
+  subscribeToContactHistory,
+  TypingEvent
+} from './Realtime';
 import { applyContactEvent, watchContact } from './ContactWatch';
 import { Icon } from '../Icons';
 import { designTokens } from '../styles/designTokens';
@@ -859,7 +860,7 @@ export class ContactChat extends ContactStoreElement {
     });
   }
 
-  private handleSocketEvent(event: any) {
+  private handleSocketEvent(event: ContactHistoryEvent) {
     if (!this.currentContact) {
       return;
     }
@@ -881,12 +882,20 @@ export class ContactChat extends ContactStoreElement {
     }
 
     // typing events are ephemeral indicator state, not history
-    if (event.type === 'typing_started' || event.type === 'typing_stopped') {
-      this.handleTypingEvent(event);
+    if (
+      event.type === Events.TYPING_STARTED ||
+      event.type === Events.TYPING_STOPPED
+    ) {
+      this.handleTypingEvent(event as TypingEvent);
       return;
     }
 
-    const messages = this.createMessages({ events: [event], next: null });
+    // createMessages parses the wire event into the rendered form the page
+    // type describes, dates and all
+    const messages = this.createMessages({
+      events: [event as unknown as ContactEvent],
+      next: null
+    });
     if (messages.length > 0) {
       this.chat.addMessages(messages, null, true);
     }
@@ -899,9 +908,7 @@ export class ContactChat extends ContactStoreElement {
    * against our copy, which is the store's cached contact, so applying it in
    * place also keeps the cache fresh for later readers.
    */
-  private handleContactStateEvent(
-    event: ContactFlowChangedEvent | ContactLastSeenChangedEvent
-  ) {
+  private handleContactStateEvent(event: ContactHistoryEvent) {
     applyContactEvent(this.currentContact, event);
     this.requestUpdate();
   }
@@ -938,13 +945,18 @@ export class ContactChat extends ContactStoreElement {
       return;
     }
 
-    event.created_on = new Date(event.created_on);
-    this.resolveUserAvatar(event);
+    // the wire event is handed to every subscriber on this channel, so render
+    // into our own copy rather than parsing its date in place
+    const typing = {
+      ...event,
+      created_on: new Date(event.created_on)
+    } as RenderedTypingEvent;
+    this.resolveUserAvatar(typing);
 
-    if (event.type === 'typing_started') {
-      this.chat.setTyping(event);
+    if (event.type === Events.TYPING_STARTED) {
+      this.chat.setTyping(typing);
     } else {
-      this.chat.clearTyping(event);
+      this.chat.clearTyping(typing);
     }
   }
 

--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -893,7 +893,7 @@ export class ContactChat extends ContactStoreElement {
     // createMessages parses the wire event into the rendered form the page
     // type describes, dates and all
     const messages = this.createMessages({
-      events: [event as unknown as ContactEvent],
+      events: [this.copyWireEvent(event) as unknown as ContactEvent],
       next: null
     });
     if (messages.length > 0) {
@@ -948,7 +948,7 @@ export class ContactChat extends ContactStoreElement {
     // the wire event is handed to every subscriber on this channel, so render
     // into our own copy rather than parsing its date in place
     const typing = {
-      ...event,
+      ...this.copyWireEvent(event),
       created_on: new Date(event.created_on)
     } as RenderedTypingEvent;
     this.resolveUserAvatar(typing);
@@ -1667,6 +1667,23 @@ export class ContactChat extends ContactStoreElement {
    * second user ref (the assignee) whose avatar feeds the event's hover
    * tooltip.
    */
+  /**
+   * A copy of a wire event we can parse and resolve into. The event object is
+   * handed to every subscriber on the channel, and resolveUserAvatar writes an
+   * avatar onto the user objects hanging off it, so a shallow spread isn't
+   * enough on its own - those ride through it aliased.
+   */
+  private copyWireEvent(event: any): any {
+    const copy = { ...event };
+    if (copy._user) {
+      copy._user = { ...copy._user };
+    }
+    if (copy.assignee) {
+      copy.assignee = { ...copy.assignee };
+    }
+    return copy;
+  }
+
   private resolveUserAvatar(event: any) {
     for (const user of [event._user, event.assignee]) {
       if (user && user.uuid && this.store) {

--- a/src/live/ContactWatch.ts
+++ b/src/live/ContactWatch.ts
@@ -1,7 +1,18 @@
 import { Contact } from '../interfaces';
 import { Events } from '../events/eventRenderers';
 import { getStore } from '../store/Store';
-import { RealtimeSubscription, subscribeToContactHistory } from './Realtime';
+import {
+  ContactFieldChangedEvent,
+  ContactFlowChangedEvent,
+  ContactGroupsChangedEvent,
+  ContactHistoryEvent,
+  ContactLanguageChangedEvent,
+  ContactLastSeenChangedEvent,
+  ContactNameChangedEvent,
+  ContactStatusChangedEvent,
+  RealtimeSubscription,
+  subscribeToContactHistory
+} from './Realtime';
 
 /**
  * Central interest registry for live contact state. Components declare what
@@ -65,7 +76,10 @@ export const CONTACT_STATE_TYPES = [
   Events.CONTACT_LAST_SEEN_CHANGED
 ];
 
-export type ContactEventHandler = (event: any, contact: Contact) => void;
+export type ContactEventHandler = (
+  event: ContactHistoryEvent | null,
+  contact: Contact
+) => void;
 
 interface Watcher {
   types: string[] | '*';
@@ -116,19 +130,28 @@ const serializeFieldValue = (key: string, value: any): string | undefined => {
 const appliers: {
   [type: string]: (contact: Contact, event: any) => boolean | void;
 } = {
-  [Events.CONTACT_NAME_CHANGED]: (contact, event) => {
+  [Events.CONTACT_NAME_CHANGED]: (contact, event: ContactNameChangedEvent) => {
     contact.name = event.name;
   },
-  [Events.CONTACT_LANGUAGE_CHANGED]: (contact, event) => {
+  [Events.CONTACT_LANGUAGE_CHANGED]: (
+    contact,
+    event: ContactLanguageChangedEvent
+  ) => {
     contact.language = event.language;
   },
-  [Events.CONTACT_STATUS_CHANGED]: (contact, event) => {
+  [Events.CONTACT_STATUS_CHANGED]: (
+    contact,
+    event: ContactStatusChangedEvent
+  ) => {
     contact.status = event.status;
   },
-  [Events.CONTACT_FLOW_CHANGED]: (contact, event) => {
+  [Events.CONTACT_FLOW_CHANGED]: (contact, event: ContactFlowChangedEvent) => {
     contact.flow = event.flow || null;
   },
-  [Events.CONTACT_LAST_SEEN_CHANGED]: (contact, event) => {
+  [Events.CONTACT_LAST_SEEN_CHANGED]: (
+    contact,
+    event: ContactLastSeenChangedEvent
+  ) => {
     // last seen only ever moves forward - ignore out of order deliveries
     if (
       !contact.last_seen_on ||
@@ -137,7 +160,10 @@ const appliers: {
       contact.last_seen_on = event.last_seen_on;
     }
   },
-  [Events.CONTACT_FIELD_CHANGED]: (contact, event) => {
+  [Events.CONTACT_FIELD_CHANGED]: (
+    contact,
+    event: ContactFieldChangedEvent
+  ) => {
     const key = event.field?.key;
     if (!key) {
       return;
@@ -150,19 +176,21 @@ const appliers: {
     // replace rather than mutate so earlier deliveries keep their values
     contact.fields = { ...contact.fields, [key]: value };
   },
-  [Events.CONTACT_GROUPS_CHANGED]: (contact, event) => {
+  [Events.CONTACT_GROUPS_CHANGED]: (
+    contact,
+    event: ContactGroupsChangedEvent
+  ) => {
     const added = event.groups_added || [];
     const removed = new Set(
-      (event.groups_removed || []).map((group: any) => group.uuid)
+      (event.groups_removed || []).map((group) => group.uuid)
     );
     contact.groups = [
       ...(contact.groups || []).filter(
         (group) =>
-          !removed.has(group.uuid) &&
-          !added.some((a: any) => a.uuid === group.uuid)
+          !removed.has(group.uuid) && !added.some((a) => a.uuid === group.uuid)
       ),
       // group references can arrive without a name, but consumers sort on it
-      ...added.map((group: any) => ({
+      ...added.map((group) => ({
         uuid: group.uuid,
         name: group.name || ''
       }))
@@ -199,7 +227,7 @@ const needsContact = (entry: WatchedContact): boolean => {
  */
 export const applyContactEvent = (
   contact: Contact,
-  event: any
+  event: ContactHistoryEvent
 ): boolean | void => {
   const apply = appliers[event.type];
   if (!contact || !apply) {
@@ -210,7 +238,11 @@ export const applyContactEvent = (
 
 // watchers are page components we don't control - one of them throwing can't
 // be allowed to cost the others their delivery
-const deliver = (watcher: Watcher, event: any, contact: Contact) => {
+const deliver = (
+  watcher: Watcher,
+  event: ContactHistoryEvent | null,
+  contact: Contact
+) => {
   try {
     watcher.onEvent(event, contact);
   } catch (error) {
@@ -322,7 +354,11 @@ const scheduleRefetch = (uuid: string, entry: WatchedContact) => {
   }, REFETCH_DEBOUNCE);
 };
 
-const handleEvent = (uuid: string, entry: WatchedContact, event: any) => {
+const handleEvent = (
+  uuid: string,
+  entry: WatchedContact,
+  event: ContactHistoryEvent
+) => {
   const apply = appliers[event.type];
   const applied = entry.contact && apply ? apply(entry.contact, event) : null;
 

--- a/src/live/Realtime.ts
+++ b/src/live/Realtime.ts
@@ -1,4 +1,6 @@
-import { Notification } from '../interfaces';
+import { Notification, ObjectReference, User } from '../interfaces';
+import { Events } from '../events/eventRenderers';
+import type { StoreAsset } from '../store/Store';
 import {
   PublicationHandler,
   SocketSubscription,
@@ -9,16 +11,135 @@ import {
  * Typed access to our realtime topics. SocketService owns the shared
  * connection and per-channel fan-out; this module owns how topics map to
  * channel names, including the page identity (org and user uuids) needed to
- * address user-scoped channels.
+ * address user-scoped channels, and what each topic publishes.
  *
  * The identity arrives via temba-store (hydrated from the page template), so
  * user-scoped subscriptions requested before the store mounts are queued and
  * activate when the context is set. On pages with no authenticated context
  * they simply never activate.
+ *
+ * Payload types below describe the wire, which is raw JSON - timestamps are
+ * strings here even where the rendered equivalents in events.ts carry Dates.
  */
 
 export interface RealtimeSubscription {
   unsubscribe(): void;
+}
+
+/** Anything published on any of our topics. */
+export interface RealtimeEvent {
+  type: string;
+}
+
+/**
+ * org:<org-uuid> - workspace-wide state every component on the page shares.
+ * An asset changed somewhere, so anything displaying it can update.
+ */
+export interface AssetChangedEvent extends RealtimeEvent {
+  type: 'asset_changed';
+  asset: StoreAsset;
+}
+
+export type OrganizationEvent = AssetChangedEvent;
+
+/**
+ * flow:<flow-uuid> - published once per committed sprint batch while a flow
+ * is running. It carries no counts, it just says they moved: the editor reads
+ * the current numbers over http when it sees one.
+ */
+export interface FlowActivityEvent extends RealtimeEvent {
+  type: 'activity';
+}
+
+export type FlowEvent = FlowActivityEvent;
+
+/**
+ * history:<contact-uuid> and history:<contact-uuid>:<ticket-uuid> - the
+ * engine's contact events (the payloads in events.ts, before their dates are
+ * parsed) plus the ephemeral ones below, which are never persisted.
+ */
+export interface ContactHistoryEvent extends RealtimeEvent {
+  uuid?: string;
+  created_on?: string;
+  _user?: User;
+  // the rest of the payload varies by type. The contact-state events - the
+  // ones we read fields off rather than hand straight to the renderers - are
+  // typed below; events.ts describes the rendered shape of the others.
+  // unknown rather than any, so reading a field nobody declared is a type
+  // error at the point of use instead of silently spreading
+  [key: string]: unknown;
+}
+
+/**
+ * The events that change what a contact *is*, as opposed to recording
+ * something that happened to them. These are the ones ContactWatch applies to
+ * the contact it holds, so their payloads are what a server-side rename would
+ * break.
+ */
+export interface ContactNameChangedEvent extends ContactHistoryEvent {
+  type: Events.CONTACT_NAME_CHANGED;
+  name: string;
+}
+
+export interface ContactLanguageChangedEvent extends ContactHistoryEvent {
+  type: Events.CONTACT_LANGUAGE_CHANGED;
+  language: string;
+}
+
+export interface ContactStatusChangedEvent extends ContactHistoryEvent {
+  type: Events.CONTACT_STATUS_CHANGED;
+  status: string;
+}
+
+export interface ContactFlowChangedEvent extends ContactHistoryEvent {
+  type: Events.CONTACT_FLOW_CHANGED;
+  flow: ObjectReference | null;
+}
+
+export interface ContactLastSeenChangedEvent extends ContactHistoryEvent {
+  type: Events.CONTACT_LAST_SEEN_CHANGED;
+  last_seen_on: string;
+}
+
+export interface ContactFieldChangedEvent extends ContactHistoryEvent {
+  type: Events.CONTACT_FIELD_CHANGED;
+  field: { key: string; name: string };
+  // engine field values always carry text; typed representations are present
+  // when the value parses as that type (see goflow's Value)
+  value: { text: string; datetime?: string; number?: string } | null;
+}
+
+export interface ContactGroupsChangedEvent extends ContactHistoryEvent {
+  type: Events.CONTACT_GROUPS_CHANGED;
+  groups_added?: ObjectReference[];
+  groups_removed?: ObjectReference[];
+}
+
+export interface ContactURNsChangedEvent extends ContactHistoryEvent {
+  type: Events.CONTACT_URNS_CHANGED;
+  urns: string[];
+}
+
+export type ContactStateEvent =
+  | ContactNameChangedEvent
+  | ContactLanguageChangedEvent
+  | ContactStatusChangedEvent
+  | ContactFlowChangedEvent
+  | ContactLastSeenChangedEvent
+  | ContactFieldChangedEvent
+  | ContactGroupsChangedEvent
+  | ContactURNsChangedEvent;
+
+/**
+ * Published by agents as they compose, and echoed back to the publisher, so
+ * consumers filter out their own by _user.
+ */
+export interface TypingEvent extends ContactHistoryEvent {
+  type: Events.TYPING_STARTED | Events.TYPING_STOPPED;
+  direction?: string;
+  // whatsapp expresses typing as an operation on the contact's last incoming
+  // message, so publications carry its external id when we have one
+  msg_external_id?: string;
 }
 
 export interface RealtimeContext {
@@ -119,10 +240,14 @@ export const subscribeToNotifications = (
  * Workspace-wide state changes shared by every component on the page.
  */
 export const subscribeToOrganization = (
-  onEvent: (event: any) => void,
+  onEvent: (event: OrganizationEvent) => void,
   onSubscribed?: () => void
 ): RealtimeSubscription => {
-  return subscribeWhenReady((ctx) => `org:${ctx.org}`, onEvent, onSubscribed);
+  return subscribeWhenReady(
+    (ctx) => `org:${ctx.org}`,
+    (data) => onEvent(data as OrganizationEvent),
+    onSubscribed
+  );
 };
 
 /**
@@ -131,10 +256,14 @@ export const subscribeToOrganization = (
  */
 export const subscribeToFlow = (
   flow: string,
-  onEvent: (event: any) => void,
+  onEvent: (event: FlowEvent) => void,
   onSubscribed?: () => void
 ): RealtimeSubscription => {
-  return subscribeToSocket(`flow:${flow}`, onEvent, onSubscribed);
+  return subscribeToSocket(
+    `flow:${flow}`,
+    (data) => onEvent(data as FlowEvent),
+    onSubscribed
+  );
 };
 
 /**
@@ -144,12 +273,12 @@ export const subscribeToFlow = (
 export const subscribeToContactHistory = (
   contact: string,
   ticket: string | null,
-  onEvent: (event: any) => void,
+  onEvent: (event: ContactHistoryEvent) => void,
   onSubscribed?: () => void
 ): RealtimeSubscription => {
   return subscribeToSocket(
     ticket ? `history:${contact}:${ticket}` : `history:${contact}`,
-    onEvent,
+    (data) => onEvent(data as ContactHistoryEvent),
     onSubscribed
   );
 };

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -25,7 +25,8 @@ import { RapidElement } from '../RapidElement';
 import {
   RealtimeSubscription,
   setRealtimeContext,
-  subscribeToOrganization
+  subscribeToOrganization,
+  OrganizationEvent
 } from '../live/Realtime';
 import { lru } from 'tiny-lru';
 import { DateTime } from 'luxon';
@@ -863,8 +864,8 @@ export class Store extends RapidElement {
     this.assetVersions.set(identity, ++this.assetVersion);
   }
 
-  private handleOrganizationEvent(event: any): void {
-    const asset = event?.asset as StoreAsset;
+  private handleOrganizationEvent(event: OrganizationEvent): void {
+    const asset = event?.asset;
     const identity = assetIdentity(asset);
     if (
       event?.type !== 'asset_changed' ||

--- a/test/temba-contact-chat.test.ts
+++ b/test/temba-contact-chat.test.ts
@@ -1259,7 +1259,14 @@ describe('temba-contact-chat', () => {
     };
     mockSocket.publish(channel, unhydrated);
 
-    expect(unhydrated._user['avatar']).to.equal('/media/avatars/ann.jpg');
+    // the avatar is resolved onto what we render, not onto the wire event
+    // the channel handed every subscriber
+    const rendered = () =>
+      (getTembaChat(chat) as any).msgMap.get(unhydrated.uuid);
+    await settle(() => !!rendered(), 150);
+
+    expect(rendered()._user.avatar).to.equal('/media/avatars/ann.jpg');
+    expect(unhydrated._user).to.not.have.property('avatar');
   });
 
   it('unsubscribes when removed from the page', async () => {
@@ -1320,6 +1327,47 @@ describe('temba-contact-chat', () => {
 
     serverTyping(chat, 'typing_stopped');
     expect(await getTypingRow(chat)).to.not.exist;
+  });
+
+  it('renders socket events without writing back to the wire object', async () => {
+    await loadStore();
+    const chat: ContactChat = await getContactChat({
+      contact: 'contact-dave-active'
+    });
+    const channel = `history:${chat.currentContact.uuid}`;
+
+    // every subscriber on the channel is handed these same objects, so
+    // parsing a date or resolving an avatar into one writes through to all
+    // of them
+    const typingUser = { uuid: 'user-bob', name: 'Bob' };
+    const typing = {
+      uuid: '01998888-0000-7000-8000-00000000aaaa',
+      type: 'typing_started',
+      created_on: '2025-09-25T12:00:00.000000+00:00',
+      _user: typingUser,
+      direction: 'outgoing'
+    };
+    mockSocket.serverPublish(channel, typing);
+    expect(await getTypingRow(chat)).to.exist;
+
+    expect(typing.created_on).to.equal('2025-09-25T12:00:00.000000+00:00');
+    expect(typingUser).to.not.have.property('avatar');
+
+    // the same holds for events that land in the history rather than the
+    // typing indicator
+    const msgUser = { uuid: 'user-bob', name: 'Bob' };
+    const msg = {
+      uuid: '01998888-0000-7000-8000-00000000bbbb',
+      type: 'msg_created',
+      created_on: '2025-09-25T12:01:00.000000+00:00',
+      _user: msgUser,
+      msg: { text: 'hello there' }
+    };
+    mockSocket.serverPublish(channel, msg);
+    await chat.updateComplete;
+
+    expect(msg.created_on).to.equal('2025-09-25T12:01:00.000000+00:00');
+    expect(msgUser).to.not.have.property('avatar');
   });
 
   it('shows and clears contact typing with no user attached', async () => {


### PR DESCRIPTION
Third of four stacked PRs. **Targets #1100** — merge #1099 and #1100 first.

`Realtime.ts` typed only notifications. `subscribeToOrganization`, `subscribeToFlow` and `subscribeToContactHistory` all handed their subscribers `any`, so nothing about those payloads was checked anywhere in the codebase — and the chat compared typing events against bare string literals (`'typing_started'`) that lived outside the `Events` enum entirely.

### What each topic publishes

- `org:<org-uuid>` → `AssetChangedEvent`
- `flow:<flow-uuid>` → `FlowActivityEvent`
- `history:<contact-uuid>[:<ticket-uuid>]` → `ContactHistoryEvent`, with the contact-state events and the ephemeral `TypingEvent` typed individually

Consumers (`Store.handleOrganizationEvent`, the editor's activity watcher, `ContactWatch`, `ContactChat`) take those types instead of `any`.

The types describe **the wire**, not the rendered form — timestamps are strings here even where the equivalents in `events.ts` carry `Date`. That distinction was previously invisible: `ContactHistoryPage.events` is declared as `ContactEvent[]` with `created_on: Date`, but both the socket and the history endpoint deliver strings, and `createMessages` parses them in place. The two places that cross that boundary now say so explicitly.

### Typing events

`typing_started` / `typing_stopped` join the `Events` enum next to the other ephemeral contact events (`contact_flow_changed`, `contact_last_seen_changed`), so they're referenced like every other event type.

### Making the types actually check something

The contact-state events — the eight `ContactWatch` reads fields off to patch the contact it holds — get individual payload types, and the applier table is declared against them.

The rest of a history payload genuinely varies by event type, so `ContactHistoryEvent` carries an index signature. It's `unknown`, not `any`, which is what makes the specific types worth having: reading a field nobody declared is a type error at the point of use. Verified by temporarily typoing an applier —

```
src/live/ContactWatch.ts(134,5): error TS2322: Type 'unknown' is not assignable to type 'string'.
```

With `any` that would have compiled and silently written `undefined` into the contact.

### One latent bug closed on the way

`handleTypingEvent` did `event.created_on = new Date(event.created_on)` — mutating the event object that the registry fans out to every watcher on that channel. It only stayed invisible because the chat is currently the sole stream consumer. It now builds its own rendered copy.

### Testing

Full suite green (2747 passing), `tsc --noEmit` clean.