### PR TITLE
4/4 Share the subscriber fan-out and expose the connection's state

### DIFF
--- a/src/live/ContactWatch.ts
+++ b/src/live/ContactWatch.ts
@@ -1,6 +1,7 @@
 import { Contact } from '../interfaces';
 import { Events } from '../events/eventRenderers';
 import { getStore } from '../store/Store';
+import { Watchers } from './Watchers';
 import {
   ContactFieldChangedEvent,
   ContactFlowChangedEvent,
@@ -88,7 +89,7 @@ interface Watcher {
 }
 
 interface WatchedContact {
-  watchers: Watcher[];
+  watchers: Watchers<Watcher>;
   sub: RealtimeSubscription;
   contact: Contact;
   fetchSeq: number;
@@ -102,6 +103,12 @@ interface WatchedContact {
 }
 
 const watched = new Map<string, WatchedContact>();
+
+const newWatchers = (watcher: Watcher): Watchers<Watcher> => {
+  const watchers = new Watchers<Watcher>('contact watcher');
+  watchers.add(watcher);
+  return watchers;
+};
 
 /**
  * Serializes an engine field value from an event the way the read API
@@ -236,30 +243,15 @@ export const applyContactEvent = (
   return apply(contact, event);
 };
 
-// watchers are page components we don't control - one of them throwing can't
-// be allowed to cost the others their delivery
-const deliver = (
-  watcher: Watcher,
-  event: ContactHistoryEvent | null,
-  contact: Contact
-) => {
-  try {
-    watcher.onEvent(event, contact);
-  } catch (error) {
-    console.error('contact watcher failed', error);
-  }
-};
-
 /**
  * Hands every non-wildcard watcher the current contact as an eventless
  * delivery.
  */
 const primeAll = (entry: WatchedContact) => {
-  for (const watcher of [...entry.watchers]) {
-    if (watcher.types !== '*') {
-      deliver(watcher, null, entry.contact);
-    }
-  }
+  entry.watchers.each(
+    (watcher) => watcher.onEvent(null, entry.contact),
+    (watcher) => watcher.types !== '*'
+  );
 };
 
 const clearRefetch = (entry: WatchedContact) => {
@@ -376,11 +368,10 @@ const handleEvent = (
     }
   }
 
-  for (const watcher of [...entry.watchers]) {
-    if (matches(watcher, event.type)) {
-      deliver(watcher, event, entry.contact);
-    }
-  }
+  entry.watchers.each(
+    (watcher) => watcher.onEvent(event, entry.contact),
+    (watcher) => matches(watcher, event.type)
+  );
 };
 
 /**
@@ -393,20 +384,10 @@ const handleSubscribed = (uuid: string, entry: WatchedContact) => {
   if (needsContact(entry)) {
     fetchContact(uuid, entry);
   }
-  for (const watcher of [...entry.watchers]) {
-    notifySubscribed(watcher);
-  }
-};
-
-const notifySubscribed = (watcher: Watcher) => {
-  if (!watcher.onSubscribed) {
-    return;
-  }
-  try {
-    watcher.onSubscribed();
-  } catch (error) {
-    console.error('contact watcher failed', error);
-  }
+  entry.watchers.each(
+    (watcher) => watcher.onSubscribed(),
+    (watcher) => !!watcher.onSubscribed
+  );
 };
 
 export const watchContact = (
@@ -422,7 +403,7 @@ export const watchContact = (
     const newEntry: WatchedContact = {
       // registered before we subscribe so the first (re)subscribe already
       // knows whether anyone needs a contact held for them
-      watchers: [watcher],
+      watchers: newWatchers(watcher),
       sub: null,
       contact: null,
       fetchSeq: 0,
@@ -442,7 +423,7 @@ export const watchContact = (
     return unwatch(uuid, newEntry, watcher);
   }
 
-  entry.watchers.push(watcher);
+  entry.watchers.add(watcher);
 
   // a watcher that renders contact state joining an entry that was holding
   // none (only stream consumers so far) needs one fetched for it. On a
@@ -455,21 +436,13 @@ export const watchContact = (
   // without waiting for another fetch - async so it mirrors the fetch path
   if (entry.contact && types !== '*') {
     const contact = entry.contact;
-    Promise.resolve().then(() => {
-      if (entry.watchers.includes(watcher)) {
-        deliver(watcher, null, contact);
-      }
-    });
+    entry.watchers.prime(watcher, () => watcher.onEvent(null, contact));
   }
 
   // and joiners on an already-live channel get their initial catch-up call,
   // which they'd otherwise wait for a reconnect to see
   if (entry.subscribed && onSubscribed) {
-    Promise.resolve().then(() => {
-      if (entry.watchers.includes(watcher)) {
-        notifySubscribed(watcher);
-      }
-    });
+    entry.watchers.prime(watcher, () => watcher.onSubscribed());
   }
 
   return unwatch(uuid, entry, watcher);
@@ -481,12 +454,7 @@ const unwatch = (
   watcher: Watcher
 ): RealtimeSubscription => ({
   unsubscribe: () => {
-    const index = entry.watchers.indexOf(watcher);
-    if (index < 0) {
-      return;
-    }
-    entry.watchers.splice(index, 1);
-    if (entry.watchers.length === 0) {
+    if (entry.watchers.remove(watcher) && entry.watchers.size === 0) {
       dropEntry(uuid, entry);
     } else if (!needsContact(entry)) {
       // only stream consumers left, and nothing keeps their contact current -
@@ -544,7 +512,7 @@ const dropEntry = (uuid: string, entry: WatchedContact) => {
 // for tests - real pages just unwatch
 export const resetContactWatches = () => {
   for (const [uuid, entry] of [...watched.entries()]) {
-    entry.watchers.length = 0;
+    entry.watchers.clear();
     dropEntry(uuid, entry);
   }
 };

--- a/src/live/SocketService.ts
+++ b/src/live/SocketService.ts
@@ -1,4 +1,5 @@
 import { Centrifuge, Subscription, SubscriptionState } from 'centrifuge';
+import { Watchers } from './Watchers';
 
 /**
  * Access to our realtime messaging socket (centrifugo). The server lives
@@ -20,6 +21,11 @@ import { Centrifuge, Subscription, SubscriptionState } from 'centrifuge';
  * channel - the underlying centrifugo subscription is created on first use
  * and torn down when the last subscriber leaves. The connection itself stays
  * open for the life of the page. Each published event arrives as raw JSON.
+ *
+ * The connection's state is readable too, so a page can tell its user when it
+ * has gone quiet rather than silently showing stale data:
+ *
+ *   window.sockets.onConnectionState((state) => { ... });
  */
 
 export interface SocketSubscription {
@@ -27,6 +33,19 @@ export interface SocketSubscription {
 }
 
 export type PublicationHandler = (data: any) => void;
+
+/**
+ * Where the shared connection is. Mirrors centrifugo's own client states -
+ * connecting covers the first attempt and every reconnect after a drop, so a
+ * page showing a "reconnecting" hint wants that one.
+ */
+export enum ConnectionState {
+  Disconnected = 'disconnected',
+  Connecting = 'connecting',
+  Connected = 'connected'
+}
+
+export type ConnectionStateHandler = (state: ConnectionState) => void;
 
 export interface SocketProvider {
   subscribe(
@@ -36,6 +55,10 @@ export interface SocketProvider {
   ): SocketSubscription;
 
   publish(channel: string, data: any): Promise<void>;
+
+  getConnectionState(): ConnectionState;
+
+  onConnectionState(handler: ConnectionStateHandler): SocketSubscription;
 }
 
 interface ChannelEntry {
@@ -47,6 +70,13 @@ export class SocketManager implements SocketProvider {
   private socket: Centrifuge = null;
   private channels = new Map<string, ChannelEntry>();
   private createSocket: () => Centrifuge;
+
+  // no connection exists until something asks for one, so that is where we
+  // start rather than pretending we know the server is unreachable
+  private state = ConnectionState.Disconnected;
+  private stateHandlers = new Watchers<ConnectionStateHandler>(
+    'socket connection handler'
+  );
 
   constructor(createSocket?: () => Centrifuge) {
     this.createSocket =
@@ -67,16 +97,69 @@ export class SocketManager implements SocketProvider {
    * and fan-out; a rejection means the publication was denied.
    */
   public publish(channel: string, data: any): Promise<void> {
-    if (!this.socket) {
-      this.socket = this.createSocket();
-    }
+    const socket = this.ensureSocket();
 
     // prefer the channel's live subscription when we have one
     const entry = this.channels.get(channel);
     const published = entry
       ? entry.sub.publish(data)
-      : this.socket.publish(channel, data);
+      : socket.publish(channel, data);
     return published.then(() => undefined);
+  }
+
+  /**
+   * The shared connection, opened on first use. Its state is tracked from
+   * here on, seeded with whatever it is already in - creating it connects, so
+   * the first transition can happen before we are listening.
+   */
+  private ensureSocket(): Centrifuge {
+    if (!this.socket) {
+      this.socket = this.createSocket();
+      this.socket.on('connecting', () =>
+        this.setState(ConnectionState.Connecting)
+      );
+      this.socket.on('connected', () =>
+        this.setState(ConnectionState.Connected)
+      );
+      this.socket.on('disconnected', () =>
+        this.setState(ConnectionState.Disconnected)
+      );
+      this.setState(this.socket.state as unknown as ConnectionState);
+    }
+    return this.socket;
+  }
+
+  private setState(state: ConnectionState): void {
+    if (!state || state === this.state) {
+      return;
+    }
+    this.state = state;
+    this.stateHandlers.each((handler) => handler(state));
+  }
+
+  /**
+   * Where the shared connection is right now. Disconnected until something
+   * subscribes or publishes, since that is what opens it.
+   */
+  public getConnectionState(): ConnectionState {
+    return this.state;
+  }
+
+  /**
+   * Watches the connection. The handler is called on every transition, and
+   * once up front with the current state so a caller never has to pair this
+   * with getConnectionState to render.
+   */
+  public onConnectionState(
+    handler: ConnectionStateHandler
+  ): SocketSubscription {
+    this.stateHandlers.add(handler);
+    this.stateHandlers.prime(handler, () => handler(this.state));
+    return {
+      unsubscribe: () => {
+        this.stateHandlers.remove(handler);
+      }
+    };
   }
 
   public subscribe(
@@ -84,16 +167,12 @@ export class SocketManager implements SocketProvider {
     onPublication: PublicationHandler,
     onSubscribed?: () => void
   ): SocketSubscription {
-    if (!this.socket) {
-      this.socket = this.createSocket();
-    }
+    const socket = this.ensureSocket();
 
     let entry = this.channels.get(channel);
     if (!entry) {
       entry = {
-        sub:
-          this.socket.getSubscription(channel) ||
-          this.socket.newSubscription(channel),
+        sub: socket.getSubscription(channel) || socket.newSubscription(channel),
         count: 0
       };
       this.channels.set(channel, entry);
@@ -172,6 +251,16 @@ export const subscribeToSocket = (
 
 export const publishToSocket = (channel: string, data: any): Promise<void> => {
   return (provider || getManager()).publish(channel, data);
+};
+
+export const getSocketConnectionState = (): ConnectionState => {
+  return (provider || getManager()).getConnectionState();
+};
+
+export const onSocketConnectionState = (
+  handler: ConnectionStateHandler
+): SocketSubscription => {
+  return (provider || getManager()).onConnectionState(handler);
 };
 
 // for tests to swap in a mock provider, returns the previous provider

--- a/src/live/SocketService.ts
+++ b/src/live/SocketService.ts
@@ -129,11 +129,16 @@ export class SocketManager implements SocketProvider {
     return this.socket;
   }
 
+  // counts transitions, so an initial delivery can tell whether one beat it
+  // to the handler
+  private stateSeq = 0;
+
   private setState(state: ConnectionState): void {
     if (!state || state === this.state) {
       return;
     }
     this.state = state;
+    this.stateSeq++;
     this.stateHandlers.each((handler) => handler(state));
   }
 
@@ -154,7 +159,18 @@ export class SocketManager implements SocketProvider {
     handler: ConnectionStateHandler
   ): SocketSubscription {
     this.stateHandlers.add(handler);
-    this.stateHandlers.prime(handler, () => handler(this.state));
+
+    // where we are now, rather than wherever we've got to by the time the
+    // prime lands - opening the connection in this same tick transitions us
+    // and delivers that to the handler ahead of it, and saying the same thing
+    // again is the repeat this is supposed to suppress
+    const initial = this.state;
+    const seq = this.stateSeq;
+    this.stateHandlers.prime(handler, () => {
+      if (this.stateSeq === seq) {
+        handler(initial);
+      }
+    });
     return {
       unsubscribe: () => {
         this.stateHandlers.remove(handler);

--- a/src/live/Watchers.ts
+++ b/src/live/Watchers.ts
@@ -1,0 +1,93 @@
+/**
+ * A list of subscribers with safe fan-out.
+ *
+ * Every registry we keep - contact watchers, the store's asset watchers,
+ * socket connection listeners - hands events to page components we don't
+ * control, so they all need the same three things: one subscriber throwing
+ * can't cost the others their delivery, a delivery iterates a snapshot so
+ * unsubscribing mid-fan-out doesn't shift the list underneath it, and
+ * unsubscribing twice does nothing the second time.
+ *
+ * The subscriber record and how an event reaches it belong to the caller -
+ * interests, payloads and arities differ - so this owns only the list and the
+ * delivery discipline.
+ */
+export class Watchers<W> {
+  private watchers: W[] = [];
+
+  // names the subscriber when reporting one that threw
+  private label: string;
+
+  constructor(label: string) {
+    this.label = label;
+  }
+
+  public get size(): number {
+    return this.watchers.length;
+  }
+
+  public has(watcher: W): boolean {
+    return this.watchers.includes(watcher);
+  }
+
+  public some(predicate: (watcher: W) => boolean): boolean {
+    return this.watchers.some(predicate);
+  }
+
+  /** A snapshot, for callers that need to read across everyone registered. */
+  public all(): W[] {
+    return [...this.watchers];
+  }
+
+  public add(watcher: W): void {
+    this.watchers.push(watcher);
+  }
+
+  /** Removes it, reporting whether it was still registered. */
+  public remove(watcher: W): boolean {
+    const index = this.watchers.indexOf(watcher);
+    if (index < 0) {
+      return false;
+    }
+    this.watchers.splice(index, 1);
+    return true;
+  }
+
+  public clear(): void {
+    this.watchers.length = 0;
+  }
+
+  /** One delivery, with a subscriber's failure kept to itself. */
+  public deliver(watcher: W, deliver: (watcher: W) => void): void {
+    try {
+      deliver(watcher);
+    } catch (error) {
+      console.error(`${this.label} failed`, error);
+    }
+  }
+
+  /** Delivers to everyone registered now, or just those matching. */
+  public each(
+    deliver: (watcher: W) => void,
+    matches?: (watcher: W) => boolean
+  ): void {
+    for (const watcher of this.all()) {
+      if (!matches || matches(watcher)) {
+        this.deliver(watcher, deliver);
+      }
+    }
+  }
+
+  /**
+   * An initial delivery to one subscriber, off the current task so it lands
+   * the way a live one would rather than before they can use the handle they
+   * are being given. Skipped if they leave before it lands.
+   */
+  public prime(watcher: W, deliver: (watcher: W) => void): void {
+    Promise.resolve().then(() => {
+      if (this.has(watcher)) {
+        this.deliver(watcher, deliver);
+      }
+    });
+  }
+}

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -28,6 +28,7 @@ import {
   subscribeToOrganization,
   OrganizationEvent
 } from '../live/Realtime';
+import { Watchers } from '../live/Watchers';
 import { lru } from 'tiny-lru';
 import { DateTime } from 'luxon';
 import { css, html } from 'lit';
@@ -230,7 +231,7 @@ export class Store extends RapidElement {
   private shortcuts: Shortcut[] = [];
   private workspace: Workspace;
   private featuredFields: ContactField[] = [];
-  private assetWatchers: AssetWatcher[] = [];
+  private assetWatchers = new Watchers<AssetWatcher>('store asset watcher');
   // canonical names, the identities we've already asked about (including ones
   // the endpoint had no asset for) and their last-write versions, all bounded
   // so a long-lived page doesn't keep every asset it has ever rendered
@@ -730,19 +731,12 @@ export class Store extends RapidElement {
         })),
       onEvent
     };
-    this.assetWatchers.push(watcher);
-    Promise.resolve().then(() => {
-      if (this.assetWatchers.includes(watcher)) {
-        this.deliverAssetEvent(watcher, null);
-      }
-    });
+    this.assetWatchers.add(watcher);
+    this.assetWatchers.prime(watcher, () => watcher.onEvent(null));
 
     return {
       unsubscribe: () => {
-        const index = this.assetWatchers.indexOf(watcher);
-        if (index >= 0) {
-          this.assetWatchers.splice(index, 1);
-        }
+        this.assetWatchers.remove(watcher);
       }
     };
   }
@@ -755,7 +749,7 @@ export class Store extends RapidElement {
    */
   private async refreshAssetCache(): Promise<void> {
     const interests = new Map<string, StoreAssetReference>();
-    for (const watcher of this.assetWatchers) {
+    for (const watcher of this.assetWatchers.all()) {
       for (const interest of watcher.interests) {
         const identity = assetIdentity(interest);
         if (identity) {
@@ -766,9 +760,7 @@ export class Store extends RapidElement {
     if (interests.size > 0) {
       await this.resolveAssets([...interests.values()], true);
     }
-    for (const watcher of this.assetWatchers) {
-      this.deliverAssetEvent(watcher, null);
-    }
+    this.assetWatchers.each((watcher) => watcher.onEvent(null));
   }
 
   private async fetchAssetBatch(
@@ -876,7 +868,7 @@ export class Store extends RapidElement {
     }
 
     const changed = { ...asset };
-    const interested = this.assetWatchers.filter((watcher) =>
+    const interested = this.assetWatchers.some((watcher) =>
       watchesAsset(watcher, changed)
     );
     const previouslyResolved = this.resolvedAssetIdentities.has(identity);
@@ -893,7 +885,7 @@ export class Store extends RapidElement {
         name: changed.name
       };
     }
-    if (!previouslyResolved && !pending && interested.length === 0) {
+    if (!previouslyResolved && !pending && !interested) {
       return;
     }
 
@@ -905,20 +897,10 @@ export class Store extends RapidElement {
       type: 'asset_changed',
       asset: changed
     };
-    for (const watcher of interested) {
-      this.deliverAssetEvent(watcher, publication);
-    }
-  }
-
-  private deliverAssetEvent(
-    watcher: AssetWatcher,
-    event: StoreAssetChangedEvent | null
-  ): void {
-    try {
-      watcher.onEvent(event);
-    } catch (error) {
-      console.error('store asset watcher failed', error);
-    }
+    this.assetWatchers.each(
+      (watcher) => watcher.onEvent(publication),
+      (watcher) => watchesAsset(watcher, changed)
+    );
   }
 
   public isDynamicGroup(uuid: string): boolean {

--- a/test/temba-flow-editor.test.ts
+++ b/test/temba-flow-editor.test.ts
@@ -8,6 +8,8 @@ import { stub, restore, useFakeTimers } from 'sinon';
 import { zustand } from '../src/store/AppState';
 import { TEMBA_COMPONENTS_VERSION } from '../src/version';
 import {
+  ConnectionState,
+  ConnectionStateHandler,
   SocketProvider,
   SocketSubscription,
   setSocketProvider
@@ -39,6 +41,15 @@ class EditorSocketProvider implements SocketProvider {
 
   publish(): Promise<void> {
     return Promise.resolve();
+  }
+
+  getConnectionState(): ConnectionState {
+    return ConnectionState.Connected;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onConnectionState(handler: ConnectionStateHandler): SocketSubscription {
+    return { unsubscribe: () => undefined };
   }
 
   serverPublish(channel: string, event: any): void {

--- a/test/temba-socket.test.ts
+++ b/test/temba-socket.test.ts
@@ -1,5 +1,5 @@
 import { assert } from '@open-wc/testing';
-import { SocketManager } from '../src/live/SocketService';
+import { ConnectionState, SocketManager } from '../src/live/SocketService';
 
 class FakeSub {
   public handlers: { [event: string]: ((ctx: any) => void)[] } = {};
@@ -49,6 +49,22 @@ class FakeCentrifuge {
   public subs = new Map<string, FakeSub>();
   public removed: FakeSub[] = [];
   public published: { channel: string; data: any }[] = [];
+
+  // creating the real client connects, so a fake starts where that leaves it
+  public state = 'connecting';
+  public handlers: { [event: string]: ((ctx: any) => void)[] } = {};
+
+  public on(event: string, fn: (ctx: any) => void) {
+    this.handlers[event] = this.handlers[event] || [];
+    this.handlers[event].push(fn);
+    return this;
+  }
+
+  // drives a connection transition as the server would
+  public transition(state: string) {
+    this.state = state;
+    (this.handlers[state] || []).forEach((handler) => handler({}));
+  }
 
   public publish(channel: string, data: any): Promise<any> {
     this.published.push({ channel, data });
@@ -199,5 +215,81 @@ describe('SocketManager', () => {
         denied = true;
       });
     assert.isTrue(denied);
+  });
+});
+
+describe('SocketManager connection state', () => {
+  it('is disconnected until something opens the connection', () => {
+    const { manager, connections } = createManager();
+
+    assert.equal(manager.getConnectionState(), ConnectionState.Disconnected);
+    assert.equal(connections(), 0);
+  });
+
+  it('picks up the state the socket is already in', () => {
+    const { manager } = createManager();
+
+    // creating the client connects, so the first transition happens before we
+    // can be listening for it
+    manager.subscribe('history:abc', () => undefined);
+    assert.equal(manager.getConnectionState(), ConnectionState.Connecting);
+  });
+
+  it('follows the connection', () => {
+    const { fake, manager } = createManager();
+    manager.subscribe('history:abc', () => undefined);
+
+    const seen: ConnectionState[] = [];
+    manager.onConnectionState((state) => seen.push(state));
+
+    fake.transition('connected');
+    fake.transition('disconnected');
+    fake.transition('connecting');
+    fake.transition('connected');
+
+    assert.deepEqual(seen, [
+      ConnectionState.Connected,
+      ConnectionState.Disconnected,
+      ConnectionState.Connecting,
+      ConnectionState.Connected
+    ]);
+    assert.equal(manager.getConnectionState(), ConnectionState.Connected);
+  });
+
+  it('gives a new handler the current state without waiting for a change', async () => {
+    const { fake, manager } = createManager();
+    manager.subscribe('history:abc', () => undefined);
+    fake.transition('connected');
+
+    const seen: ConnectionState[] = [];
+    manager.onConnectionState((state) => seen.push(state));
+
+    await Promise.resolve();
+    assert.deepEqual(seen, [ConnectionState.Connected]);
+  });
+
+  it('does not repeat a state it is already in', () => {
+    const { fake, manager } = createManager();
+    manager.subscribe('history:abc', () => undefined);
+    fake.transition('connected');
+
+    const seen: ConnectionState[] = [];
+    manager.onConnectionState((state) => seen.push(state));
+
+    fake.transition('connected');
+    assert.deepEqual(seen, []);
+  });
+
+  it('stops telling a handler once it unsubscribes', () => {
+    const { fake, manager } = createManager();
+    manager.subscribe('history:abc', () => undefined);
+
+    const seen: ConnectionState[] = [];
+    const watch = manager.onConnectionState((state) => seen.push(state));
+    fake.transition('connected');
+    watch.unsubscribe();
+    fake.transition('disconnected');
+
+    assert.deepEqual(seen, [ConnectionState.Connected]);
   });
 });

--- a/test/temba-socket.test.ts
+++ b/test/temba-socket.test.ts
@@ -280,6 +280,20 @@ describe('SocketManager connection state', () => {
     assert.deepEqual(seen, []);
   });
 
+  it('does not repeat a state a same-tick transition already delivered', async () => {
+    const { manager } = createManager();
+
+    const seen: ConnectionState[] = [];
+    // nothing has opened the connection yet, and then something does before
+    // the initial delivery lands - that transition is the handler's first
+    // word on where we are, so priming would only say it twice
+    manager.onConnectionState((state) => seen.push(state));
+    manager.subscribe('history:abc', () => undefined);
+
+    await Promise.resolve();
+    assert.deepEqual(seen, [ConnectionState.Connecting]);
+  });
+
   it('stops telling a handler once it unsubscribes', () => {
     const { fake, manager } = createManager();
     manager.subscribe('history:abc', () => undefined);

--- a/test/temba-watchers.test.ts
+++ b/test/temba-watchers.test.ts
@@ -1,0 +1,144 @@
+import { assert } from '@open-wc/testing';
+import { stub } from 'sinon';
+import { Watchers } from '../src/live/Watchers';
+
+interface TestWatcher {
+  name: string;
+  onEvent: () => void;
+}
+
+const watcher = (name: string, onEvent: () => void = () => undefined) => ({
+  name,
+  onEvent
+});
+
+describe('Watchers', () => {
+  let watchers: Watchers<TestWatcher>;
+
+  beforeEach(() => {
+    watchers = new Watchers<TestWatcher>('test watcher');
+  });
+
+  it('tracks membership', () => {
+    const one = watcher('one');
+    assert.equal(watchers.size, 0);
+    assert.isFalse(watchers.has(one));
+
+    watchers.add(one);
+    assert.equal(watchers.size, 1);
+    assert.isTrue(watchers.has(one));
+    assert.isTrue(watchers.some((w) => w.name === 'one'));
+  });
+
+  it('reports whether a removal did anything', () => {
+    const one = watcher('one');
+    watchers.add(one);
+
+    assert.isTrue(watchers.remove(one));
+    // unsubscribing twice is a no-op, not a second teardown
+    assert.isFalse(watchers.remove(one));
+    assert.equal(watchers.size, 0);
+  });
+
+  it('hands out a snapshot rather than the list', () => {
+    const one = watcher('one');
+    watchers.add(one);
+
+    const all = watchers.all();
+    all.push(watcher('two'));
+    assert.equal(watchers.size, 1);
+  });
+
+  it('delivers to everyone registered', () => {
+    const seen: string[] = [];
+    watchers.add(watcher('one'));
+    watchers.add(watcher('two'));
+
+    watchers.each((w) => seen.push(w.name));
+    assert.deepEqual(seen, ['one', 'two']);
+  });
+
+  it('delivers only to those matching', () => {
+    const seen: string[] = [];
+    watchers.add(watcher('one'));
+    watchers.add(watcher('two'));
+
+    watchers.each(
+      (w) => seen.push(w.name),
+      (w) => w.name === 'two'
+    );
+    assert.deepEqual(seen, ['two']);
+  });
+
+  it('keeps one subscriber throwing from costing the others', () => {
+    const consoleStub = stub(console, 'error');
+    const seen: string[] = [];
+    watchers.add(watcher('one'));
+    watchers.add(watcher('boom'));
+    watchers.add(watcher('three'));
+
+    watchers.each((w) => {
+      if (w.name === 'boom') {
+        throw new Error('boom');
+      }
+      seen.push(w.name);
+    });
+
+    assert.deepEqual(seen, ['one', 'three']);
+    assert.isTrue(consoleStub.calledWith('test watcher failed'));
+    consoleStub.restore();
+  });
+
+  it('survives a subscriber leaving mid delivery', () => {
+    const seen: string[] = [];
+    const one = watcher('one');
+    const two = watcher('two');
+    watchers.add(one);
+    watchers.add(two);
+
+    watchers.each((w) => {
+      seen.push(w.name);
+      if (w.name === 'one') {
+        // a delivery that tears its neighbour down would otherwise shift the
+        // list out from under the loop
+        watchers.remove(two);
+      }
+    });
+
+    assert.deepEqual(seen, ['one', 'two']);
+  });
+
+  describe('prime', () => {
+    it('delivers off the current task', async () => {
+      const seen: string[] = [];
+      const one = watcher('one');
+      watchers.add(one);
+
+      watchers.prime(one, (w) => seen.push(w.name));
+      assert.deepEqual(seen, [], 'should not have delivered synchronously');
+
+      await Promise.resolve();
+      assert.deepEqual(seen, ['one']);
+    });
+
+    it('skips a subscriber that left before it landed', async () => {
+      const seen: string[] = [];
+      const one = watcher('one');
+      watchers.add(one);
+
+      watchers.prime(one, (w) => seen.push(w.name));
+      watchers.remove(one);
+
+      await Promise.resolve();
+      assert.deepEqual(seen, []);
+    });
+  });
+
+  it('clears everyone', () => {
+    watchers.add(watcher('one'));
+    watchers.add(watcher('two'));
+
+    watchers.clear();
+    assert.equal(watchers.size, 0);
+  });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -36,6 +36,8 @@ import { Options } from '../src/display/Options';
 import { Attachment } from '../src/interfaces';
 import { Compose } from '../src/form/Compose';
 import {
+  ConnectionState,
+  ConnectionStateHandler,
   PublicationHandler,
   SocketProvider,
   SocketSubscription
@@ -109,6 +111,43 @@ export class MockSocketProvider implements SocketProvider {
     return this.subs
       .filter((sub) => !sub.unsubscribed)
       .map((sub) => sub.channel);
+  }
+
+  // a mock socket is connected from the start - tests that care drive it with
+  // setConnectionState
+  private state = ConnectionState.Connected;
+  private stateHandlers: ConnectionStateHandler[] = [];
+
+  public getConnectionState(): ConnectionState {
+    return this.state;
+  }
+
+  public onConnectionState(
+    handler: ConnectionStateHandler
+  ): SocketSubscription {
+    this.stateHandlers.push(handler);
+    Promise.resolve().then(() => {
+      if (this.stateHandlers.includes(handler)) {
+        handler(this.state);
+      }
+    });
+    return {
+      unsubscribe: () => {
+        const index = this.stateHandlers.indexOf(handler);
+        if (index >= 0) {
+          this.stateHandlers.splice(index, 1);
+        }
+      }
+    };
+  }
+
+  // drives a connection transition as the server would
+  public setConnectionState(state: ConnectionState) {
+    if (state === this.state) {
+      return;
+    }
+    this.state = state;
+    [...this.stateHandlers].forEach((handler) => handler(state));
   }
 }
 


### PR DESCRIPTION
Last of four stacked PRs. **Targets #1101** — merge #1099, #1100 and #1101 first.

### Watchers

`ContactWatch` and the store's asset watchers each hand-rolled the same subscriber list:

- push on subscribe, `indexOf`/`splice` on unsubscribe
- snapshot (`[...watchers]`) before iterating, so a delivery that tears down a neighbour doesn't shift the list underneath the loop
- `try`/`catch` per delivery, because these are page components we don't control and one throwing can't cost the others theirs
- an async initial delivery guarded by an is-it-still-registered check

`Watchers<W>` owns that discipline once. The subscriber record and how an event reaches it stay with the caller — interests, payloads and arities genuinely differ between the two, so trying to own those as well would have made it a worse abstraction than what it replaces.

**`SocketManager` is deliberately left alone.** I'd originally listed it as the third instance of this pattern, but reading it properly it isn't one: it refcounts a resource and centrifugo's own emitter does the fan-out, so there's no subscriber list there to share. Folding it in would have meant inventing a shape to fit all three.

The connection-state handlers added below are the third real user.

### Connection state

Nothing could tell whether the socket was up. Every consumer independently refetches when its channel resubscribes — which keeps data correct — but a page had no way to know it was showing data that stopped updating ten minutes ago, so it couldn't say so to the user.

`SocketManager` now tracks the connection and exposes `getConnectionState()` / `onConnectionState()`:

- seeded from whatever state the client is already in, since creating it connects and that first transition can land before we're listening
- handlers get the current state up front, so a caller never has to pair the watch with a read to render
- repeat states are suppressed, so handlers only see actual transitions
- `Disconnected` until something subscribes or publishes, because that's what opens the connection — documented rather than faked

Exposed the same way as the rest of the module: module-level helpers for components, and on `window.sockets` for the page's own js. The connection is page-scoped and shared, and an offline banner is the containing page's to render — this PR adds no UI, just the signal it would need. `SocketProvider` gains the two methods; the two in-tree test providers implement them.

### Testing

Full suite green (2763 passing), `tsc --noEmit` clean.

New `test/temba-watchers.test.ts` covers membership, removal reporting false the second time, `all()` handing back a snapshot, matched and unmatched delivery, one subscriber throwing not costing the others, a subscriber removed mid-delivery still being reached, and `prime` delivering off-task and skipping someone who left first.

`test/temba-socket.test.ts` gains connection-state coverage: disconnected before first use, picking up the state the client is already in, following transitions, priming a new handler, suppressing repeats, and going quiet after unsubscribe.