### PR TITLE
Stop a menu refresh from orphaning a load already in flight

### DIFF
--- a/src/list/TembaMenu.ts
+++ b/src/list/TembaMenu.ts
@@ -41,6 +41,10 @@ interface MenuItemState {
   collapsed?: string;
 }
 
+// fields the menu maintains on an item rather than reading off the server, so
+// a reload carries them across instead of treating them as dropped
+const OWN_ITEM_FIELDS = ['items', 'level', 'loading'];
+
 const findItem = (
   items: MenuItem[],
   id: string
@@ -738,8 +742,17 @@ export class TembaMenu extends ResizeElement {
   @property({ type: Object })
   pressedItem: MenuItem;
 
-  // http promise to monitor for completeness
-  public httpComplete: Promise<void>;
+  /**
+   * Resolves when every load in flight has settled. Awaiting it has to mean
+   * "the menu has finished fetching", not "the last load anyone started has
+   * finished" - loads overlap (a click while a debounced refresh is armed),
+   * and a caller that awaited whichever promise happened to be here last
+   * would read the menu mid-update.
+   */
+  public httpComplete: Promise<void> = Promise.resolve();
+
+  private loadsInFlight = 0;
+  private loadsSettled: () => void;
 
   root: MenuItem;
   selection: string[] = [];
@@ -854,22 +867,66 @@ export class TembaMenu extends ResizeElement {
     });
   }
 
+  /**
+   * Folds a load into httpComplete, which stays unresolved until the last one
+   * outstanding settles.
+   */
+  private trackLoad(load: Promise<void>): void {
+    if (this.loadsInFlight === 0) {
+      this.httpComplete = new Promise((resolve) => {
+        this.loadsSettled = resolve;
+      });
+    }
+    this.loadsInFlight++;
+
+    load.then(() => {
+      if (--this.loadsInFlight === 0) {
+        this.loadsSettled();
+      }
+    });
+  }
+
+  /**
+   * Reloading a level reuses the item objects it already had. Replacing them
+   * would orphan anything already pointing at one - a rendered click handler,
+   * or a load in flight for that item's own children, which would then land
+   * on a copy no longer in the tree.
+   */
+  private mergeItems(item: MenuItem, items: MenuItem[]): MenuItem[] {
+    const previous = item.items || [];
+    return items.map((newItem) => {
+      const prevItem = previous.find((prev) => prev.id == newItem.id);
+      if (!prevItem) {
+        return newItem;
+      }
+
+      // sub-items the reload didn't speak to are ours to carry over - either
+      // ones we already had or ones still on their way
+      const carried = newItem.items || prevItem.items;
+
+      // anything the reload dropped is gone, so this reads as a replacement
+      // everywhere except identity - bar the fields the menu sets on an item
+      // itself, which the server never speaks to
+      Object.keys(prevItem).forEach((key) => {
+        if (!(key in newItem) && !OWN_ITEM_FIELDS.includes(key)) {
+          delete prevItem[key];
+        }
+      });
+      Object.assign(prevItem, newItem);
+      if (carried) {
+        prevItem.items = carried;
+      }
+      return prevItem;
+    });
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   private loadItems(item: MenuItem, event: MouseEvent | KeyboardEvent = null) {
     if (item && item.endpoint) {
       item.loading = true;
-      this.httpComplete = fetchResults(item.endpoint)
+      const load = fetchResults(item.endpoint)
         .then((items: MenuItem[]) => {
-          items.forEach((newItem) => {
-            if (!newItem.items) {
-              const prevItem = (item.items || []).find(
-                (prev) => prev.id == newItem.id
-              );
-              if (prevItem && prevItem.items) {
-                newItem.items = prevItem.items;
-              }
-            }
-          });
+          items = this.mergeItems(item, items);
 
           // update our item level
           items.forEach((subItem) => {
@@ -901,6 +958,7 @@ export class TembaMenu extends ResizeElement {
         .catch((error) => {
           this.fireCustomEvent(CustomEventType.Error, { error });
         });
+      this.trackLoad(load);
     }
   }
 

--- a/test/temba-menu.test.ts
+++ b/test/temba-menu.test.ts
@@ -79,8 +79,10 @@ describe('temba-menu', () => {
     menu.getDiv('#menu-tasks').click();
     await menu.httpComplete;
 
-    // now set the focus manually
-    menu.setFocusedItem('schedule');
+    // setFocusedItem is async and arms a debounced refresh of the selection
+    // path - leaving it in flight lets that refresh land in the middle of
+    // what follows
+    await menu.setFocusedItem('schedule');
 
     // setting focus does NOT fetch items
     expect(menu.root.items[IDX_SCHEDULE].items).to.equal(undefined);
@@ -92,11 +94,45 @@ describe('temba-menu', () => {
 
     await assertScreenshot('menu/menu-focused-with items', getClip(menu));
 
-    menu.setFocusedItem('tasks');
+    await menu.setFocusedItem('tasks');
     await assertScreenshot('menu/menu-tasks', getClip(menu));
 
-    menu.setFocusedItem('tasks/todo');
+    await menu.setFocusedItem('tasks/todo');
     await assertScreenshot('menu/menu-tasks-nextup', getClip(menu));
+  });
+
+  it('survives a level reloading while one of its items is loading', async () => {
+    const menu: TembaMenu = await getMenu({
+      endpoint: '/test-assets/menu/menu-root.json'
+    });
+    const schedule = menu.root.items[IDX_SCHEDULE];
+
+    // load an item's children, then reload the level underneath it before
+    // those children land - which is what a debounced refresh firing during
+    // a click does
+    menu.getDiv('#menu-schedule').click();
+    menu.reset();
+    await menu.httpComplete;
+
+    // the reload reused the item rather than swapping in a copy, so the
+    // children landed somewhere still in the tree
+    assert.strictEqual(menu.root.items[IDX_SCHEDULE], schedule);
+    expect(menu.root.items[IDX_SCHEDULE].items.length).to.equal(3);
+  });
+
+  it('waits for every load in flight', async () => {
+    const menu: TembaMenu = await getMenu({
+      endpoint: '/test-assets/menu/menu-root.json'
+    });
+
+    // two overlapping loads - awaiting has to cover both, not just whichever
+    // one was started last
+    menu.getDiv('#menu-tasks').click();
+    menu.getDiv('#menu-schedule').click();
+    await menu.httpComplete;
+
+    expect(menu.root.items[IDX_TASKS].items.length).to.equal(3);
+    expect(menu.root.items[IDX_SCHEDULE].items.length).to.equal(3);
   });
 
   it('refreshes', async () => {


### PR DESCRIPTION
`temba-menu > sets focus` fails intermittently in CI, always on the same line — the schedule item's children are `undefined` immediately after awaiting the fetch meant to load them:

```
❌ temba-menu > sets focus
   TypeError: Cannot read properties of undefined (reading 'length')
     at test/temba-menu.test.ts:91
```

### What's racing

`setFocusedItem` ends with `this.refresh()` — a **200ms debounce** over `doRefresh`, which reloads the selection path. The test doesn't await `setFocusedItem` (it's `async`) and does its work inside that 200ms window, so passing depends on the schedule fetch finishing before the debounce fires.

Locally it always does — I ran the file 25× in isolation with no failures. Under coverage instrumentation with pages running in parallel it sometimes doesn't, which is why it only shows up in CI and only in a full run. On the run that caught it, the `pull_request` run on the identical SHA passed while the `push` run failed.

### The bug the race exposes

This isn't just a test racing itself. Reloading a level replaced its items with fresh objects, carrying sub-items across from the ones it replaced:

```ts
items.forEach((newItem) => {
  if (!newItem.items) {
    const prevItem = (item.items || []).find((prev) => prev.id == newItem.id);
    if (prevItem && prevItem.items) {
      newItem.items = prevItem.items;   // only carries what already arrived
    }
  }
});
```

An item whose own load was **still in flight** had nothing to carry, so it was swapped for a copy — and when its children landed they were written into an object no longer in the tree. In the app that reads as clicking a menu item that never populates, whenever a refresh lands in the same window.

A reload now reuses the item objects it already had, so anything pointing at one — a rendered click handler, a load in flight for its children — keeps pointing at something the menu can still see. Fields the server dropped are still deleted, so it reads as a replacement everywhere except identity; the three fields the menu maintains itself (`items`, `level`, `loading`) are carried across.

### httpComplete

`httpComplete` tracked whichever load was started last. Both the menu's own `await this.httpComplete` calls and every test already assume it means "the menu has finished fetching" — but loads overlap, so awaiting a field any of them can overwrite sometimes means awaiting an already-resolved promise and reading the menu mid-update. It now resolves when every load in flight has settled.

That alone wouldn't have fixed this (the orphaned write is what produces the `undefined`), but it's the same class of bug and it's what makes the test's `await` mean what it says.

### Testing

New `survives a level reloading while one of its items is loading` **fails deterministically on the unfixed component** and passes with it — verified by stashing the `TembaMenu.ts` change and re-running:

```
❌ temba-menu > survives a level reloading while one of its items is loading
   AssertionError: expected { Object (id, name, ...) } to equal { Object (id, name, ...) }
```

Also added `waits for every load in flight` for the `httpComplete` change, and the focus test now awaits `setFocusedItem`.

Full suite green, `tsc --noEmit` clean, and 6 consecutive `test:coverage` runs with no menu failure.

**Unrelated flake seen while stressing:** one of those 6 runs hit `temba-simulator > sends an image attachment` on a pixel diff (1.99% differing). Nothing here touches the simulator — that's a separate screenshot flake, left alone.