### PR TITLE
Fix the flow search table tests against the new SearchModal base

### DIFF
--- a/test/temba-flow-search-table.test.ts
+++ b/test/temba-flow-search-table.test.ts
@@ -41,7 +41,7 @@ const createSearch = async (
 // runs a query through the component's own search path
 const search = async (element: FlowSearch, query: string) => {
   (element as any).searchQuery = query;
-  (element as any).performSearch();
+  (element as any).runSearch();
   await element.updateComplete;
   return (element as any).results;
 };

--- a/test/temba-slider.test.ts
+++ b/test/temba-slider.test.ts
@@ -1,12 +1,24 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import { TemplateResult } from 'lit';
 import { TembaSlider } from '../src/form/TembaSlider';
-import { assertScreenshot, getClip, showMouse } from './utils.test';
+import {
+  assertScreenshot,
+  getClip,
+  showMouse,
+  waitForAnimations
+} from './utils.test';
 
 const createSlider = async (def: TemplateResult) => {
   const parentNode = document.createElement('div');
   parentNode.setAttribute('style', 'width: 200px;');
   return await fixture<TembaSlider>(def, { parentNode });
+};
+
+// the circle scales up while it is grabbed and eases back over 200ms once it
+// is let go, so releasing the mouse leaves it mid-transition
+const settle = async (slider: TembaSlider) => {
+  await slider.updateComplete;
+  await waitForAnimations(slider.shadowRoot.querySelector('.circle'));
 };
 
 describe('temba-slider', () => {
@@ -174,6 +186,7 @@ describe('temba-slider', () => {
     await mouseUp();
 
     expect(slider.value).to.equal('75');
+    await settle(slider);
     await assertScreenshot(
       'slider/update-slider-on-track-clicked',
       getClip(slider)
@@ -198,6 +211,7 @@ describe('temba-slider', () => {
     await mouseUp();
 
     expect(slider.value).to.equal('80');
+    await settle(slider);
     await assertScreenshot(
       'slider/update-slider-on-circle-dragged',
       getClip(slider)

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -425,6 +425,39 @@ export const waitForImages = async (
   await new Promise((resolve) => window.setTimeout(resolve, 50));
 };
 
+/**
+ * Waits for the CSS transitions and animations running on an element to
+ * finish, so a screenshot catches the state they settle into rather than a
+ * frame partway through one.
+ *
+ * How far a transition has got by the time we capture depends on how busy the
+ * machine is, so comparing pixels mid-transition is a coin flip against the
+ * recorded truth - it passes locally and fails on a loaded CI box. Anything
+ * looping forever never settles, so those are left running and a timeout
+ * backstops the rest.
+ */
+export const waitForAnimations = async (
+  ele: Element,
+  timeout = 2000
+): Promise<void> => {
+  const animations = ele
+    .getAnimations()
+    .filter(
+      (animation) =>
+        (animation.effect as KeyframeEffect)?.getTiming().iterations !==
+        Infinity
+    );
+
+  await Promise.race([
+    // a cancelled animation rejects, which tells us the same thing as one that
+    // ran to completion - there is nothing left moving
+    Promise.all(
+      animations.map((animation) => animation.finished.catch(() => null))
+    ),
+    new Promise((resolve) => window.setTimeout(resolve, timeout))
+  ]);
+};
+
 export const assertScreenshot = async (
   filename: string,
   clip: Clip,


### PR DESCRIPTION
`main` is currently red. #1083 moved the search query off component state and onto a `performSearch(query)` argument in the new `SearchModal` base, while #1089 had already added `test/temba-flow-search-table.test.ts`, whose helper called `performSearch()` bare after assigning `searchQuery` itself. Each PR was green on its own base; together every one of those 21 tests throws `Cannot read properties of undefined (reading 'toLowerCase')`.

The helper now goes through the base class's real `runSearch()` path instead of poking at `performSearch` directly, so it exercises what the component actually does — including the empty-query short circuit — and won't drift from the signature again.

All 165 test files pass locally (2763 passed, 0 failed).