### PR TITLE
Let the slider circle settle before screenshotting it

### DIFF
--- a/test/temba-slider.test.ts
+++ b/test/temba-slider.test.ts
@@ -1,12 +1,24 @@
 import { html, fixture, expect } from '@open-wc/testing';
 import { TemplateResult } from 'lit';
 import { TembaSlider } from '../src/form/TembaSlider';
-import { assertScreenshot, getClip, showMouse } from './utils.test';
+import {
+  assertScreenshot,
+  getClip,
+  showMouse,
+  waitForAnimations
+} from './utils.test';
 
 const createSlider = async (def: TemplateResult) => {
   const parentNode = document.createElement('div');
   parentNode.setAttribute('style', 'width: 200px;');
   return await fixture<TembaSlider>(def, { parentNode });
+};
+
+// the circle scales up while it is grabbed and eases back over 200ms once it
+// is let go, so releasing the mouse leaves it mid-transition
+const settle = async (slider: TembaSlider) => {
+  await slider.updateComplete;
+  await waitForAnimations(slider.shadowRoot.querySelector('.circle'));
 };
 
 describe('temba-slider', () => {
@@ -174,6 +186,7 @@ describe('temba-slider', () => {
     await mouseUp();
 
     expect(slider.value).to.equal('75');
+    await settle(slider);
     await assertScreenshot(
       'slider/update-slider-on-track-clicked',
       getClip(slider)
@@ -198,6 +211,7 @@ describe('temba-slider', () => {
     await mouseUp();
 
     expect(slider.value).to.equal('80');
+    await settle(slider);
     await assertScreenshot(
       'slider/update-slider-on-circle-dragged',
       getClip(slider)

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -425,6 +425,39 @@ export const waitForImages = async (
   await new Promise((resolve) => window.setTimeout(resolve, 50));
 };
 
+/**
+ * Waits for the CSS transitions and animations running on an element to
+ * finish, so a screenshot catches the state they settle into rather than a
+ * frame partway through one.
+ *
+ * How far a transition has got by the time we capture depends on how busy the
+ * machine is, so comparing pixels mid-transition is a coin flip against the
+ * recorded truth - it passes locally and fails on a loaded CI box. Anything
+ * looping forever never settles, so those are left running and a timeout
+ * backstops the rest.
+ */
+export const waitForAnimations = async (
+  ele: Element,
+  timeout = 2000
+): Promise<void> => {
+  const animations = ele
+    .getAnimations()
+    .filter(
+      (animation) =>
+        (animation.effect as KeyframeEffect)?.getTiming().iterations !==
+        Infinity
+    );
+
+  await Promise.race([
+    // a cancelled animation rejects, which tells us the same thing as one that
+    // ran to completion - there is nothing left moving
+    Promise.all(
+      animations.map((animation) => animation.finished.catch(() => null))
+    ),
+    new Promise((resolve) => window.setTimeout(resolve, timeout))
+  ]);
+};
+
 export const assertScreenshot = async (
   filename: string,
   clip: Clip,


### PR DESCRIPTION
`temba-slider > updates slider position on circle drag` fails intermittently on CI with `Pixel match failed (41 pixels differ, 0.129%)`, just over the 0.1% tolerance.

The circle scales to 1.2 while it is grabbed and eases back over a 200ms transition once released, so both mouse-driven slider tests screenshot it partway through that transition. A probe puts it at `scale(1.046)` at capture time — and how far it has got depends on how loaded the machine is, which is why it passes standalone and fails in a full CI run.

Both tests now wait for the circle's animations to finish before comparing pixels. That lands them on exactly the state the recorded truth already holds: measured against the current baselines the captures now come out at **0 differing pixels**, rather than sitting near the tolerance and hoping.

The wait is a general `waitForAnimations` helper in the test utils, since any screenshot taken right after a transition starts has the same problem. It skips animations that loop forever and is backstopped by a timeout.

No baselines needed regenerating. Full suite green (165 files, 2754 passed, 0 failed).

Based on #1106, which fixes the unrelated flow search failures currently making `main` red — this targets that branch so CI here is meaningful. Retargets to `main` once #1106 merges.