### PR TITLE
Search the full contact history even when the chat is viewing a ticket

### DIFF
--- a/src/live/ContactChat.ts
+++ b/src/live/ContactChat.ts
@@ -1302,16 +1302,9 @@ export class ContactChat extends ContactStoreElement {
       this.chat.reset();
     }
 
-    // a ticket-scoped chat only shows this ticket's history, so its search
-    // only covers this ticket's messages too. The endpoint narrows the
-    // search to ticket messages and drops the other tickets' matches
-    // itself, so its cap is no longer spent on messages this view can't
-    // show — matches from the contact's other tickets can still crowd out
-    // this one's, so the cap isn't per-ticket
-    let url = `/contact/chat_search/${this.currentContact.uuid}/?text=${encodeURIComponent(query)}`;
-    if (this.currentTicket) {
-      url += `&ticket=${encodeURIComponent(this.currentTicket.uuid)}`;
-    }
+    // the chat always shows the contact's full history — even when viewing
+    // a ticket — so search always covers all of the contact's messages
+    const url = `/contact/chat_search/${this.currentContact.uuid}/?text=${encodeURIComponent(query)}`;
 
     getUrl(url)
       .then((response: WebResponse) => {

--- a/test/temba-contact-chat.test.ts
+++ b/test/temba-contact-chat.test.ts
@@ -788,13 +788,13 @@ describe('temba-contact-chat', () => {
     expect(chat.searchIndex).to.equal(1);
   });
 
-  it('scopes a ticket chat search to its ticket', async () => {
+  it('searches the full contact history even when viewing a ticket', async () => {
     await loadStore();
 
-    // only a request carrying the ticket param is mocked, so results can
-    // only appear if the search was scoped server-side
+    // only a request without any ticket param is mocked, so results can
+    // only appear if the search wasn't scoped to the ticket
     mockGET(
-      /\/contact\/chat_search\/.*\?text=primus&ticket=ticket-1/,
+      /\/contact\/chat_search\/.*\?text=primus$/,
       '/test-assets/contacts/chat-search-primus.json'
     );
 


### PR DESCRIPTION
## Summary

In-chat search was scoped to the current ticket when the chat was hosted on the tickets page, but the chat always shows the contact's *complete* history — viewing a ticket only adds that ticket's detail events (notes, assignments) to the timeline. So search covered less than what was on screen. Search now always covers all of the contact's messages, matching the behavior on the contact read page.

## Changes

- **`src/live/ContactChat.ts`** — `executeSearch` no longer appends `&ticket=` to the `chat_search` request when `currentTicket` is set.
- **`test/temba-contact-chat.test.ts`** — replaced the ticket-scoping test with one asserting that no ticket param is sent even when a ticket is selected (the mock only matches the un-parametered URL, so results can only appear if the search wasn't scoped).

The hand-off from the cross-ticket search modal is unaffected — the target event is still spliced into the results if the endpoint's capped matches don't include it.

## Test plan

- [x] Full suite passes (2803 passed, 0 failed)
- [x] New test verifies search requests carry no ticket param when a ticket is selected
- [x] `bun run format` / `bun run build` clean