### PR TITLE
Don't navigate the current page on meta/ctrl row click

### DIFF
--- a/src/list/ContentList.ts
+++ b/src/list/ContentList.ts
@@ -2228,14 +2228,17 @@ export class ContentList<T = any> extends RapidElement {
     if (path.some((n: any) => n?.classList?.contains?.('check-cell'))) {
       return;
     }
+    const rowHref = this.getRowHref(item);
+    const href = rowHref && this.isSafeHref(rowHref) ? rowHref : null;
+    // Meta/ctrl-click opens a new tab, matching ordinary links. Skip
+    // RowClick entirely — host pages navigate on it unconditionally,
+    // which would also swap out the current page.
+    if (href && (event.metaKey || event.ctrlKey)) {
+      window.open(href, '_blank');
+      return;
+    }
     this.fireCustomEvent(CustomEventType.RowClick, { item });
-    const href = this.getRowHref(item);
-    if (href && this.isSafeHref(href)) {
-      // Meta/ctrl-click opens a new tab, matching ordinary links.
-      if (event.metaKey || event.ctrlKey) {
-        window.open(href, '_blank');
-        return;
-      }
+    if (href) {
       // Fire Redirected rather than assigning window.location so the
       // host SPA frame swaps content in place instead of doing a full
       // page reload — the frame listens for this event on document and

--- a/test/temba-content-list.test.ts
+++ b/test/temba-content-list.test.ts
@@ -326,7 +326,7 @@ describe('temba-content-list', () => {
     expect(redirectUrl).to.equal('/contact/read/u-1/');
   });
 
-  it('opens a new tab on meta-click without firing temba-redirected', async () => {
+  it('opens a new tab on meta-click without firing temba-redirected or temba-row-click', async () => {
     const list = (await getList({
       endpoint: '/test-assets/content-list/items.json'
     })) as ContentList;
@@ -338,6 +338,13 @@ describe('temba-content-list', () => {
     let redirected = false;
     list.addEventListener(CustomEventType.Redirected, () => {
       redirected = true;
+    });
+
+    // Host pages navigate on RowClick unconditionally, so firing it on
+    // a meta-click would swap out the current page alongside the new tab.
+    let rowClicked = false;
+    list.addEventListener(CustomEventType.RowClick, () => {
+      rowClicked = true;
     });
 
     const openStub = stub(window, 'open');
@@ -355,6 +362,7 @@ describe('temba-content-list', () => {
       expect(openStub.calledOnceWithExactly('/contact/read/u-1/', '_blank')).to
         .be.true;
       expect(redirected).to.be.false;
+      expect(rowClicked).to.be.false;
     } finally {
       openStub.restore();
     }


### PR DESCRIPTION
## Summary

Command/ctrl-clicking a row in the new list components opened the row in a new tab as expected, but the original page also navigated. The row click handler fired the `temba-row-click` event before checking for meta/ctrl, and host pages navigate on that event unconditionally — so the host swapped the current page out from under the new tab.

## Changes

- **src/list/ContentList.ts** — `handleRowClick` now resolves the row href and checks for meta/ctrl first. When the click opens a new tab, the handler returns without firing `RowClick` (or `Redirected`), so host pages never see it. Plain clicks are unchanged: `RowClick` fires, followed by `Redirected` when the row has a safe href. All list subclasses (flows, contacts, messages, campaigns, triggers, broadcasts) share this handler.
- **test/temba-content-list.test.ts** — extended the meta-click test to also assert `temba-row-click` does not fire, which is the assertion that would have caught this.

## Behavior examples

| Action | Before | After |
|---|---|---|
| Click a row | Navigates in place | Navigates in place (unchanged) |
| Meta/ctrl-click a row | New tab opens **and** current page navigates | New tab opens, current page stays put |

## Test plan

- [x] Full suite passes in the components container (2803 passed, 0 failed)
- [x] Meta-click test asserts `window.open` is called once and neither `temba-redirected` nor `temba-row-click` fires